### PR TITLE
WEB: Fix HTML tag in German announcement of the new server

### DIFF
--- a/data/news/de/20160119.xml
+++ b/data/news/de/20160119.xml
@@ -1,4 +1,4 @@
-<NAME>Ein neues Zuhause für unsere Website</NAME>
+<NAME>Ein neues Zuhause für unsere Webseite</NAME>
 <DATE>Jan 19, 2016</DATE>
 <AUTHOR>sev</AUTHOR>
 <BODY>
@@ -6,7 +6,7 @@
 		Für viele Jahre haben wir SourceForge.net verwendet. Es war das allererste 
 		Zuhause für unser Projekt, und es hat uns gute Dienste erwiesen. Dennoch müssen
 		wir nun weiterziehen, weshalb wir auf der Suche nach einem neuen Zuhause waren.
-		Letztes Jahr hat uns Florian Schicker, Geschäftsführer der <a href="http://easyname.at"
+		Letztes Jahr hat uns Florian Schicker, Geschäftsführer der <a href="http://easyname.at">
 		easyname GmbH</a>, das spannende Angebot gemacht, uns einen Server im unternehmenseigenen
 		Rechenzentrum in Wien zur Verfügung zu stellen. Was dieses Angebot so 
 		besonders macht, ist die Tatsache, dass im easyname-Team auch "seeeeehr große Fans der guten


### PR DESCRIPTION
This is small fix for a broken HTML tag and a small typo in the German announcement of the "New Home".