### PR TITLE
WEB: Sync German translation to latest changes

### DIFF
--- a/lang/lang.de.ini
+++ b/lang/lang.de.ini
@@ -93,7 +93,7 @@ contactTrackers = """
 </p>
 <p>
     Solltest du schließlich Änderungen im Quellcode von ScummVM durchgeführt haben (sog. Patches), die in den ScummVM-Quellcode einfließen sollen,
-    kannst du dafür unser <a href="http://sourceforge.net/p/scummvm/patches/">System zum Einsenden von Patches</a> verwenden.
+    kannst du eine entsprechende Anfrage (sog. "Pull Request") auf unserer <a href="https://github.com/scummvm/scummvm/pulls">GitHub-Projektseite</a> erstellen.
 </p>
 """
 contactListsHeader = "Mailinglisten"
@@ -126,12 +126,10 @@ downloadsContentTitle = "ScummVM herunterladen"
 # downloads.tpl
 downloadsHeader = "Navigation"
 downloadsContentP1 = """
-Die meisten Downloads werden über SourceForge.net zum Download angeboten. Wenn du eines der unterstützten Systeme
-besitzt, kannst du direkt die passende Programmdatei herunterladen. Wenn du ein anderes System besitzt, dann lade
-dir den Quellcode herunter und lies die <a href="http://github.com/scummvm/scummvm/blob/v{release}/doc/de/Liesmich">Liesmich-Datei</a>
+Wenn du eines der unterstützten Systeme besitzt, kannst du direkt die passende Programmdatei herunterladen. Wenn du ein anderes System besitzt, dann lade
+dir den Quellcode herunter und lies die englischsprachige Seite <a href="<a href="http://wiki.scummvm.org/index.php/Compiling_ScummVM">Compiling ScummVM</a> in unserem Wiki
 für Informationen darüber, wie ScummVM aus dem Quellcode gebaut (kompiliert) wird.
-Solltest du ScummVM erfolgreich auf eine andere Plattform portiert haben, hinterlasse uns bitte eine Nachricht
-und nenne uns das Betriebssystem, welches du verwendet hast.
+Solltest du ScummVM erfolgreich auf eine andere Plattform portiert haben, hinterlasse uns bitte eine Nachricht und nenne uns Betriebssystem, Compiler etc., welche du verwendet hast.
 """
 downloadsContentP2 = """
 Die aktuelle STABILE Version von ScummVM ist {release} und kann unter
@@ -145,10 +143,10 @@ was sie tun), lies den Abschnitt über die <a href="downloads/#daily">täglich e
 am Ende dieser Seite.
 """
 downloadsContentP4 = """
-Weiter unten findest du noch die <a href="downloads/#extras">Extras</a>.
-Darin enthalten sind zur Zeit fünf Spiele, die als Freeware freigegeben wurden:
-'Beneath a Steel Sky', 'Flight of the Amazon Queen', 'Lure of the Temptress',
-'Drascula: The Vampire Strikes Back' und 'Soltys'.
+Zusätzlich gibt es noch eine eigene Seite <a href="games/">für Spiele-Downloads.</a>.
+Darin enthalten sind zur Zeit sieben Spiele, die als Freeware freigegeben wurden:
+'Beneath a Steel Sky', 'Dreamweb', 'Flight of the Amazon Queen', 'Lure of the Temptress',
+'Drascula: The Vampire Strikes Back', 'Soltys' und 'Sfinx'.
 Zusätzlich findest du dort auch Pakete mit Zwischenszenen, die empfohlen werden,
 wenn du die 'Broken Sword (Baphomets Fluch)'-Spiele oder 'Feeble Files (Floyd: Es gibt noch Helden)'
 unter ScummVM spielen möchtest.

--- a/lang/lang.de.ini
+++ b/lang/lang.de.ini
@@ -1,7 +1,7 @@
 # Locale. Set it to ISO639 locale name. Used for date formatting
 locale = de_DE
   # see http://php.net/manual/en/function.strftime.php for format. Used in news
-dateformat = "%b %e, %Y"
+dateformat = "%e. %B %Y"
 
 # CompatibilityPage.php
 compatibilityUntested = "Nicht getestet"


### PR DESCRIPTION
This 2 commits update the German translation of the website to the current state of the English website (now sync with commit cbda272). It also localizes the news date format to our local format.