### PR TITLE
Add a cookie consent form for Google Analytics

### DIFF
--- a/lang/lang.ini
+++ b/lang/lang.ini
@@ -416,3 +416,8 @@ Currently both subprojects are still in a state only suitable for
 developers... so if you can't compile the code yourself, then these are
 not really ready for you.
 """
+
+# cookie.tpl
+cookieText = "We use cookies to enhance content and analyze information on site performance and usage."
+cookieAccept = "Allow Cookies"
+cookieDecline = "Refuse Cookies"

--- a/scss/components/_cookie.scss
+++ b/scss/components/_cookie.scss
@@ -9,30 +9,15 @@
 	vertical-align: middle;
 	padding: 20px 20px;
 
-	.buttons {
-		float: right;
-		width: 10%;
-	}
-
-	.text {
-		min-width: 90%;
-		max-width: 100%;
-		float: left;		
-	}
-
-	@include respond-to(small) {
-		.buttons {
-			float: left;
-			width: 100%;
-			text-align: center;
-			margin-top: 5px;
-		}
+	.middle {
+		text-align: center;
+		width: 100%;		
 	}
 
 	a {
 		color: white;
 		font-size: 0.8em;
-		margin-right: 5px;
+		margin: 5px;
 		cursor: pointer;	
 		white-space: nowrap;
 

--- a/scss/components/_cookie.scss
+++ b/scss/components/_cookie.scss
@@ -1,0 +1,50 @@
+.cookie-consent {	
+	position: fixed;
+	bottom: 0;
+	left: 0;
+	width: 100%;
+	background: black;
+	color: white;
+	min-height: 40px;
+	vertical-align: middle;
+	padding: 20px 20px;
+
+	.buttons {
+		float: right;
+		width: 10%;
+	}
+
+	.text {
+		min-width: 90%;
+		max-width: 100%;
+		float: left;		
+	}
+
+	@include respond-to(small) {
+		.buttons {
+			float: left;
+			width: 100%;
+			text-align: center;
+			margin-top: 5px;
+		}
+	}
+
+	a {
+		color: white;
+		font-size: 0.8em;
+		margin-right: 5px;
+		cursor: pointer;	
+		white-space: nowrap;
+
+		&.accept {
+			background-color: $totem-pole;
+			border: 1px solid $totem-pole;
+			border-radius: 4px;
+			padding: 4px;
+		}
+
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+}

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -16,6 +16,7 @@
 @import 'components/box';
 @import 'components/roundbox';
 @import 'components/toc';
+@import 'components/cookie';
 
 @import 'pages/chart';
 @import 'pages/compatibility';

--- a/templates/components/cookie.tpl
+++ b/templates/components/cookie.tpl
@@ -1,7 +1,7 @@
 <div class="cookie-consent">
 	<div class="middle">
-	 <span class="text">We use cookies to enhance content and analyze information on site performance and usage.</span>
-	 <span class="buttons"><a class="accept" onclick="cookie_consent(true)">Allow Cookies</a><a onclick="cookie_consent(false)">Refuse Cookies</a></span>
+	 <span class="text">{#cookieText#}</span>
+	 <span class="buttons"><a class="accept" onclick="cookie_consent(true)">{#cookieAccept#}</a><a onclick="cookie_consent(false)">{#cookieDecline#}</a></span>
 	</div>
 </div>
 

--- a/templates/components/cookie.tpl
+++ b/templates/components/cookie.tpl
@@ -1,15 +1,13 @@
 <div class="cookie-consent">
-   <div class="text">This website uses third-party cookies to collect traffic information. By continuing to use the site you are providing consent to do so.</div>
-   <div class="buttons"><a onclick="cookie_consent(false)">Decline</a><a class="accept" onclick="cookie_consent(true)">Got it!</a></div>   
+	<div class="middle">
+	 <span class="text">We use cookies to enhance content and analyze information on site performance and usage.</span>
+	 <span class="buttons"><a class="accept" onclick="cookie_consent(true)">Allow Cookies</a><a onclick="cookie_consent(false)">Refuse Cookies</a></span>
+	</div>
 </div>
 
 <script>
-	if (window.localStorage.getItem('COOKIE_CONSENT')) {
-			document.querySelector('.cookie-consent').hidden = true;
-		}
-
 	function cookie_consent(allowCookies) {
-		window.localStorage.setItem('COOKIE_CONSENT', allowCookies)
-		document.querySelector('.cookie-consent').hidden = true;
+		document.cookie = "cookie_consent=" + allowCookies + "; expires=Fri, 31 Dec 9999 23:59:59 GMT";
+		document.querySelector('.cookie-consent').style.display = "none";
 	}
 </script>

--- a/templates/pages/index.tpl
+++ b/templates/pages/index.tpl
@@ -87,7 +87,10 @@
 	<script type="text/javascript">
 		_uacct = "UA-1455743-1";
 		_udn = "scummvm.org";
-		urchinTracker();
+
+		if (window.localStorage.getItem('COOKIE_CONSENT') == 'true') {
+			urchinTracker();
+		}		
 	</script>
 {* End Google analytics javascript. *}
 	<script>
@@ -98,5 +101,8 @@
 				document.body.classList.remove('no-scroll');
 		});
 	</script>
+
+
+{include file='components/cookie.tpl'}
 </body>
 </html>

--- a/templates/pages/index.tpl
+++ b/templates/pages/index.tpl
@@ -82,17 +82,7 @@
 {foreach from=$js_files item=script}
 	<script src="/javascripts/{$script}"></script>
 {/foreach}
-{* Google analytics javascript. *}
-	<script src="https://www.google-analytics.com/urchin.js" type="text/javascript"></script>
-	<script type="text/javascript">
-		_uacct = "UA-1455743-1";
-		_udn = "scummvm.org";
 
-		if (window.localStorage.getItem('COOKIE_CONSENT') == 'true') {
-			urchinTracker();
-		}		
-	</script>
-{* End Google analytics javascript. *}
 	<script>
 		document.querySelector('.nav-trigger').addEventListener('change', function() {
 			if (this.checked)
@@ -101,8 +91,19 @@
 				document.body.classList.remove('no-scroll');
 		});
 	</script>
-
-
-{include file='components/cookie.tpl'}
-</body>
+	{if $smarty.cookies.cookie_consent == "true"}
+		{* Google analytics javascript. *}
+			<script src="https://www.google-analytics.com/urchin.js" type="text/javascript"></script>
+			<script type="text/javascript">
+				_uacct = "UA-1455743-1";
+				_udn = "scummvm.org";		
+				urchinTracker();				
+			</script>
+		{* End Google analytics javascript. *}
+	{else if $smarty.cookies.cookie_consent == "false"}
+		{* Do nothing *}
+	{else}
+		{include file='components/cookie.tpl'}	
+	{/if}
+	</body>
 </html>


### PR DESCRIPTION
To comply with EU regulations, we must ask customers if they're willing to let us use tracking cookies. This PR adds a floating form on the bottom that requires the user to consent to in order to enable google analytics.  

There doesn't seem to be a way to use GA without it storing a cookie, so if the user doesn't provide consent, the script never even loads.

This addresses #89 

![image](https://user-images.githubusercontent.com/803371/44497671-b5a2c680-a648-11e8-8665-d7abf8027f38.png)
