### PR TITLE
WEB: Remove links to the old Feature Tracker

### DIFF
--- a/data/menus.de.xml
+++ b/data/menus.de.xml
@@ -60,10 +60,6 @@
 			<href>http://bugs.scummvm.org/</href>
 		</link>
 		<link>
-			<name>Funktionswünsche</name>
-			<href>https://sourceforge.net/p/scummvm/feature-requests/</href>
-		</link>
-		<link>
 			<name>Code beitragen</name>
 			<href>https://github.com/scummvm/scummvm/pulls</href>
 		</link>

--- a/data/menus.fr.xml
+++ b/data/menus.fr.xml
@@ -60,10 +60,6 @@
 			<href>http://bugs.scummvm.org/</href>
 		</link>
 		<link>
-			<name>Demandes de fonctionnalités</name>
-			<href>https://sourceforge.net/p/scummvm/feature-requests/</href>
-		</link>
-		<link>
 			<name>Base de Patches</name>
 			<href>https://github.com/scummvm/scummvm/pulls</href>
 		</link>

--- a/data/menus.it.xml
+++ b/data/menus.it.xml
@@ -60,10 +60,6 @@
 			<href>https://sourceforge.net/p/scummvm/bugs/</href>
 		</link>
 		<link>
-			<name>Feature Request</name>
-			<href>https://sourceforge.net/p/scummvm/feature-requests/</href>
-		</link>
-		<link>
 			<name>Patch Tracker</name>
 			<href>https://sourceforge.net/p/scummvm/patches/</href>
 		</link>

--- a/data/menus.ru.xml
+++ b/data/menus.ru.xml
@@ -60,10 +60,6 @@
 			<href>http://bugs.scummvm.org/</href>
 		</link>
 		<link>
-			<name>Запросы</name>
-			<href>https://sourceforge.net/p/scummvm/feature-requests/</href>
-		</link>
-		<link>
 			<name>Патчи</name>
 			<href>https://github.com/scummvm/scummvm/pulls</href>
 		</link>

--- a/data/menus.xml
+++ b/data/menus.xml
@@ -60,10 +60,6 @@
 			<href>http://bugs.scummvm.org/</href>
 		</link>
 		<link>
-			<name>Feature Requests</name>
-			<href>https://sourceforge.net/p/scummvm/feature-requests/</href>
-		</link>
-		<link>
 			<name>Patch Tracker</name>
 			<href>https://github.com/scummvm/scummvm/pulls</href>
 		</link>


### PR DESCRIPTION
The menus still linked to the old feature/bug tracker on sourceforge. 