### PR TITLE
WEB/DE: Fix encoding in 1.8.0 announcement

### DIFF
--- a/data/news/de/20160304.xml
+++ b/data/news/de/20160304.xml
@@ -4,66 +4,66 @@
 <BODY>
 
 <p>
-    Nein, wir wollen es nicht zur Regel machen, dass wir ScummVM langsamer und langsamer veröffentlichen!
-    Viele Monate sind seit der letzten offiziellen Veröffentlichung vergangen...
+    Nein, wir wollen es nicht zur Regel machen, dass wir ScummVM langsamer und langsamer verÃ¶ffentlichen!
+    Viele Monate sind seit der letzten offiziellen VerÃ¶ffentlichung vergangen...
     aber in der Zwischenzeit wurde eine ganze Menge an Arbeit geleistet.
-    Das Ergebnis ist eine der bisher größten Veröffentlichungen von ScummVM! 
+    Das Ergebnis ist eine der bisher grÃ¶ÃŸten VerÃ¶ffentlichungen von ScummVM! 
 
 </p>
 
-<p>ScummVM 1.8 fügt die Unterstützung für <em>zehn</em> neue Spiele unter Verwendung acht brandneuer Spiele-Engines hinzu:</p>
+<p>ScummVM 1.8 fÃ¼gt die UnterstÃ¼tzung fÃ¼r <em>zehn</em> neue Spiele unter Verwendung acht brandneuer Spiele-Engines hinzu:</p>
 
 <ul>
     <li><i>Amazon: Guardians of Eden</i></li>
     <li><i>Beavis and Butthead in Virtual Stupidity</i></li>
-    <li><i>Baphomets Fluch 2.5: Die Rückkehr der Tempelritter</i></li>
+    <li><i>Baphomets Fluch 2.5: Die RÃ¼ckkehr der Tempelritter</i></li>
     <li><i>Labyrinth of Time</i></li>
     <li><i>Rex Nebular and the Cosmic Gender Bender</i></li>
     <li><i>Sfinx</i></li>
-    <li><i>Die ungelösten Fälle von Sherlock Holmes: Das Geheimnis der tätowierten Rose</i></li>
-    <li><i>Die ungelösten Fälle von Sherlock Holmes: Das gezackte Skalpell</i></li>
-    <li><i>Zork: Der Großinquisitor</i></li>
+    <li><i>Die ungelÃ¶sten FÃ¤lle von Sherlock Holmes: Das Geheimnis der tÃ¤towierten Rose</i></li>
+    <li><i>Die ungelÃ¶sten FÃ¤lle von Sherlock Holmes: Das gezackte Skalpell</i></li>
+    <li><i>Zork: Der GroÃŸinquisitor</i></li>
     <li><i>Zork Nemesis: Das verbotene Land</i></li>
 </ul>
 
 <p>
-    Neben der Unterstützung für die neuen Spiele haben wir auch den MT-32-Emulator auf die
-    aktuelle Version von "munt" aktualisiert. Außerdem haben wir für Spiele mit entsprechender
-    Unterstützung "AdLib" durch "Miles Audio" ersetzt. Dies bedeutet, dass Spiele in ScummVM nun
+    Neben der UnterstÃ¼tzung fÃ¼r die neuen Spiele haben wir auch den MT-32-Emulator auf die
+    aktuelle Version von "munt" aktualisiert. AuÃŸerdem haben wir fÃ¼r Spiele mit entsprechender
+    UnterstÃ¼tzung "AdLib" durch "Miles Audio" ersetzt. Dies bedeutet, dass Spiele in ScummVM nun
     besser klingen als je zuvor!
 </p>
 <p>
-    Wir haben auch das Grafik-Subsystem in der AGI-Engine überarbeitet und im Grunde genommen ersetzt.
-    Das Ergebnis ist eine Kompatibilität mit alten Sierra-Spielen, die so hoch ist wie nie zuvor.
+    Wir haben auch das Grafik-Subsystem in der AGI-Engine Ã¼berarbeitet und im Grunde genommen ersetzt.
+    Das Ergebnis ist eine KompatibilitÃ¤t mit alten Sierra-Spielen, die so hoch ist wie nie zuvor.
     Enthalten sind jetzt auch plattformspezifische Dialoge, Farbpaletten und Schriftarten
