### PR TITLE
WEB: Convert the German website to a more polite form of address

### DIFF
--- a/data/news/de/20150330.xml
+++ b/data/news/de/20150330.xml
@@ -8,7 +8,7 @@ Rex Nebular, Gottes Geschenk an die Galaxie, ist auf der Suche nach einer wertvo
 </p>
 
 <p>
-Das ScummVM-Team ist stolz darauf, die Unterstützung für <a href="http://en.wikipedia.org/wiki/Rex_Nebular_and_the_Cosmic_Gender_Bender"><i>Rex Nebular and the Cosmic Gender Bender</i></a>, dem ersten MADS-Spiel von Micropose, ankündigen zu können. Es ist nun vollständig mithilfe der aktuellen <a href="http://www.scummvm.org/downloads.php#daily">Entwicklerversion</a> spielbar und ist bereit für die Testphase. Wie üblich sollten alle Fehler an den <a href="http://sourceforge.net/p/scummvm/bugs/">Bug Tracker</a> gemeldet werden, unter Beachtung unserer <a href="http://www.scummvm.org/faq.php#question.report-bugs">Richtlinien für Fehlerberichte</a>. Wir fänden es großartig, wenn Sie während des Spielens ein paar <a href="http://wiki.scummvm.org/index.php/Screenshots">Bildschirmfotos</a> für uns anfertigen könnten.
+Das ScummVM-Team ist stolz darauf, die Unterstützung für <a href="http://en.wikipedia.org/wiki/Rex_Nebular_and_the_Cosmic_Gender_Bender"><i>Rex Nebular and the Cosmic Gender Bender</i></a>, dem ersten MADS-Spiel von Micropose, ankündigen zu können. Es ist nun vollständig mithilfe der aktuellen <a href="http://www.scummvm.org/downloads.php#daily">Entwicklerversion</a> spielbar und bereit für die Testphase. Wie üblich sollten alle Fehler an den <a href="http://sourceforge.net/p/scummvm/bugs/">Bug Tracker</a> gemeldet werden, unter Beachtung unserer <a href="http://www.scummvm.org/faq.php#question.report-bugs">Richtlinien für Fehlerberichte</a>. Wir fänden es großartig, wenn Sie während des Spielens ein paar <a href="http://wiki.scummvm.org/index.php/Screenshots">Bildschirmfotos</a> für uns anfertigen könnten.
 </p>
 
 <p>

--- a/data/news/de/20150330.xml
+++ b/data/news/de/20150330.xml
@@ -4,13 +4,13 @@
 <BODY>
 
 <p>
-Rex Nebular, Gottes Geschenk an die Galaxie, ist auf der Suche nach einer wertvollen Vase auf einem Planeten gestranded. Um zu entkommen, muss er den berüchtigten "Gender Bender" benutzen, damit er seine weibliche Seite kennenlernt, um so sowohl die Vase als auch einen Fluchtweg von besagtem Planeten zu finden.
+Rex Nebular, Gottes Geschenk an die Galaxie, ist auf der Suche nach einer wertvollen Vase auf einem Planeten gestranded. Um zu entkommen, muss er den berüchtigten "Geschlechtsumwandler" benutzen, damit er seine weibliche Seite kennenlernt, um so sowohl die Vase als auch einen Fluchtweg von besagtem Planeten zu finden.
 </p>
 
 <p>
-Das ScummVM-Team ist stolz darauf, die Unterstützung für <a href="http://en.wikipedia.org/wiki/Rex_Nebular_and_the_Cosmic_Gender_Bender"><i>Rex Nebular and the Cosmic Gender Bender</i></a>, dem ersten MADS-Spiel von Micropose, ankündigen zu können. Es ist nun vollständig mithilfe der aktuellen <a href="http://www.scummvm.org/downloads.php#daily">Entwicklerversion</a> spielbar und ist bereit für die Testphase. Wie üblich sollten alle Fehler an den <a href="http://sourceforge.net/p/scummvm/bugs/">Bug Tracker</a> gemeldet werden, unter Beachtung unserer <a href="http://www.scummvm.org/faq.php#question.report-bugs">Richtlinien für Fehlerberichte</a>. Wir fänden es großartig, wenn du während des Spielens ein paar <a href="http://wiki.scummvm.org/index.php/Screenshots">Bildschirmfotos</a> für uns anfertigen könntest.
+Das ScummVM-Team ist stolz darauf, die Unterstützung für <a href="http://en.wikipedia.org/wiki/Rex_Nebular_and_the_Cosmic_Gender_Bender"><i>Rex Nebular and the Cosmic Gender Bender</i></a>, dem ersten MADS-Spiel von Micropose, ankündigen zu können. Es ist nun vollständig mithilfe der aktuellen <a href="http://www.scummvm.org/downloads.php#daily">Entwicklerversion</a> spielbar und ist bereit für die Testphase. Wie üblich sollten alle Fehler an den <a href="http://sourceforge.net/p/scummvm/bugs/">Bug Tracker</a> gemeldet werden, unter Beachtung unserer <a href="http://www.scummvm.org/faq.php#question.report-bugs">Richtlinien für Fehlerberichte</a>. Wir fänden es großartig, wenn Sie während des Spielens ein paar <a href="http://wiki.scummvm.org/index.php/Screenshots">Bildschirmfotos</a> für uns anfertigen könnten.
 </p>
 
 <p>
