### PR TITLE
BUILD: Standardizing the variable names for parsing data

### DIFF
--- a/include/Models/ArticleModel.php
+++ b/include/Models/ArticleModel.php
@@ -14,9 +14,9 @@ abstract class ArticleModel extends BasicModel
     {
         $fname = DIR_DATA . '/press_articles.xml';
         $parser = new XMLParser();
-        $a = $parser->parseByFilename($fname);
+        $parsedData = $parser->parseByFilename($fname);
         $entries = array();
-        foreach ($a['articles']['article'] as $key => $value) {
+        foreach (array_values($parsedData['articles']['article']) as $value) {
             $entries[] = new Article(
                 array(
                 'name' => $value['name'],

--- a/include/Models/CompatibilityModel.php
+++ b/include/Models/CompatibilityModel.php
@@ -25,9 +25,9 @@ abstract class CompatibilityModel extends BasicModel
             throw new \ErrorException(self::NO_FILES);
         }
         $parser = new XMLParser();
-        $a = $parser->parseByFilename($fname);
+        $parsedData = $parser->parseByFilename($fname);
         $entries = array();
-        foreach ($a['compatibility']['company'] as $key => $value) {
+        foreach (array_values($parsedData['compatibility']['company']) as $value) {
             $games = array();
             if (is_array($value['games'])) {
                 foreach ($value['games']['game'] as $data) {

--- a/include/Models/CreditsModel.php
+++ b/include/Models/CreditsModel.php
@@ -12,8 +12,8 @@ abstract class CreditsModel extends BasicModel
     public static function getAllCredits()
     {
         $fname = DIR_DATA . '/credits.yaml';
-        $credits = \yaml_parse_file($fname);
-        foreach ($credits['credits']['section'] as $key => $value) {
+        $parsedData = \yaml_parse_file($fname);
+        foreach (array_values($parsedData['credits']['section']) as $value) {
             $sections[] = new CreditsSection($value);
         }
         return $sections;

--- a/include/Models/DocumentationModel.php
+++ b/include/Models/DocumentationModel.php
@@ -14,9 +14,9 @@ abstract class DocumentationModel extends BasicModel
     {
         $fname = DIR_DATA . '/documentation.xml';
         $parser = new XMLParser();
-        $a = $parser->parseByFilename($fname);
+        $parsedData = $parser->parseByFilename($fname);
         $entries = array();
-        foreach ($a['documentation']['document'] as $key => $value) {
+        foreach (array_values($parsedData['documentation']['document']) as $value) {
             $entries[] = new Document($value);
         }
         return $entries;

--- a/include/Models/DownloadsModel.php
+++ b/include/Models/DownloadsModel.php
@@ -16,9 +16,9 @@ abstract class DownloadsModel
         $fname = DIR_DATA . '/downloads.xml';
         /* Now parse the data. */
         $parser = new XMLParser();
-        $a = $parser->parseByFilename($fname);
+        $parsedData = $parser->parseByFilename($fname);
         $sections = array();
-        foreach ($a['downloads']['section'] as $key => $value) {
+        foreach (array_values($parsedData['downloads']['section']) as $value) {
             $sections[] = new DownloadsSection($value);
         }
         return $sections;

--- a/include/Models/FAQModel.php
+++ b/include/Models/FAQModel.php
@@ -88,7 +88,7 @@ abstract class FAQModel extends BasicModel
 
         /* Now parse the data. */
         $parser = new XMLParser();
-        $a = $parser->parseByData($data);
+        $parsedData = $parser->parseByData($data);
         $sections = array();
         /**
          * Build a map of the defined hrefs so we can give the xrefs the correct
@@ -96,7 +96,7 @@ abstract class FAQModel extends BasicModel
          */
         $xref = array();
         $count = 1;
-        foreach ($a['faq']['section'] as $data) {
+        foreach (array_values($parsedData['faq']['section']) as $data) {
             $sections[] = new FaqSection($data, $count++, $xref);
         }
         return $sections;

--- a/include/Models/GameDemosModel.php
+++ b/include/Models/GameDemosModel.php
@@ -12,9 +12,9 @@ abstract class GameDemosModel extends BasicModel
     public static function getAllGroupsAndDemos()
     {
         $fname = DIR_DATA . '/game_demos.yaml';
-        $gameDemos = \yaml_parse_file($fname);
+        $parsedData = \yaml_parse_file($fname);
         $entries = array();
-        foreach (array_values($gameDemos['game_demos']['group']) as $value) {
+        foreach (array_values($parsedData['game_demos']['group']) as $value) {
             $demos = array();
             foreach ($value['demos'] as $data) {
                 $demos[] = new GameDemo($data);

--- a/include/Models/GamesModel.php
+++ b/include/Models/GamesModel.php
@@ -15,9 +15,9 @@ abstract class GamesModel
         $fname = DIR_DATA . '/games.xml';
         /* Now parse the data. */
         $parser = new XMLParser();
-        $a = $parser->parseByFilename($fname);
+        $parsedData = $parser->parseByFilename($fname);
         $sections = array();
-        foreach ($a['downloads']['section'] as $key => $value) {
+        foreach (array_values($parsedData['downloads']['section']) as $value) {
             $sections[] = new DownloadsSection($value);
         }
         return $sections;

--- a/include/Models/LinksModel.php
+++ b/include/Models/LinksModel.php
@@ -15,9 +15,9 @@ abstract class LinksModel extends BasicModel
     {
         $fname = DIR_DATA . '/links.xml';
         $parser = new XMLParser();
-        $a = $parser->parseByFilename($fname);
+        $parsedData = $parser->parseByFilename($fname);
         $entries = array();
-        foreach ($a['external_links']['group'] as $key => $value) {
+        foreach (array_values($parsedData['external_links']['group']) as $value) {
             /* Get all links. */
             $links = array();
             foreach ($value['link'] as $data) {

--- a/include/Models/MenuModel.php
+++ b/include/Models/MenuModel.php
@@ -14,9 +14,9 @@ abstract class MenuModel extends BasicModel
     {
         $fname = DIR_DATA . '/menus.xml';
         $parser = new XMLParser();
-        $a = $parser->parseByFilename($fname);
+        $parsedData = $parser->parseByFilename($fname);
         $entries = array();
-        foreach ($a['menus']['group'] as $key => $value) {
+        foreach (array_values($parsedData['menus']['group']) as $value) {
             $entries[] = new MenuItem(
                 array(
                 'name' => $value['name'],

--- a/include/Models/ScreenshotsModel.php
+++ b/include/Models/ScreenshotsModel.php
@@ -18,10 +18,10 @@ abstract class ScreenshotsModel extends BasicModel
     {
         $fname = DIR_DATA . '/screenshots.xml';
         $parser = new XMLParser();
-        $a = $parser->parseByFilename($fname);
+        $parsedData = $parser->parseByFilename($fname);
         $entries = array();
-        BasicObject::toArray($a['screenshots']['group']);
-        foreach ($a['screenshots']['group'] as $value) {
+        BasicObject::toArray($parsedData['screenshots']['group']);
+        foreach (array_values($parsedData['screenshots']['group']) as $value) {
             BasicObject::toArray($value['game']);
             $games = array();
             foreach ($value['game'] as $data) {

--- a/include/Models/SubprojectsModel.php
+++ b/include/Models/SubprojectsModel.php
@@ -16,10 +16,10 @@ abstract class SubprojectsModel extends BasicModel
     {
         $fname = DIR_DATA . '/subprojects.xml';
         $parser = new XMLParser();
-        $a = $parser->parseByFilename($fname);
+        $parsedData = $parser->parseByFilename($fname);
         $entries = array();
-        BasicObject::toArray($a['subprojects']['project']);
-        foreach ($a['subprojects']['project'] as $key => $value) {
+        BasicObject::toArray($parsedData['subprojects']['project']);
+        foreach ($parsedData['subprojects']['project'] as $key => $value) {
             $downloads = array();
             foreach ($value['entries'] as $type => $data) {
                 if ($type == 'file') {


### PR DESCRIPTION
Fixes the following [Codacy issues](https://app.codacy.com/manual/sev-/scummvm-web/issues):

* Avoid variables with short names like `$a`. Configured minimum length is 3.
* Avoid unused local variables such as '$key'.