### PR TITLE
WEB: Remove links to sf.net project home

### DIFF
--- a/data/menus.de.xml
+++ b/data/menus.de.xml
@@ -56,10 +56,6 @@
 		<name>Entwicklung</name>
 		<class>menu-sf</class>
 		<link>
-			<name>Projektseite auf SF.net</name>
-			<href>https://sourceforge.net/projects/scummvm/</href>
-		</link>
-		<link>
 			<name>Fehlerberichte</name>
 			<href>http://bugs.scummvm.org/</href>
 		</link>

--- a/data/menus.fr.xml
+++ b/data/menus.fr.xml
@@ -56,10 +56,6 @@
 		<name>Dévelopement</name>
 		<class>menu-sf</class>
 		<link>
-			<name>Accueil Projet SF.net</name>
-			<href>https://sourceforge.net/projects/scummvm/</href>
-		</link>
-		<link>
 			<name>Base de Bogue</name>
 			<href>http://bugs.scummvm.org/</href>
 		</link>

--- a/data/menus.it.xml
+++ b/data/menus.it.xml
@@ -56,10 +56,6 @@
 		<name>Development</name>
 		<class>menu-sf</class>
 		<link>
-			<name>Homepage su SF.net</name>
-			<href>https://sourceforge.net/projects/scummvm/</href>
-		</link>
-		<link>
 			<name>Bug Tracker</name>
 			<href>https://sourceforge.net/p/scummvm/bugs/</href>
 		</link>

--- a/data/menus.ru.xml
+++ b/data/menus.ru.xml
@@ -56,10 +56,6 @@
 		<name>Pазработка</name>
 		<class>menu-sf</class>
 		<link>
-			<name>Страница проекта на SF.net</name>
-			<href>https://sourceforge.net/projects/scummvm/</href>
-		</link>
-		<link>
 			<name>Багтрекер</name>
 			<href>http://bugs.scummvm.org/</href>
 		</link>

--- a/data/menus.xml
+++ b/data/menus.xml
@@ -56,10 +56,6 @@
 		<name>Development</name>
 		<class>menu-sf</class>
 		<link>
-			<name>SF.net Project Home</name>
-			<href>https://sourceforge.net/projects/scummvm/</href>
-		</link>
-		<link>
 			<name>Bug Tracker</name>
 			<href>http://bugs.scummvm.org/</href>
 		</link>


### PR DESCRIPTION
Now that we moved everything (downloads, ticket system, mailing lists...) away from sf.net, I think it makes sense to remove the last remaining links to the sf.net project home.