-Also, entstaube deine Kopie und probier das Spiel einmal aus. Wenn du das Spiel noch nicht besitzt, kannst du es online auf <a href="http://www.gog.com/game/rex_nebular_and_the_cosmic_gender_bender?pp=22d200f8670dbdb3e253a90eee5098477c95c23d">GOG.com</a> kaufen.
+Also, entstauben Sie Ihre Kopie und probieren Sie das Spiel einmal aus. Wenn Sie das Spiel noch nicht besitzen, können Sie es online auf <a href="http://www.gog.com/game/rex_nebular_and_the_cosmic_gender_bender?pp=22d200f8670dbdb3e253a90eee5098477c95c23d">GOG.com</a> kaufen.
 </BODY>

--- a/data/news/de/20150913.xml
+++ b/data/news/de/20150913.xml
@@ -4,15 +4,15 @@
 <BODY>
 
 <p>
-Sherlock Holmes, der größte Detektiv aller Zeiten, hat einige knifflige Fälle zu lösen. Erstens: Ein grausamer Mord vor einem Theater. Die Polizei ist ratlos. Könnte es das Werk des notorischen Killes Jack the Ripper sein? In seinem zweiten Fall wird sein Bruder Mycroft beinahe in einer Explosion getötet. In diesem Fall spielst du zuerst als Watson, der versucht, Sherlock aus seiner Verzweiflung zu befreien, später als Sherlock, der herausfinden will, warum Mycroft attackiert wurde, und warum noch dieser kurz vor der Explosion nach Sherlock gefragt hat...
+Sherlock Holmes, der größte Detektiv aller Zeiten, hat einige knifflige Fälle zu lösen. Erstens: Ein grausamer Mord vor einem Theater. Die Polizei ist ratlos. Könnte es das Werk des notorischen Killes Jack the Ripper sein? In seinem zweiten Fall wird Sherlocks Bruder Mycroft beinahe in einer Explosion getötet. In diesem Fall spielen Sie zuerst als Watson, der versucht, Sherlock aus seiner Verzweiflung zu befreien, später als Sherlock, der herausfinden will, warum Mycroft attackiert wurde, und warum dieser noch kurz vor der Explosion nach Sherlock gefragt hat...
 </p>
 
 <p>
-Das ScummVM-Team ist stolz darauf, die Unterstützung der beiden Spiele der Reihe <a href="https://en.wikipedia.org/wiki/The_Lost_Files_of_Sherlock_Holmes"<i>The Lost Files of Sherlock Holmes</i></a> - "The Case of the Serrated Scalpel" und "The Rose Tattoo" ankündigen zu können. Vielen Dank an Electronic Arts, dafür dass wir Zugriff auf den originalen Quellcode erhalten haben. Beide Spiele sind in ScummVM in der aktuellen <a href="http://www.scummvm.org/downloads.php#daily">Entwicklerversion</a> spielbar und können getestet werden. Im Fall von "The Serrated Scalpel" wird derzeit nur die PC-Version unterstützt. Die 3DO-Version ist größtenteils spielbar, benötigt jedoch noch etwas Arbeit. Wie üblich sollten Fehlermeldungen an <a href="http://sourceforge.net/p/scummvm/bugs/">unseren Bug-Tracker</a> gemeldet werden. Bitte beachte dabei unsere <a href="http://scummvm.org/faq.php#question.report-bugs">Richtlinien für Fehlerberichte</a>. Während du das Spiel spielst, würden wir uns sehr freuen, wenn du einige <a href="http://wiki.scummvm.org/index.php/Screenshots">Bildschirmfotos</a> für uns anfertigen könntest.
+Das ScummVM-Team ist stolz darauf, die Unterstützung der beiden Spiele der Reihe <a href="https://en.wikipedia.org/wiki/The_Lost_Files_of_Sherlock_Holmes"<i>The Lost Files of Sherlock Holmes</i></a> - "The Case of the Serrated Scalpel" und "The Rose Tattoo" ankündigen zu können. Vielen Dank an Electronic Arts für das zur Verfügung stellen des originalen Quellcodes. Beide Spiele sind in ScummVM in der aktuellen <a href="http://www.scummvm.org/downloads.php#daily">Entwicklerversion</a> spielbar und können getestet werden. Im Fall von "The Serrated Scalpel" wird derzeit nur die PC-Version unterstützt. Die 3DO-Version ist größtenteils spielbar, benötigt jedoch noch etwas Arbeit. Wie üblich sollten Fehlermeldungen an <a href="http://sourceforge.net/p/scummvm/bugs/">unseren Bug-Tracker</a> gemeldet werden. Bitte beachten Sie dabei unsere <a href="http://scummvm.org/faq.php#question.report-bugs">Richtlinien für Fehlerberichte</a>. Während Sie das Spiel spielen, würden wir uns sehr freuen, wenn Sie einige <a href="http://wiki.scummvm.org/index.php/Screenshots">Bildschirmfotos</a> für uns anfertigen könnten.
 </p>
 
 <p>
-Kannst du in die Fußstapfen des großen Sherlock Holmes treten? Das Spiel hat begonnen. Oder, in diesem Fall, die Spiele :)
+Können Sie in die Fußstapfen des großen Sherlock Holmes treten? Das Spiel hat begonnen. Oder, in diesem Fall, die Spiele :)
 </p>
 </BODY>
 

--- a/data/news/de/20151111.xml
+++ b/data/news/de/20151111.xml
@@ -5,19 +5,19 @@
 
 <p>
 Zwanzig Jahre nach der ursprünglichen Veröffentlichung, sind wir sehr stolz darauf,
