### PR TITLE
WEB: Remove the reference to Debian unstable; use generic wording instead

### DIFF
--- a/lang/i18n/lang.en.json
+++ b/lang/i18n/lang.en.json
@@ -75,7 +75,7 @@
     "downloadsBinaries": "{release} Release binaries",
     "downloadsBinariesNote1": "For a list of changes since the previous version,",
     "downloadsBinariesNote2": "read the release notes",
-    "downloadsBinariesNote3": "{release_debian} is also apt-get'able from Debian unstable (sid).",
+    "downloadsBinariesNote3": "ScummVM {release} is also available in the software repositories of many GNU/Linux distributions.",
     "downloadsSourceCode": "{release} Source Code",
     "downloadsTools": "{release_tools} Tools",
     "downloadsOldBinaries": "Older versions (unsupported)",


### PR DESCRIPTION
Since current versions of ScummVM are not only available in Debian sid, but also in many more bleeding edge Linux distributions like Arch, Manjaro, Fedora, openSUSE Tumbleweed, current Ubuntu and many more, I propose to remove the reference to Debian sid on the download page and use a more generic wording instead:

"ScummVM {release} is also available in the software repositories of many GNU/Linux distributions."

Please let me hear your thoughts.