### PR TITLE
WEB: Use German release titles in news

### DIFF
--- a/data/news/de/20151206.xml
+++ b/data/news/de/20151206.xml
@@ -3,9 +3,8 @@
 <AUTHOR>md5</AUTHOR>
 <BODY>
 	<p>
-		Die Templer sind zurück! In diesem von Fans erstellten Spiel aus der 'Broken Sword'-Reihe
-		(in Deutschland ist die Reihe unter dem Namen 'Baphomets Fluch' bekannt) kommt
-		George zurück, um den Ursprung eines mysteriösen Briefes über Nicos Tod zu erkunden.
+		Die Templer sind zurück! In diesem von Fans erstellten Spiel aus der 'Baphomets Fluch'-Reihe
+		kehrt George zurück, um den Ursprung eines mysteriösen Briefes über Nicos Tod zu erkunden.
 		Dabei enthüllt er noch einmal den Aufenthaltsort der heutigen Templer...
 	</p>
 	<p>

--- a/data/news/de/20160201.xml
+++ b/data/news/de/20160201.xml
@@ -15,13 +15,13 @@
 <ul>
 	<li><i>Rex Nebular and the Cosmic Gender Bender</i></li>
 	<li><i>Sfinx</i></li>
-	<li><i>Zork Nemesis: The Forbidden Lands</i></li>
-	<li><i>Zork: Grand Inquisitor</i></li>
-	<li><i>The Lost Files of Sherlock Holmes: The Case of the Serrated Scalpel</i></li>
-	<li><i>The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo</i></li>
+	<li><i>Zork Nemesis: Das verbotene Land</i></li>
+	<li><i>Zork: Der Großinquisitor</i></li>
+	<li><i>Die ungelösten Fälle von Sherlock Holmes: Das gezackte Skalpel</i></li>
+	<li><i>Die ungelösten Fälle von Sherlock Holmes: Das Geheimnis der tätowierten Rose</i></li>
 	<li><i>Beavis and Butthead in Virtual Stupidity</i></li>
 	<li><i>Amazon: Guardians of Eden</i></li>
-	<li><i>Broken Sword 2.5: The Return of the Templars</i></li>
+	<li><i>Baphomets Fluch 2.5: Die Rückkehr der Tempelritter</i></li>
 	<li><i>Labyrinth of Time</i></li>
 </ul>
 

--- a/data/news/de/20160201.xml
+++ b/data/news/de/20160201.xml
@@ -17,7 +17,7 @@
 	<li><i>Sfinx</i></li>
 	<li><i>Zork Nemesis: Das verbotene Land</i></li>
 	<li><i>Zork: Der Großinquisitor</i></li>
-	<li><i>Die ungelösten Fälle von Sherlock Holmes: Das gezackte Skalpel</i></li>
+	<li><i>Die ungelösten Fälle von Sherlock Holmes: Das gezackte Skalpell</i></li>
 	<li><i>Die ungelösten Fälle von Sherlock Holmes: Das Geheimnis der tätowierten Rose</i></li>
 	<li><i>Beavis and Butthead in Virtual Stupidity</i></li>
 	<li><i>Amazon: Guardians of Eden</i></li>


### PR DESCRIPTION
BS2.5 and 1.8.0 testing announcements now use the German release titles instead of the English ones.