### PR TITLE
WEB: Update RELEASE_DEBIAN to 1.7.0

### DIFF
--- a/include/config.inc.php
+++ b/include/config.inc.php
@@ -2,7 +2,7 @@
 /* Current version. */
 define('RELEASE', '1.8.0');
 define('RELEASE_TOOLS', '1.8.0');
-define('RELEASE_DEBIAN', '1.6.0');
+define('RELEASE_DEBIAN', '1.7.0');
 /* Version when the percentages on the compat page were removed */
 define('COMPAT_LAYOUT_CHANGE', '1.7.0');
 


### PR DESCRIPTION
According to the Debian website for the ScummVM package [https://packages.debian.org/sid/scummvm], the current version available in the "sid" repository is 1.7.0 and not 1.6.0 as stated on the ScummVM downloads website.