-heute die Unterstützung von MTV's <i>Beavis and Butthead in Virtual Stupidity</i> ankündigen zu können.
-Nimm die Herausforderung dieser Anti-Helden der 90er Jahre an und hilf ihnen, ihren Weg durch ein 
+heute die Unterstützung von MTVs <i>Beavis and Butthead in Virtual Stupidity</i> ankündigen zu können.
+Nehmen Sie die Herausforderung dieser Anti-Helden der 90er Jahre an und helfen Sie ihnen, ihren Weg durch ein 
 Abenteuer voller Puzzles und Mini-Spielen zu finden.
 </p>
 
 <p>
-Also, lade dir die aktuelle <a href="http://scummvm.org/downloads/#daily">Entwicklerversion von ScummVM</a> herunter, schnapp dir deine Kopie von BBVS und probier das Spiel einmal aus!
-Solltest du auf Fehler oder unbekannte Spielversionen stoßen, bitte melde diese über unseren <a href=https://sourceforge.net/p/scummvm/bugs/">Bug Tracker</a>.
-Bitte beachte dabei die <a href="http://www.scummvm.org/faq.php#question.report-bugs">Richtlinien für das Einsenden von Fehlerberichten</a>.
+Also, laden Sie sich die aktuelle <a href="http://scummvm.org/downloads/#daily">Entwicklerversion von ScummVM</a> herunter, schnappen Sie sich Ihre Kopie von BBVS und probieren Sie das Spiel einmal aus!
+Sollten Sie auf Fehler oder unbekannte Spielversionen stoßen, melden Sie dies bitte über unseren <a href=https://sourceforge.net/p/scummvm/bugs/">Bug Tracker</a>.
+Bitte beachten Sie dabei die <a href="http://www.scummvm.org/faq.php#question.report-bugs">Richtlinien für das Einsenden von Fehlerberichten</a>.
 </p>
 
 <p>
-Wie üblich sind wir an deinen <a href="http://wiki.scummvm.org/index.php/Screenshots">Bildschirmfotos</a> interessiert.
+Wie üblich sind wir an Ihren <a href="http://wiki.scummvm.org/index.php/Screenshots">Bildschirmfotos</a> interessiert.
 </p>
 
 </BODY>

--- a/data/news/de/20151122.xml
+++ b/data/news/de/20151122.xml
@@ -1,27 +1,28 @@
-<NAME>Betritt die Welt der Amazonen</NAME>
+<NAME>Betreten Sie die Welt der Amazonen</NAME>
 <DATE>November 22, 2015</DATE>
 <AUTHOR>Strangerke</AUTHOR>
 <BODY>
 <p>
-Wir schreiben das Jahr 1957. Du bist Jason Roberts. Du bereitest dich auf eine Expedition
-vor, um deinem verschollenen Bruder im Land der Amazonen zu helfen, bevor du dich schlussendlich
-auf die Suche nach einem verlorenen Schatz begibst.
+Wir schreiben das Jahr 1957. Sie sind Jason Roberts. Sie bereiten sich auf eine Expedition
+vor, um Ihrem verschollenen Bruder im Land der Amazonen zu helfen, bevor Sie sich schlussendlich
+auf die Suche nach einem verlorenen Schatz begeben.
 </p>
 <p>
-Das ScummVM-Team ist stolz darauf, ank&uuml;ndigen zu k&ouml;nnen, dass
+Das ScummVM-Team ist stolz darauf, anündigen zu können, dass
 <a href="http://www.mobygames.com/game/dos/amazon-guardians-of-eden">Amazon: Guardians of Eden</a> jetzt
 in der <a href="http://www.scummvm.org/downloads.php#daily">aktuellen Entwicklerversion</a> von ScummVM spielbar ist
 und getestet werden kann.
 </p>
 <p>
-Solltest du auf Fehler sto&szlig;en oder eine bislang unbekannte Spielversion besitzen, melde dies bitte
-in unserem <a href="https://sourceforge.net/p/scummvm/bugs/">Bug Tracker</a>. Bitte orientiere dich dabei
+Sollten Sie auf Fehler stoßen oder eine bislang unbekannte Spielversion besitzen, melden Sie dies bitte
+in unserem <a href="https://sourceforge.net/p/scummvm/bugs/">Bug Tracker</a>. Bitte orientieren Sie sich dabei
 an den <a href="http://www.scummvm.org/faq.php#question.report-bugs">Richtlinien zum Einsenden von Fehlermeldungen</a>.
-Alle <a href="http://wiki.scummvm.org/index.php/Screenshots">Bildschirmfotos</a>, die du w&auml;hrend deines Spiels anfertigst, sind willkommen.
+Alle <a href="http://wiki.scummvm.org/index.php/Screenshots">Bildschirmfotos</a>, die Sie während Ihres Spiels anfertigen, sind willkommen.
 </p>
 <p>
-Du bist nicht im Besitz dieses Spiels, aber willst uns trotzdem helfen? Da gibt es eine M&ouml;glichkeit! F&uuml;r &uuml;ber ein Dutzend Spiele haben wir noch keine Bildschirmfotos!
-Wirf einen Blick <a href="http://wiki.scummvm.org/index.php/Screenshots#List_of_screenshots_we_need">auf die Liste fehlender Bildschirmfotos</a>,
-schnapp dir deine Originalspiele und mach deine Lieblings-Spielszenen unsterblich!
+Sie besitzen dieses Spiel noch nicht, wollen uns jedoch trotzdem helfen? Da gibt es eine Möglichkeit!
+Für über ein Dutzend Spiele haben wir noch keine Bildschirmfotos!
+Werfen Sie einen Blick <a href="http://wiki.scummvm.org/index.php/Screenshots#List_of_screenshots_we_need">auf die Liste fehlender Bildschirmfotos</a>,
+nehmen Sie Ihre Originalspiele aus dem Schrank und machen Sie Ihre Lieblings-Spielszenen unsterblich!
 </p>
 </BODY>

