### PR TITLE
WEB: Update Maemo downloads

### DIFF
--- a/data/downloads.de.xml
+++ b/data/downloads.de.xml
@@ -185,14 +185,14 @@
 					<name>Paket f&uuml;r Tizen</name>
 					<extra_info>(12.2M .tpk)</extra_info>
 				</file>
-<!--
+
 				<file>
 					<category_icon>catpl-maemo.png</category_icon>
 					<url>scummvm_{$release}-maemo_armel.deb?download</url>
 					<name>Paket f&uuml;r Maemo (OS 2008 und Maemo5/Fremantle)</name>
-					<extra_info>(9.1M .deb)</extra_info>
+					<extra_info>(9.6M .deb)</extra_info>
 				</file>
-
+<!--
 				<file>
 					<category_icon>catpl-linuxmoto.png</category_icon>
 					<url>scummvm-{$release}-motoezx.pkg?download</url>
@@ -570,13 +570,6 @@
 					<url>scummvm-1.6.0_slack-x86_64-1.txz?download</url>
 					<name>1.6.0 f&uuml;r SlackWare x86 64bit</name>
 					<extra_info>(9.4M .txz)</extra_info>
-				</file>
-
-				<file>
-					<category_icon>catpl-maemo.png</category_icon>
-					<url>scummvm_1.6.0-maemo_armel.deb?download</url>
-					<name>1.6.0 f&uuml;r Maemo (OS 2008 und Maemo5/Fremantle)</name>
-					<extra_info>(9.1M .deb)</extra_info>
 				</file>
 
 				<file>

--- a/data/downloads.xml
+++ b/data/downloads.xml
@@ -185,14 +185,14 @@
 					<name>Tizen package</name>
 					<extra_info>(12.2M .tpk)</extra_info>
 				</file>
-<!--
+
 				<file>
 					<category_icon>catpl-maemo.png</category_icon>
 					<url>scummvm_{$release}-maemo_armel.deb</url>
 					<name>Maemo package (OS 2008 and Maemo5/Fremantle)</name>
-					<extra_info>(9.1M .deb)</extra_info>
+					<extra_info>(9.6M .deb)</extra_info>
 				</file>
-
+<!--
 				<file>
 					<category_icon>catpl-linuxmoto.png</category_icon>
 					<url>scummvm-{$release}-motoezx.pkg</url>
@@ -570,13 +570,6 @@
 					<url>1.6.0/scummvm-1.6.0_slack-x86_64-1.txz</url>
 					<name>1.6.0 SlackWare x86 64bit package</name>
 					<extra_info>(9.4M .txz)</extra_info>
-				</file>
-
-				<file>
-					<category_icon>catpl-maemo.png</category_icon>
-					<url>1.6.0/scummvm_1.6.0-maemo_armel.deb</url>
-					<name>1.6.0 Maemo package (OS 2008 and Maemo5/Fremantle)</name>
-					<extra_info>(9.1M .deb)</extra_info>
 				</file>
 
 				<file>


### PR DESCRIPTION
The 1.7.0 build for Maemo was uploaded 2015-09-14.
I didn't realize the download page still says 1.6.0 is the latest.

I am not sure if this is enough because I have no experience with scummvm-web. Please let me know if there is anything else that is required. I will update the wiki when this is resolved.