### PR TITLE
WEB: Add redirect for unknown game reports

### DIFF
--- a/index.php
+++ b/index.php
@@ -102,6 +102,11 @@ $router = new \AltoRouter();
 // Custom match for Compatability ID.
 $router->addMatchTypes(array('cId' => '(DEV)|[0-9\.]++'));
 
+// Redirect for unknowgame
+$router->map('GET', '/unknowngame?[*:query]', function( $query ) {
+    require __DIR__ . '/unknowngame.php';
+});
+
 foreach ($pages as $key => $value) {
     $router->map('GET', $key, $value);
     $router->map('GET', $key . '/', $value);
@@ -109,8 +114,12 @@ foreach ($pages as $key => $value) {
 
 $match = $router->match();
 if ($match) {
+  if( is_array($match) && is_callable( $match['target'] ) ) {
+    call_user_func_array( $match['target'], $match['params'] );
+  } else {
     $page = new $match['target']();
     return $page->index($match['params']);
+  }
 } else {
   $page = new \ScummVM\Pages\NewsPage();
   return $page->index(array());

--- a/unknowngame.php
+++ b/unknowngame.php
@@ -1,0 +1,7 @@
+<?php
+    parse_str($_SERVER['QUERY_STRING'], $values);
+    # It is unlikely the engine name will be correct (e.g. missing capitalization) but
+    # try to use it nonetheless. The worst that can happen is that it will be ignored.
+    header("Location: https://bugs.scummvm.org/newticket?&type=enhancement&keywords=unknown-game&component=Engine:%20".$values['engine']."&description=".$values['description']);
+    exit();
+?>

--- a/unknowngame.php
+++ b/unknowngame.php
@@ -2,6 +2,6 @@
     parse_str($_SERVER['QUERY_STRING'], $values);
     # It is unlikely the engine name will be correct (e.g. missing capitalization) but
     # try to use it nonetheless. The worst that can happen is that it will be ignored.
-    header("Location: https://bugs.scummvm.org/newticket?&type=enhancement&keywords=unknown-game&component=Engine:%20".$values['engine']."&description=".$values['description']);
+    header("Location: https://bugs.scummvm.org/newticket?&type=enhancement&keywords=unknown-game&component=Engine:%20".urlencode($values['engine'])."&description=".urlencode($values['description']));
     exit();
 ?>


### PR DESCRIPTION
In the ScummVM unknown game dialog there is some code to have button that opens a new ticket on our bug tracker with pre-filled information to report an unknown game. Currently this code is disabled as it directly accesses bugs.scummvm.org and this was deemed not very robust against future change to our bug tracker. You can see the discussion regarding this in https://github.com/scummvm/scummvm/pull/1160

There is also a comment in the code (https://github.com/scummvm/scummvm/blob/master/gui/unknown-game-dialog.cpp#L57) about it.

The idea here is to have the dialog generate a request in the form of `https://www.scummvm.org/unknowngame?engine=foo&description=bar` and our web site redirects this to our bug tracker with the proper query reformatting. If we make some changes to our bug tracker, we can at the same time update the redirect so that reporting unknown games in old ScummVM version will still properly work.

Note: To alley some fears, I should point out that reporting a game in this way will not automatically create a new ticket. This will open a form for a new ticket, with some field pre filled, but the user still has to validate it. Also the user will need to have an account and be logged in on bugs.scummvm.org.

I am really not familiar with web development in general and php in particular. So it is possible (and even likely) that this could be done in a cleaner, safer, and better way. So don't hesitate to comment on that.

If we decide to accept this PR, the next step will be to update the unknown game dialog to use this.