--- a/data/news/de/20151206.xml
+++ b/data/news/de/20151206.xml
@@ -1,25 +1,25 @@
-<NAME>Baphomets Fluch geht weiter - mit einem Spiel von Fans f&uuml;r Fans</NAME>
+<NAME>Baphomets Fluch geht weiter - mit einem Spiel von Fans für Fans</NAME>
 <DATE>Dec 6, 2015</DATE>
 <AUTHOR>md5</AUTHOR>
 <BODY>
 	<p>
-		Die Templer sind zur&uuml;ck! In diesem von Fans erstellten Spiel aus der 'Broken Sword'-Reihe
+		Die Templer sind zurück! In diesem von Fans erstellten Spiel aus der 'Broken Sword'-Reihe
 		(in Deutschland ist die Reihe unter dem Namen 'Baphomets Fluch' bekannt) kommt
-		George zur&uuml;ck, um den Ursprung eines mysteri&ouml;sen Briefes &uuml;ber Nicos Tod zu erkunden.
-		Dabei enth&uuml;llt er noch einmal den Aufenthaltsort der heutigen Templer...
+		George zurück, um den Ursprung eines mysteriösen Briefes über Nicos Tod zu erkunden.
+		Dabei enthüllt er noch einmal den Aufenthaltsort der heutigen Templer...
 	</p>
 	<p>
-		Das ScummVM-Team ist stolz darauf, ank&uuml;ndigen zu k&ouml;nnen, dass das von Fans erstellte
-		Spiel 'Baphomets Fluch 2.5: Die R&uuml;ckkehr der Tempelritter' mithilfe der aktuellen
+		Das ScummVM-Team ist stolz darauf, ankündigen zu können, dass das von Fans erstellte
+		Spiel 'Baphomets Fluch 2.5: Die Rückkehr der Tempelritter' mithilfe der aktuellen
 		<a href="http://www.scummvm.org/downloads/#daily">Entwicklerversion</a> gespielt werden kann und in die Testphase eintritt.
 	</p>
 	<p>
-		Bitte melde alle Fehler sowie unbekannte Spieleversionen in unserem <a href="https://sourceforge.net/p/scummvm/bugs/">Bug Tracker</a>.
-		Bitte orientiere dich dabei an unseren <a href="http://www.scummvm.org/faq.php#question.report-bugs">Richtlinien zum Einsenden von Fehlerberichten</a>.
-		Alle <a href="http://wiki.scummvm.org/index.php/Screenshots">Bildschirmfotos</a> sind wie &uuml;blich willkommen.
+		Wir bitten Sie, alle Fehler sowie unbekannte Spieleversionen in unserem <a href="https://sourceforge.net/p/scummvm/bugs/">Bug Tracker</a> zu melden.
+		Bitte orientieren Sie sich dabei an unseren <a href="http://www.scummvm.org/faq.php#question.report-bugs">Richtlinien zum Einsenden von Fehlerberichten</a>.
+		Alle <a href="http://wiki.scummvm.org/index.php/Screenshots">Bildschirmfotos</a> sind wie üblich willkommen.
 	</p>
 	<p>
-		Unser Dank gilt dem wunderbaren Team von <a href="http://brokensword25.com/team/mitglieder.htm">mindFactory</a>, welches diese gro&szlig;artige Fortsetzung
-		erschaffen hat und den originalen Quellcode mit uns geteilt hat! Das Spiel kann kostenlos <a href="http://brokensword25.com/">hier</a> heruntergeladen werden.
+		Unser Dank gilt dem wunderbaren Team von <a href="http://brokensword25.com/team/mitglieder.htm">mindFactory</a>, welches diese großartige Fortsetzung
+		geschaffen hat und den originalen Quellcode mit uns geteilt hat! Das Spiel kann kostenlos <a href="http://brokensword25.com/">hier</a> heruntergeladen werden.
 	</p>
 </BODY>

--- a/data/news/de/20160119.xml
+++ b/data/news/de/20160119.xml
@@ -11,23 +11,23 @@
 		Rechenzentrum in Wien zur Verfügung zu stellen. Was dieses Angebot so
 		besonders macht, ist die Tatsache, dass im easyname-Team auch "seeeeehr große Fans der guten
 		alten SCUMM-Spiele" vertreten sind.
-		Sieh dir nur einmal <a href="http://www.easyname.com/de/unternehmen/team">diese schicke
+		Sehen Sie sich nur einmal <a href="http://www.easyname.com/de/unternehmen/team">diese schicke
 		Teamseite mit dem gewissen "SCUMM-Gefühl" an!</a>
 		Ein wirklich großartiges und völlig unerwartetes Angebot.
 	</p>
 
 	<p>
 		Also, wir ziehen um. Zuerst mit unserer Webseite und mit unserem Download-Angebot. Vielleicht
-		hast du bereits den Geschwindigkeitsschub bemerkt, den wir dem neuen Server zu verdanken haben.
+		haben Sie bereits den Geschwindigkeitsschub bemerkt, den wir dem neuen Server zu verdanken haben.
 		Wir verabschieden uns auch von den Werbeeinblendungen während der Downloads,
 		da diese von SourceForge.net ausgeliefert wurden. Von nun an wird im Zusammenhang mit diesem
 		Projekt nur noch die Werbung geschaltet, die wir selbst sehen möchten (natürlich gehört dazu
-		auch easyname.com - schau dir mal das nette Logo in der rechten Seitenleiste an).
+		auch easyname.com - schauen Sie sich doch einmal das nette Logo in der rechten Seitenleiste an).
 		Später werden wir auch weitere Dienste auf den neuen Server umziehen, und vielleicht sogar
 		mit etwas komplett Neuem erweitern.
 	</p>
 
 	<p>