-    für Apple IIgs-, Atari ST- und Amiga-Versionen dieser Spiele.
-    Die Spiele-Geschwindigkeit für Apple IIgs-Spiele wird nun genau behandelt.
-    Es ist jetzt sogar möglich, auf die Darstellung einer anderen Plattform umzuschalten.
+    fÃ¼r Apple IIgs-, Atari ST- und Amiga-Versionen dieser Spiele.
+    Die Spiele-Geschwindigkeit fÃ¼r Apple IIgs-Spiele wird nun genau behandelt.
+    Es ist jetzt sogar mÃ¶glich, auf die Darstellung einer anderen Plattform umzuschalten.
 </p>
 
 <p>
-    Neu hinzugekommen sind Portierungen auf das GCW-Zero (ja, sev hat endlich ein Gerät aus dem Kickstarter-Projekt erhalten) und auf den Raspberry Pi.
+    Neu hinzugekommen sind Portierungen auf das GCW-Zero (ja, sev hat endlich ein GerÃ¤t aus dem Kickstarter-Projekt erhalten) und auf den Raspberry Pi.
 </p>
 
 <p>
     Nebenbei sind wir auch auf einen neuen Server umgezogen und haben unserer Website eine
-    Übersetzungsmöglichkeit hinzugefügt. Wenn Sie uns mit der Übersetzung helfen möchten,
+    ÃœbersetzungsmÃ¶glichkeit hinzugefÃ¼gt. Wenn Sie uns mit der Ãœbersetzung helfen mÃ¶chten,
     finden Sie <a href="http://wiki.scummvm.org/index.php/HOWTO-Translate_ScummVM_Web_Site">hier</a> die entsprechenden Informationen dazu.
 </p>
 
 <p>
-    Diese Liste ist längst nicht vollständig. Die ausführlichere Version finden Sie in
-    den <a href="http://wiki.scummvm.org/index.php/HOWTO-Translate_ScummVM_Web_Site">Veröffentlichungshinweisen</a>. Die passenden Programmdateien für Ihr System stehen
-    auf unserer <a href="http://www.scummvm.org/downloads">Download-Seite</a> zur Verfügung.
-    Die für die jeweiligen Portierungen verantwortlichen Personen arbeiten noch an
-    der Bereitstellung der Pakete. Wir möchten Sie daher um Geduld bitten, wenn Sie
-    die aktuelle Version noch nicht für Ihr System herunterladen können.
+    Diese Liste ist lÃ¤ngst nicht vollstÃ¤ndig. Die ausfÃ¼hrlichere Version finden Sie in
+    den <a href="http://wiki.scummvm.org/index.php/HOWTO-Translate_ScummVM_Web_Site">VerÃ¶ffentlichungshinweisen</a>. Die passenden Programmdateien fÃ¼r Ihr System stehen
+    auf unserer <a href="http://www.scummvm.org/downloads">Download-Seite</a> zur VerfÃ¼gung.
+    Die fÃ¼r die jeweiligen Portierungen verantwortlichen Personen arbeiten noch an
+    der Bereitstellung der Pakete. Wir mÃ¶chten Sie daher um Geduld bitten, wenn Sie
+    die aktuelle Version noch nicht fÃ¼r Ihr System herunterladen kÃ¶nnen.
 
 </p>
 
 <p>
     Verlaufen Sie sich nicht im Labyrinth und rufen Sie im schlimmsten Fall nach Mr. Holmes!
-    (Und wir versprechen, dass wir häufiger eine neue Version veröffentlichen!)
+    (Und wir versprechen, dass wir hÃ¤ufiger eine neue Version verÃ¶ffentlichen!)
 </p>
 
 </BODY>


### PR DESCRIPTION
This time using proper UTF-8 encoding.

Sorry, I don't get why my editor switched to ANSI without asking me.