### PR TITLE
WEB: Fix typos + grammar in German 1.8.0 testing announcement

### DIFF
--- a/data/news/de/20160201.xml
+++ b/data/news/de/20160201.xml
@@ -4,7 +4,7 @@
 <BODY>
 
 <p>
-	Nach einer sehr langen Pause, haben wir endlich mit den Vorbereitungen für unsere nächste Veröffentlichung, ScummVM 1.8.0, begonnen.
+	Nach einer sehr langen Pause haben wir endlich mit den Vorbereitungen für unsere nächste Veröffentlichung, ScummVM 1.8.0, begonnen.
 </p>
 
 <p>
@@ -26,21 +26,21 @@
 </ul>
 
 <p>
-	Wir große Teile der AGI-Engine neu geschrieben, sodass alle AGI-Spiele nun besser laufen sollten. Allerdings können sich auch neue, unerwartete Fehler eingeschlichen haben.
+	Wir haben große Teile der AGI-Engine neu geschrieben, sodass alle AGI-Spiele nun besser laufen sollten. Allerdings können sich auch neue, unerwartete Fehler eingeschlichen haben.
 </p>
 
 <p>Aus diesem Grund benötigen wir Ihre Unterstützung beim Testen der Spiele, die neu hinzugefügt wurden oder die AGI-Engine verwenden.
-	Um Ihnen die Suche nach Fehlern etwas zu erleichtern, haben wir eine Liste der Spiele, die gestestet werden müssen,
+	Um Ihnen die Suche nach Fehlern etwas zu erleichtern, haben wir eine Liste der Spiele, die getestet werden müssen,
 	<a href="http://wiki.scummvm.org/index.php/Release_Testing/1.8.0">in unserem Wiki</a> zusammengestellt.
 	Auf dieser Liste finden Sie auch ein paar andere alte Klassiker, die einen erneuten Testlauf gut gebrauchen können.
 </p>
 
-<p>Sie benötigen eine aktuelle <a href="http://www.scummvm.org/downloads.php#daily">Entwicklerversion </a> von ScummVM,
+<p>Sie benötigen eine aktuelle <a href="http://www.scummvm.org/downloads.php#daily">Entwicklerversion</a> von ScummVM,
 	um direkt mit Ihrer Hilfe zu beginnen! Sollten Sie einen Fehler finden, melden Sie diesen bitte in unserem 
 	<a href="http://sourceforge.net/p/scummvm/bugs/">Bug Tracker</a>. Wenn Sie eines der Spiele komplett durchgespielt haben,
 	lassen Sie uns das bitte <a href="http://forums.scummvm.org/viewtopic.php?t=14006">in unserem Forum</a> wissen, damit wir Ihren
 	Fortschritt in unserem <a href="http://wiki.scummvm.org/index.php/Release_Testing/1.8.0">Wiki</a> markieren und sich andere
-	Spieler auf die ungetesteten Spiele konzentrieren können. Bitte bevolgen Sie unsere Richtlinien für Tests einer bevorstehenden neuen Version.
+	Spieler auf die ungetesteten Spiele konzentrieren können. Bitte befolgen Sie unsere Richtlinien für Tests einer bevorstehenden neuen Version.
 	Diese können Sie <a href="http://wiki.scummvm.org/index.php/Release_Testing">hier einsehen</a>.
 </p>
 


### PR DESCRIPTION
This commit fixes a few typos and grammar mistakes in the German 1.8.0 testing announcement.

Sorry for that.