### PR TITLE
DOC: Adding prerequisite to install PHP and PECL

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ The ScummVM website relies on several tools to install properly.
 Before installing please make sure you have the following installed:
 
 * [PHP](https://www.php.net/manual/en/install.php)
-  - After installing, run `pecl install yaml` to install the PHP YAML extension
-  - The version of PHP included with macOS doesn't include PECL, so you'll need to install a different version of PHP [through Homebrew](https://formulae.brew.sh/formula/php) or another method
+  * After installing, run `pecl install yaml` to install the PHP YAML extension
+  * The version of PHP included with macOS doesn't include PECL, so you'll need to install a different version of PHP [through Homebrew](https://formulae.brew.sh/formula/php) or another method
 * [Composer](https://getcomposer.org/)
 * [Python & pip](https://www.python.org/) (2.7.9+/3.4+)
 * [Node.js & npm](https://nodejs.org/)

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ on how to deploy the project on a live system.
 The ScummVM website relies on several tools to install properly.
 Before installing please make sure you have the following installed:
 
-* [PHP](https://www.php.net/manual/en/install.php)
-  * After installing, run `pecl install yaml` to install the PHP YAML extension
-  * The version of PHP included with macOS doesn't include PECL, so you'll need to install a different version of PHP [through Homebrew](https://formulae.brew.sh/formula/php) or another method
-* [Composer](https://getcomposer.org/)
-* [Python & pip](https://www.python.org/) (2.7.9+/3.4+)
-* [Node.js & npm](https://nodejs.org/)
-* [Git](https://git-scm.com/)
-* [Glue](https://glue.readthedocs.io/en/latest/installation.html)
+  * [PHP](https://www.php.net/manual/en/install.php)
+    * After installing, run `pecl install yaml` to install the PHP YAML extension
+    * The version of PHP included with macOS doesn't include PECL, so you'll need to install a different version of PHP [through Homebrew](https://formulae.brew.sh/formula/php) or another method
+  * [Composer](https://getcomposer.org/)
+  * [Python & pip](https://www.python.org/) (2.7.9+/3.4+)
+  * [Node.js & npm](https://nodejs.org/)
+  * [Git](https://git-scm.com/)
+  * [Glue](https://glue.readthedocs.io/en/latest/installation.html)
 
 ### Installing
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ on how to deploy the project on a live system.
 The ScummVM website relies on several tools to install properly.
 Before installing please make sure you have the following installed:
 
+* [PHP](https://www.php.net/manual/en/install.php)
+  * After installing, run `pecl install yaml` to install the PHP YAML extension
+  * The version of PHP included with macOS doesn't include PECL, so you'll need to install a different version of PHP [through Homebrew](https://formulae.brew.sh/formula/php) or another method
 * [Composer](https://getcomposer.org/)
 * [Python & pip](https://www.python.org/) (2.7.9+/3.4+)
 * [Node.js & npm](https://nodejs.org/)

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ on how to deploy the project on a live system.
 The ScummVM website relies on several tools to install properly.
 Before installing please make sure you have the following installed:
 
-  * [PHP](https://www.php.net/manual/en/install.php)
-    * After installing, run `pecl install yaml` to install the PHP YAML extension
-    * The version of PHP included with macOS doesn't include PECL, so you'll need to install a different version of PHP [through Homebrew](https://formulae.brew.sh/formula/php) or another method
-  * [Composer](https://getcomposer.org/)
-  * [Python & pip](https://www.python.org/) (2.7.9+/3.4+)
-  * [Node.js & npm](https://nodejs.org/)
-  * [Git](https://git-scm.com/)
-  * [Glue](https://glue.readthedocs.io/en/latest/installation.html)
+* [PHP](https://www.php.net/manual/en/install.php)
+  - After installing, run `pecl install yaml` to install the PHP YAML extension
+  - The version of PHP included with macOS doesn't include PECL, so you'll need to install a different version of PHP [through Homebrew](https://formulae.brew.sh/formula/php) or another method
+* [Composer](https://getcomposer.org/)
+* [Python & pip](https://www.python.org/) (2.7.9+/3.4+)
+* [Node.js & npm](https://nodejs.org/)
+* [Git](https://git-scm.com/)
+* [Glue](https://glue.readthedocs.io/en/latest/installation.html)
 
 ### Installing
 


### PR DESCRIPTION
Thanks to the help of @SupSuper, @lotharsm, and @criezy on Discord, I was able to figure out how to get past an issue I was having with YAML pages like `/credits` not showing up correctly. I've added instructions to README.md so that others can avoid the same issues.

Includes a description of why the Apple-supplied version of PHP won't work, which is an issue that I ran into.