### PR TITLE
Move language button to top of screen, mobile fixes

### DIFF
--- a/css/lang-menu.css
+++ b/css/lang-menu.css
@@ -19,14 +19,6 @@ code.text-badge {
 	padding: 0 0px;
 }
 
-#langmenu a {
-	position: relative;
-	top: 4px;
-	color: #000000;
-	text-decoration: none;
-	font-size: 9pt;
-}
-
 #langmenu > li {
 	float: left;
 	height: 29px;
@@ -36,6 +28,7 @@ code.text-badge {
 	margin-bottom: 0pt;
 	position: relative;
 	background: url(../images/header-background.gif) repeat-x;
+	cursor: pointer;
 
 	border-left: 1px solid #cecece;
 	border-right: 1px solid #cecece;
@@ -45,15 +38,23 @@ code.text-badge {
 	-webkit-border-radius: 4px 4px 0 0;
 }
 
-#langmenu > li > a {
+#langmenu > li > span {
+	display: inline;
+	width: auto;
+	position: relative;
+	top: 4px;
+	color: #000000;
+	text-decoration: none;
+	font-size: 9pt;
 	text-shadow: 0 1px 2px #fff;
 	font-weight: 700;
-	/* padding: 0px 7px 0px 7px; */
-	/* display: block; */
-	color: #000000;
-
 	padding: 0px 20px 0px 10px;
 	background: url(../images/dropdown.png) no-repeat right center;
+}
+
+#langmenu > li > span > img {
+	display: inline;
+	vertical-align: middle;
 }
 
 #langmenu > li > ul {
@@ -70,9 +71,10 @@ code.text-badge {
 	display: none;
 	background: #f6f6f6;
 	z-index: 1000;
+	cursor: default;
 }
 
-#langmenu > li:hover > a {
+#langmenu > li:hover > span {
 	background: url(../images/dropdown-over.png) no-repeat right center;
 	color: rgb(168, 39, 9);
 }
@@ -94,6 +96,9 @@ code.text-badge {
 }
 
 #langmenu li ul li a {
+	position: relative;
+	color: #000000;
+	text-decoration: none;
 	font-size: 9pt;
 	font-weight: bold;
 	display: block;

--- a/css/lang-menu.css
+++ b/css/lang-menu.css
@@ -1,9 +1,8 @@
 #lang-wrapper {
-	margin: 0 auto;
+	margin-right: 10px;
 	float: right;
 	position: relative;
-	top: 79px;
-	margin-right: 10px;
+	top: 0px;
 }
 
 code.text-badge {
@@ -14,6 +13,7 @@ code.text-badge {
 }
 
 #langmenu {
+	margin: 0 auto;
 	font-size: 8pt;
 	list-style: none;
 	padding: 0 0px;
@@ -23,19 +23,17 @@ code.text-badge {
 	float: left;
 	height: 29px;
 	padding-right: 2px;
-	margin-right: 10px;
-	margin-top: 0pt;
-	margin-bottom: 0pt;
+	margin-top: 0px;
+	margin-bottom: 0px;
 	position: relative;
 	background: url(../images/header-background.gif) repeat-x;
 	cursor: pointer;
-
 	border-left: 1px solid #cecece;
 	border-right: 1px solid #cecece;
-	border-top: 1px solid #cecece;
-	border-radius: 4px 4px 0 0;
-	-moz-border-radius: 4px 4px 0 0;
-	-webkit-border-radius: 4px 4px 0 0;
+	border-bottom: 1px solid #cecece;
+	border-radius: 0 0 4px 4px;
+	-moz-border-radius: 0 0 4px 4px;
+	-webkit-border-radius: 0 0 4px 4px;
 }
 
 #langmenu > li > span {
@@ -91,8 +89,6 @@ code.text-badge {
 	width: 100%;
 	float: left;
 	list-style: none;
-	margin-bottom: 7px;
-	padding: 0 0 3px 0;
 }
 
 #langmenu li ul li a {
@@ -102,11 +98,11 @@ code.text-badge {
 	font-size: 9pt;
 	font-weight: bold;
 	display: block;
-	padding: 2px 0px 2px 0px;
+	padding: 5px 0px 5px 0px;
 }
 
 #langmenu li ul li a:hover {
 	color: #ffffff;
-	padding: 2px 0px 2px 0px;
+	padding: 5px 0px 5px 0px;
 	background: url(../images/par-head.png) repeat-x;
 }

--- a/css/layout.css
+++ b/css/layout.css
@@ -2,13 +2,13 @@ body {
 	font: normal 8pt/normal verdana, tahoma, arial, helvetica, sans-serif;
 	background: rgb(239, 196, 24) url('../images/body-bg.png') repeat-x scroll 0 0;
 	margin-top: 0px;
+	min-width: 1031px;
 }
 
 #header {
 	background: transparent url('../images/bg-upper.gif') repeat scroll 0 0;
 	height: 118px;
 	margin: 0 auto;
-	min-width: 780px;
 	width: 90%;
 }
 
@@ -26,7 +26,6 @@ body {
 	margin: 0;
 	margin: 0px auto;
 	min-height: 1080px;
-	min-width: 780px;
 	position: relative;
 	width: 90%;
 }

--- a/templates/lang_menu.tpl
+++ b/templates/lang_menu.tpl
@@ -1,7 +1,7 @@
 <div id="lang-wrapper">
-    <div id="drop-down">
+    <div>
         <ul id="langmenu">
-            <li><a href=""><img src="/images/lang-icon.png" width="16" height="16" alt="Language">&nbsp;&nbsp;Language</a>
+            <li><span><img src="/images/lang-icon.png" width="16" height="16" alt="Language">&nbsp;&nbsp;Language</span>
                 <ul>
                     {foreach from=$available_languages key=key item=item}
                     <li><a href="{$pageurl}?lang={$key}"><code class="text-badge">{$key|strtoupper}</code>{$item|escape}</a></li>


### PR DESCRIPTION
1. Fixed #52 by using a larger `min-width` for the page.
My earlier change made it disappear, but even before that, the language button was hovering over the logo.

2. The button was unusable on mobile. Since mobile doesn't have "hover", you have to click on it. Clicking on it reloaded the main page since it was a `<a href="">`. I fixed this by changing the `<a>` to a `<span>` and prettied it up by changing the cursor to a pointer. I also took the opportunity to remove some unused CSS, and vertically center the "language book" image in the tab.