### PR TITLE
WEB: Center "Language" button

### DIFF
--- a/css/lang-menu.css
+++ b/css/lang-menu.css
@@ -1,8 +1,8 @@
 #lang-wrapper {
-	margin-right: 10px;
-	float: right;
-	position: relative;
-	top: 0px;
+	width: 100%;
+	position: absolute;
+	left: 0;
+	top: 0;
 }
 
 code.text-badge {
@@ -12,11 +12,14 @@ code.text-badge {
 	padding: 0 2px 0 2px;
 }
 
-#langmenu {
-	margin: 0 auto;
+#langmenu {	
 	font-size: 8pt;
 	list-style: none;
 	padding: 0 0px;
+	margin: 0 0 0 50%;
+	transform: translateX(-50%);
+	display: inline-block;
+	z-index: 10;
 }
 
 #langmenu > li {

--- a/css/lang-menu.css
+++ b/css/lang-menu.css
@@ -3,6 +3,7 @@
 	position: absolute;
 	left: 0;
 	top: 0;
+	z-index: 1000;
 }
 
 code.text-badge {
@@ -19,7 +20,6 @@ code.text-badge {
 	margin: 0 0 0 50%;
 	transform: translateX(-50%);
 	display: inline-block;
-	z-index: 10;
 }
 
 #langmenu > li {


### PR DESCRIPTION
Simply centered button.

This solution uses `transform` property, which is CSS3, but should be supported quite well. There are browser-specific prefix-versions of this property, which are supported by older versions of browsers, but probably still not all of them.

It looks like that: ![Centered button](http://tkachov.ru/images/wyN7hwrYWs0ttMQ7KtQKOdjC7fRk0UlxT94A5xkc/step2.png)

@salty-horse says he assumed it's supposed to be centered between the logo and the characters instead of the whole page.
