### PR TITLE
WEB: Fix language switching

### DIFF
--- a/include/Controller.php
+++ b/include/Controller.php
@@ -29,7 +29,16 @@ class Controller {
 		$Smarty = $this->_smarty;
 
 		global $lang;
-
+		
+		/* Configure smarty. */
+		$this->_smarty->compile_dir = SMARTY_DIR_COMPILE;
+		$this->_smarty->cache_dir = SMARTY_DIR_CACHE;
+		$this->_smarty->config_dir = SMARTY_DIR_CONFIG;
+		$this->_smarty->request_use_auto_globals = SMARTY_USE_GLOBALS;
+		$this->_smarty->caching = SMARTY_CACHING_ENABLE;
+		$this->_smarty->cache_lifetime = SMARTY_CACHING_LIFETIME;
+		$this->_smarty->compile_check = SMARTY_CACHING_COMPILE_CHECK;
+		$this->_smarty->force_recheck = SMARTY_CACHING_FORCE_RECHECK;
 		$this->_smarty->template_dir = array("templates_$lang", 'templates');
 		$this->_smarty->compile_id = $lang;
 		$this->_smarty->config_dir = ".";
@@ -45,15 +54,6 @@ class Controller {
 
 		setlocale(LC_TIME, $Smarty->_config[0]['vars']['locale']);
 
-		/* Configure smarty. */
-		$this->_smarty->compile_dir = SMARTY_DIR_COMPILE;
-		$this->_smarty->cache_dir = SMARTY_DIR_CACHE;
-		$this->_smarty->config_dir = SMARTY_DIR_CONFIG;
-		$this->_smarty->request_use_auto_globals = SMARTY_USE_GLOBALS;
-		$this->_smarty->caching = SMARTY_CACHING_ENABLE;
-		$this->_smarty->cache_lifetime = SMARTY_CACHING_LIFETIME;
-		$this->_smarty->compile_check = SMARTY_CACHING_COMPILE_CHECK;
-		$this->_smarty->force_recheck = SMARTY_CACHING_FORCE_RECHECK;
 		/**
 		 * Add a output-filter to make sure ampersands are properly encoded to
 		 * HTML-entities.

--- a/index.php
+++ b/index.php
@@ -1,4 +1,5 @@
 <?php
+session_start();
 
 global $lang;
 


### PR DESCRIPTION
As mentioned in f3c2203e2fc179e3f384e0499c34dcff63e792c1,
the language switching was always 1 behind. As in, the
language would be the last language you selected.

The first problem is that some of the smarty config variables
were being set after the call to _smarty->config_load(). Since
the smarty instance is cached, it was using the last set of variables.

I don't know why the production web site isn't throwing errors. My
personal set up wouldn't load until I could set _smarty->compile_dir
the first time. Perhaps the language update was done on the fly, so
smarty was still cached.

The next potential problem is persistence with $_SESSION.
The session is never initialized with session_start(). However,
the production php.ini may have session auto start enabled.