-		Freue dich mit uns auf unser neues Zuhause!
+		Freuen Sie sich mit uns auf unser neues Zuhause!
 	</p>
 </BODY>

--- a/lang/lang.de.ini
+++ b/lang/lang.de.ini
@@ -25,17 +25,17 @@ compatibilityDetailsBack = "« Zurück"
 # copmpatibility.tpl
 compatibilityIntro = """
 Diese Seite zeigt den Fortschritt von ScummVM bezüglich der Kompatibilität zu den einzelnen Spielen.
-Bitte beachte, dass diese Liste jeweils für die englische Spielversion gilt. Wir versuchen, viele
+Bitte beachten Sie, dass diese Liste jeweils für die englische Spielversion gilt. Wir versuchen, viele
 Spieleversionen zu testen, trotzdem können vereinzelt Probleme mit anderen Sprachen auftreten.
 """
-compatibilityIntroExplanation = "Klicke auf den Namen eines Spiels, um die vollständigen Kompatibilitätshinweise zu diesem Spiel anzusehen."
+compatibilityIntroExplanation = "Klicken Sie auf den Namen eines Spiels, um die vollständigen Kompatibilitätshinweise zu diesem Spiel anzusehen."
 compatibilityDevContent = """
 Dies ist die Kompatibilitätsliste der aktuellen Entwicklerversion, <b>nicht die einer stabilen Version</b>
-(Bitte beachte die Kompatibilitätslisten der bisher vereöffentlichten stabilen Versionen:
+(Bitte beachten Sie die Kompatibilitätslisten der bisher vereöffentlichten stabilen Versionen:
 """
 compatibilityDevDisclaimer = """
 Da dies den Status der aktuellen Entwicklerversion darstellt, können vereinzelt vorübergehende
-Fehler durch neue änderungen eingeführt werden, weshalb diese Liste den Optimalfall darstellt.
+Fehler durch neue Änderungen eingeführt werden, weshalb diese Liste den Optimalfall darstellt.
 Wenn möglich, empfehlen wir dringend die Verwendung der jeweils aktuellen stabilen Version.
 """
    # leave {version} intact
@@ -43,7 +43,7 @@ compatibilityStableContent = """
 Dies ist die Kompatibilitätsliste für die aktuelle stabile Version {version}, <b>nicht die der aktuellen Entwicklerversion</b>.
 Der Status der Entwicklerversion kann der <a href="compatibility/"> Kompatibilitätsliste für Entwicklerversionen</a> entnommen werden.
 """
-compatibilityStableReleases = "Hier kannst du die Kompatibilitätslisten der früheren Versionen einsehen:"
+compatibilityStableReleases = "Hier können Sie die Kompatibilitätslisten der früheren Versionen einsehen:"
 compatiblityLastUpdated = "zuletzt aktualisiert:"
 compatibilityLegendTitle = "Legende"
 compatibilitySectionTitle = "Kompatibilitätsliste für Spiele von {company}"
@@ -55,9 +55,9 @@ contactContentTitle = "Kontakt"
 # contact.tpl
 contactIntro = """
 <p>
-    <b>Bitte kontaktiere das Team nicht wegen Fragen zur Verwendung von ScummVM. Stattessen
-    solltest du das englischsprachige <a href="http://forums.scummvm.org/">Forum</a> oder
-    das <a href="http://sourceforge.net/p/scummvm/bugs/">den Bug Tracker (System zum Einsenden von Fehlermeldungen)</a> verwenden!</b>
+    <b>Bitte kontaktieren Sie das Team nicht wegen Fragen zur Verwendung von ScummVM. Stattessen
+    sollten Sie das englischsprachige <a href="http://forums.scummvm.org/">Forum</a> oder
+    <a href="http://sourceforge.net/p/scummvm/bugs/">den Bug Tracker (System zum Einsenden von Fehlermeldungen)</a> verwenden!</b>
 </p>
 """
 contactIRCHeader = "IRC-Channel"
