### PR TITLE
WEB: Translate GSoC 2016 news to German

### DIFF
--- a/data/news/de/20160301.xml
+++ b/data/news/de/20160301.xml
@@ -1,0 +1,19 @@
+<NAME>Herzlich willkommen zu einem neuen "Summer of Code"</NAME>
+<DATE>March 1, 2016</DATE>
+<AUTHOR>Strangerke</AUTHOR>
+<BODY>
+<p>
+     <img src="data/news/GSoC2016Logo.png" alt="GSoC 2016 Logo" align="middle">
+</p>
+ 
+<p>Gestern hat Google die Liste der akzeptierten Mentoren-Organisationen veröffentlicht. Es ist uns eine große Freude, dass wir als teilnehmende Organisation akzeptiert wurden.</p>
+ 
+<p>
+In den letzten Jahren haben wir uns hauptsächlich auf Adventure-Spiele konzentriert. Nach Diskussionen mit unserem Schwesterprojekt ResidualVM freuen wir uns, ankündigen zu können, dass wir dieses Jahr auch Aufgaben bezüglich RPG-Spielen akzeptieren werden.</p>
+ 
+<p>ScummVM und ResidualVM warten nun auf motivierte Studenten, welche diesen Sommer daran arbeiten möchten, Abenteuerspiele und Rollenspiele wieder aufleben zu lassen.</p>
+<p>Werden Sie ein Teil davon! Schreiben Sie Geschichte und nehmen Sie an unserem bislang besten GSoC teil! Werfen Sie einen Blick auf <a href="http://wiki.scummvm.org/index.php/Summer_of_Code/GSoC_Ideas_2016">unsere Ideen-Seite</a> oder bringen Sie Ihre eigenen Ideen ein. Nehmen Sie Kontakt mit uns auf: Wir erwarten Sie in unserem IRC!
+
+<p>Ein Ort: Freenode. Zwei Kanäle: #scummvm und #residualvm</p>
+ 
+</BODY>

--- a/data/news/de/20160301.xml
+++ b/data/news/de/20160301.xml
@@ -11,7 +11,7 @@
 <p>
 In den letzten Jahren haben wir uns hauptsächlich auf Adventure-Spiele konzentriert. Nach Diskussionen mit unserem Schwesterprojekt ResidualVM freuen wir uns, ankündigen zu können, dass wir dieses Jahr auch Aufgaben bezüglich RPG-Spielen akzeptieren werden.</p>
  
-<p>ScummVM und ResidualVM warten nun auf motivierte Studenten, welche diesen Sommer daran arbeiten möchten, Abenteuerspiele und Rollenspiele wieder aufleben zu lassen.</p>
+<p>ScummVM und ResidualVM warten nun auf motivierte Studenten, die diesen Sommer daran arbeiten möchten, Abenteuerspiele und Rollenspiele wieder aufleben zu lassen.</p>
 <p>Werden Sie ein Teil davon! Schreiben Sie Geschichte und nehmen Sie an unserem bislang besten GSoC teil! Werfen Sie einen Blick auf <a href="http://wiki.scummvm.org/index.php/Summer_of_Code/GSoC_Ideas_2016">unsere Ideen-Seite</a> oder bringen Sie Ihre eigenen Ideen ein. Nehmen Sie Kontakt mit uns auf: Wir erwarten Sie in unserem IRC!
 
 <p>Ein Ort: Freenode. Zwei Kanäle: #scummvm und #residualvm</p>


### PR DESCRIPTION
This PR adds a German translation of the GSoC 2016 announcement to the website.