### PR TITLE
WEB: Changed legacy Android Market URL into Play Store one

### DIFF
--- a/data/downloads.xml
+++ b/data/downloads.xml
@@ -131,8 +131,8 @@
 -->
 				<file>
 					<category_icon>catpl-android.png</category_icon>
-					<url>https://market.android.com/details?id=org.scummvm.scummvm</url>
-					<name>Android Market</name>
+					<url>https://play.google.com/store/apps/details?id=org.scummvm.scummvm</url>
+					<name>Android package at Google Play Store</name>
 				</file>
 <!--
 				<file>


### PR DESCRIPTION
The term Android Market (and the used url) was replaced by Google Play Store on March 2012. Some branding guidelines: http://developer.android.com/distribute/googleplay/promote/brand.html

I also contemplating on replacing the icon with https://dl.dropboxusercontent.com/u/25959245/catpl-android.png but then decided against it, since the Android robot icon better represents the used platform.