@@ -71,36 +71,36 @@ contactForumsHeader = "Foren"
 contactForums = """
 <p>
     Wir bieten verschiedene englischsprachige <a href="http://forums.scummvm.org/">Foren</a> an.
-    Verwende das <a href="http://forums.scummmv.org/viewforum.php?f=2">Hilfe-Forum</a>, wenn Probleme während der Verwendung von ScummVM auftreten.
+    Verwenden Sie das <a href="http://forums.scummmv.org/viewforum.php?f=2">Hilfe-Forum</a>, wenn Probleme während der Verwendung von ScummVM auftreten.
     Das <a href="http://forums.scummmvm.org/viewforum.php?f=1">allgemeine Diskussionsforum</a> ist, wie der Name schon sagt,
     für allgemeine Diskussionen im Zusammenhang mit ScummVM vorgesehen.
     Zusätzlich gibt es noch einige plattformspezifische Foren und <a href="http://forums.scummvm.org/viewforum.php?f=8">den Schrottplatz</a>
 </p>
 <p>
-    <b>Vergiss nicht, die <a href="http://forums.scummvm.org/viewtopic.php?t=17">Forenregeln</a> zu lesen, bevor du einen Eintrag verfasst.</b>
+    <b>Vergessen Sie bitte nicht, die <a href="http://forums.scummvm.org/viewtopic.php?t=17">Forenregeln</a> zu lesen, bevor Sie einen Eintrag verfassen.</b>
 </p>
 """
 contactTrackersHeader = "Fehlermeldungen, Anfragen, Korrekturen"
 contactTrackers = """
 <p>
-    Wenn du denkst, dass du einen Fehler gefunden hast, wirf einen Blick in unseren <a href="http://sourceforge.net/p/scummvm/bugs/">Bug Tracker</a>.
-    Eventuell wurde ein ähnlicher Fehler bereits gemeldet. In diesem Fall kannst du einen Kommentar zu diesem Fehlerbericht verfassen. Wenn nicht, kannst du
-    einen neuen Fehlerbericht einsenden, aber <b>lies bitte die Hinweise auf dem Einsendeformular aufmerksam durch</b>. Und natürlich solltest du diese auch befolgen :-)
+    Wenn Sie denken, dass Sie einen Fehler gefunden haben, werfen Sie bitte einen Blick in unseren <a href="http://sourceforge.net/p/scummvm/bugs/">Bug Tracker</a>.
+    Eventuell wurde ein ähnlicher Fehler bereits gemeldet. In diesem Fall können Sie einen Kommentar zu diesem Fehlerbericht verfassen. Wenn nicht, können Sie
+    einen neuen Fehlerbericht einsenden, aber <b>lesen Sie bitte zuvor die Hinweise auf dem Einsendeformular aufmerksam</b>. Wir bitten Sie, diese Hinweise auch befolgen :-)
 </p>
 <p>
     Wünsche bezüglich zusätzlicher Funktionen sind auf unserer <a href="http://sourceforge.net/p/scummvm/feature-requests/">Wunschliste</a> gut aufgehoben.
-    (auch hier solltest du überprüfen, ob etwas ähnliches bereits angefordert wurde.)
+    (auch hier sollten Sie überprüfen, ob etwas ähnliches bereits angefordert wurde.)
 </p>
 <p>
-    Solltest du schließlich Änderungen im Quellcode von ScummVM durchgeführt haben (sog. Patches), die in den ScummVM-Quellcode einfließen sollen,
-    kannst du eine entsprechende Anfrage (sog. "Pull Request") auf unserer <a href="https://github.com/scummvm/scummvm/pulls">GitHub-Projektseite</a> erstellen.
+    Sollten Sie schließlich Änderungen im Quellcode von ScummVM durchgeführt haben (sog. Patches), die in den ScummVM-Quellcode einfließen sollen,
+    können Sie eine entsprechende Anfrage (sog. "Pull Request") auf unserer <a href="https://github.com/scummvm/scummvm/pulls">GitHub-Projektseite</a> erstellen.
 </p>
 """
 contactListsHeader = "Mailinglisten"
 contactLists = """
 <p>
     Es gibt drei verschiedene <a href="http://sourceforge.net/p/scummvm/mailman/">Mailinglisten</a> innerhalb des ScummVM-Projektes.
-    Zwei davon sind nur für automatisierte Inhalte gedacht. Die Mailingliste, an die du selbst E-Mails schicken kannst, ist scummvm-devel.
+    Zwei davon sind nur für automatisierte Inhalte gedacht. Die Mailingliste, an die Sie selbst E-Mails schicken können, ist scummvm-devel.
 </p>
 """
 
@@ -117,7 +117,7 @@ documentationTitle = "Dokumentation"
 documentationContentTitle = "ScummVM-Dokumentation"
 
 # documentation.tpl
-documentationIntro = "Klicke auf den Titel der Dokumentation, die du lesen möchtest."
+documentationIntro = "Klicken Sie auf den Titel der Dokumentation, die Sie lesen möchten."
 
 # DownloadsPage.php
 downloadsTitle = "Downloads"
@@ -126,10 +126,10 @@ downloadsContentTitle = "ScummVM herunterladen"
 # downloads.tpl
 downloadsHeader = "Navigation"
 downloadsContentP1 = """
-Wenn du eines der unterstützten Systeme besitzt, kannst du direkt die passende Programmdatei herunterladen. Wenn du ein anderes System besitzt, dann lade
-dir den Quellcode herunter und lies die englischsprachige Seite <a href="<a href="http://wiki.scummvm.org/index.php/Compiling_ScummVM">Compiling ScummVM</a> in unserem Wiki
+Wenn Sie eines der unterstützten Systeme besitzen, können Sie direkt die passende Programmdatei herunterladen. Wenn Sie ein anderes System besitzen, dann laden
+Sie sich den Quellcode herunter und lesen Sie die englischsprachige Seite <a href="<a href="http://wiki.scummvm.org/index.php/Compiling_ScummVM">Compiling ScummVM</a> in unserem Wiki
 für Informationen darüber, wie ScummVM aus dem Quellcode gebaut (kompiliert) wird.
-Solltest du ScummVM erfolgreich auf eine andere Plattform portiert haben, hinterlasse uns bitte eine Nachricht und nenne uns Betriebssystem, Compiler etc., welche du verwendet hast.
+Sollten Sie ScummVM erfolgreich auf eine andere Plattform portiert haben, hinterlassen Sie uns bitte eine Nachricht und nennen Sie uns Betriebssystem, Compiler etc., welche Sie verwendet haben.
 """
 downloadsContentP2 = """
 Die aktuelle STABILE Version von ScummVM ist {release} und kann unter
@@ -139,7 +139,7 @@ wir, den 'Windows Installer' herunterzuladen.
 """
 downloadsContentP3 = """
 Für INSTABILE, experimentelle Versionen von ScummVM (für diejenigen, die wissen,
-was sie tun), lies den Abschnitt über die <a href="downloads/#daily">täglich erstellten Versionen</a>
+was sie tun), lesen Sie den Abschnitt über die <a href="downloads/#daily">täglich erstellten Versionen/Entwicklerversionen</a>
 am Ende dieser Seite.
 """
 downloadsContentP4 = """
@@ -147,21 +147,21 @@ Zusätzlich gibt es noch eine eigene Seite <a href="games/">für Spiele-Download
 Darin enthalten sind zur Zeit sieben Spiele, die als Freeware freigegeben wurden:
 'Beneath a Steel Sky', 'Dreamweb', 'Flight of the Amazon Queen', 'Lure of the Temptress',
 'Drascula: The Vampire Strikes Back', 'Soltys' und 'Sfinx'.
-Zusätzlich findest du dort auch Pakete mit Zwischenszenen, die empfohlen werden,
-wenn du die 'Broken Sword (Baphomets Fluch)'-Spiele oder 'Feeble Files (Floyd: Es gibt noch Helden)'
-unter ScummVM spielen möchtest.
+Zusätzlich finden Sie dort auch Pakete mit Zwischenszenen, die empfohlen werden,
+wenn Sie die 'Broken Sword (Baphomets Fluch)'-Spiele oder 'Feeble Files (Floyd: Es gibt noch Helden)'
+mit ScummVM spielen möchten.
 """
