### PR TITLE
WEB: Set language cookie to expire after 60 days

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -7,7 +7,7 @@ RewriteBase /
 
 # Fetch language and put it into Cookie
 RewriteCond     %{QUERY_STRING}                                             lang=(.*)?
-RewriteRule     .*                                                           -  [CO=lang:%1:.scummvm.org]
+RewriteRule     .*                                                           -  [CO=lang:%1:.scummvm.org:86400]
 
 RewriteRule		^old/.*														-	[L]
 


### PR DESCRIPTION
The default is to have a session cookie, but it might be better to remember the selected language for longer than just the current session. This commit is here for discussion as I don't know if this is what we want. Also I picked 60 days randomly. Maybe we want more, maybe less.