-downloadsBadge = "Empfohlener Download für dein System:"
+downloadsBadge = "Empfohlener Download für Ihr System:"
 
 # ExceptionsPage.php
 exceptionsTitle = "Fehler"
-exceptionsContentTitle = "Es gab ein Problem beim Ausführen deiner Anfrage!""
+exceptionsContentTitle = "Es gab ein Problem beim Ausführen Ihrer Anfrage!""
 
 # exception.tpl
 exceptionHeading = "Ein dreiköpfiger Affe!"
 exceptionIntro = "Hinter dir, ein dreiköpfiger Affe!"
 exceptionAlt = "Dreiköpfiger Affe"
-exceptionContent = "Es gab ein Problem beim Ausführen deiner Anfrage:"
+exceptionContent = "Es gab ein Problem beim Ausführen Ihrer Anfrage:"
 
 # FAQPage.php
 faqTitle = "F.A.Q."
@@ -190,38 +190,38 @@ gamesContentTitle = "Kostenlose Spiele herunterladen"
 # games.tpl
 gamesHeader = "Navigation"
 gamesContentP1 = """
-Hier findest du die <a href="games/#games">Spiele-Downloads</a>. Darunter
+Hier finden Sie die <a href="games/#games">Spiele-Downloads</a>. Darunter
 sind derzeit auch die sieben Freeware-Spiele 'Beneath a Steel Sky', 'Dreamweb',
 'Flight of the Amazon Queen', 'Lure of the Temptress', 'Drascula: The Vampire Strikes Back',
 'Sfinx' und 'Soltys' enthalten.
 """
 gamesContentP2 = """
-Hier findest du auch Pakete mit Zwischensequenzen, die empfohlen werden, wenn du die
+Hier findest Sie auch Pakete mit Zwischensequenzen, die empfohlen werden, wenn Sie die
 Spiele der 'Broken Sword'-Reihe oder 'Feeble Files (dt: Floyd - Es gibt noch Helden)'
-in ScummVM spielen willst.
+in ScummVM spielen möchten.
 """
 
 # game_demos.tpl
 gamesDemosHeading = "Navigation"
-gamesDemosContentP1 = "Diese Seite listet Demo-Versionen von verschiedenen Spielen auf. Bitte kontaktiere uns, wenn du eine Demo-Version besitzt, die hier nicht aufgeführt ist."
+gamesDemosContentP1 = "Diese Seite listet Demo-Versionen von verschiedenen Spielen auf. Bitte kontaktieren Sie uns, wenn Sie eine Demo-Version besitzen, die hier nicht aufgeführt ist."
 gamesDemosContentP2 = "Aus technischen Gründen werden Demo-Versionen von Beneath a Steel Sky nicht unterstützt."
 gamesDemosH1 = "Demo-Name / Download-Link"
-gamesDemosH2 = "Kürzel"
+gamesDemosH2 = "Kurzbezeichnung"
 
 # index.tpl
 indexAtomFeed = "ScummVM Atom news feed"
 indexRSSFeed = "ScummVM RSS news feed"
 indexLogo = "ScummVM-Logo"
 indexCharacters = "Charaktere"
-indexSupport = "Unterstütze dieses Projekt"
+indexSupport = "Unterstützen Sie dieses Projekt"
 indexCombobreaker = "Combobreaker.com T-Shirts"
 indexEasyname = "Hosting auf easyname.at"
 indexGOG = "Spiele auf GOG.com"
 indexGithub = "ScummVM auf GitHub"
-indexFacebook = "Folge uns auf Facebook"
-indexTwitter = "Folge uns auf Twitter"
+indexFacebook = "Folgen Sie uns auf Facebook"
+indexTwitter = "Folgen Sie uns auf Twitter"
 indexLegal = """
-LucasArts, Monkey Island, Maniac Mansion, Full Throttle, The Dig, LOOM, und wahrscheinlich noch viele Dinge
+LucasArts, Monkey Island, Maniac Mansion, Full Throttle, The Dig, LOOM, und wahrscheinlich noch viele weitere
 mehr sind eingetragene Warenzeichen von <a href="http://www.lucasarts.com/">LucasArts, Inc.</a>. Alle anderen
 Marken und eingetragenen Warenzeichen sind Eigentum der entsprechenden Firmen. ScummVM ist in keiner Weise
 mit LucasArts, Inc. verbunden.
@@ -235,9 +235,9 @@ introHeaderPrevShot = "« vorheriges"
 introHeaderNextShot = "nächstes »"
 introHeaderWhatIs = "Was ist ScummVM?"
 introHeaderContentP1 = """
-ScummVM ist ein Programm, welches dir ermöglicht, bestimmte klassische
+ScummVM ist ein Programm, welches Ihnen ermöglicht, bestimmte klassische
 Grafik-Adventures (Point-and-Click-Adventures) auszuführen, vorausgesetzt,
-du bist im Besitz der passenden Spieldateien.
+Sie sind im Besitz der passenden Spieldateien.
 ScummVM ersetzt dabei die ausführbaren Programmdateien,
 die ursprünglich mit dem Spiel mitgeliefert wurden. Dadurch können diese Spiele
 auf Systemen gespielt werden, für welche sie nie entwickelt wurden!
@@ -257,11 +257,11 @@ von Humongous Entertainment (einschließlich der <i>Freddi-Fisch-</i>
 und der <i>Töff-Töff-</i>Spiele) und noch vielen weiteren mehr.
 """
 introHeaderContentP3 = """
-du findest eine komplette Liste mit allen Informationen darüber,
-welche Spiele wie gut unterstützt werden auf der <a href="compatibility/">
+Sie finden eine komplette Liste mit allen Informationen darüber,
+welche Spiele in welchem Umfang unterstützt werden auf der <a href="compatibility/">
 Kompatibilitätsseite</a>.
 Da ScummVM laufend verbessert wird, lohnt es sich, häufiger vorbeizuschauen.
-Unter den Systemen, auf welchen du diese Spiele spielen kannst, sind Windows, Linux, Mac OS X,
+Unter den Systemen, auf welchen Sie diese Spiele spielen können, sind Windows, Linux, Mac OS X,
 Dreamcast, PocketPC, PalmOS, AmigaOS, BeOS, OS/2, PSP, PS2, SymbianOS und viele mehr.
 """
 introHeaderContentP4 = """
@@ -269,7 +269,7 @@ Offizielle Anlaufstellen für Kommentare und Vorschläge sind das <a href="http:
 (englischsprachige) Forum</a> und der <a href="irc://irc.freenode.net/scummvm"> (ebenfalls englischsprachige) IRC-Channel #scummvm </a>
 im IRC-Netzwerk freenode.net. Die Kommunikation in Forum und IRC sollte ausschließlich auf Englisch erfolgen.
 
-Bitte lies unsere <a href="faq/">häufig gestellten Fragen (FAQ)</a>, bevor du einen Eintrag dort verfasst.
+Bitte lesen Sie unsere <a href="faq/">häufig gestellten Fragen (FAQ)</a>, bevor Sie einen Eintrag dort verfassen.
 """
 
 # LinksPage.php
@@ -278,7 +278,7 @@ linksContentTitle = "Links"
 
 # links.tpl
 linksHeading = "Links"
-linksIntro = "<b>Verlinke zu uns:</b> Bitte verwende dieses Bild, wenn du einen Link zu uns auf deine Website setzen willst."
+linksIntro = "<b>Verlinken Sie zu uns:</b> Bitte verwenden Sie dieses Bild, wenn Sie einen Link zu uns auf Ihre Website setzen wollen."
 
 # list_items.tpl
 listItemsBuildFromRepo = "aus dem aktuellen Quellcode gebaut,"
@@ -298,7 +298,7 @@ pressContentTitle = "Pressespiegel"
 
 # press.tpl
 pressHeading = "ScummVM in der Presse"
-pressIntro = "(Wenn du bezüglich Medienberichten mit uns in Kontakt treten willst, schreibe bitte eine e-Mail an press (@) scummvm.org)"
+pressIntro = "(Wenn Sie bezüglich Medienberichten mit uns in Kontakt treten wollen, schreiben Sie bitte eine e-Mail an press (@) scummvm.org)"
 
 # PressSnowberryPage.php
 pressSnowberryTitle = "GOBLIIINS + ScummVM = TRAUMPAAR"
@@ -335,8 +335,8 @@ Trotzdem soll diese Seite über diese Projekte informieren, in der vagen
 Hoffnung, weitere Entwickler für diese Nebenprojekte zu gewinnen.
 """
 subprojectsIntroP2 = """
-Bitte frage nicht danach, wo du die Binärdateien für diese
-Programme beziehen kannst. Beide Nebenprojekte sind derzeit nur für
-Entwickler geeignet... Wenn du den Code nicht selbst kompilieren kannst,
-dann sind diese Programme nicht wirklich für dich geeignet.
+Bitte fragen Sie nicht danach, wo Sie die Binärdateien für diese
+Programme beziehen können. Beide Nebenprojekte sind derzeit nur für
+Entwickler geeignet... Wenn Sie den Code nicht selbst kompilieren können,
+dann sind diese Programme nicht wirklich für Sie geeignet.
 """


### PR DESCRIPTION
This pull request converts the existing German website from the currently very informal "du" form of address to the more polite and formal "Sie" form of address as suggested by @SimSaw.

I converted the entire website except the downloads.de.xml file which seems to be obsolete as soon as the next version of ScummVM is released. 

Maybe someone can merge the downloads.xml file in the lang.ini? :)