### PR TITLE
Changing table hyperlinks from black to default color

### DIFF
--- a/scss/theme/_themes.scss
+++ b/scss/theme/_themes.scss
@@ -38,7 +38,6 @@ $themes: (
         chart-row-even: $white,
         chart-caption-background: $totem-pole,
         chart-caption-header: $white,
-        chart-link: $black,
         chart-border: $silver,
         // Misc elements
         table-of-contents: $japanese-laurel,


### PR DESCRIPTION
This makes hyperlinks consistent with other pages, including ones with lots of links such as the Downloads page

## Before

<img width="1058" alt="Clickable Compatibility Table" src="https://user-images.githubusercontent.com/6200170/130719698-bc3327c4-f77f-433e-94a9-384e36ca37f3.png">
<img width="339" alt="Clickable Game" src="https://user-images.githubusercontent.com/6200170/130719915-38df12d6-4678-44ad-bb59-006f83f0a16c.png">
<img width="1064" alt="Clickable Demo" src="https://user-images.githubusercontent.com/6200170/130719926-6e42fb48-d26b-4648-8e5d-7dc490c4df9a.png">

## After

<img width="1063" alt="image" src="https://user-images.githubusercontent.com/6200170/130719988-378955bd-7faf-4e1a-99cd-c810737c11f7.png">
<img width="329" alt="image" src="https://user-images.githubusercontent.com/6200170/130720019-33a16461-fa41-495f-904d-d7d2caef4963.png">
<img width="1067" alt="image" src="https://user-images.githubusercontent.com/6200170/130720034-7dca2b6b-03f3-4a85-af83-f459fc88d453.png">

The concern was raised in Discord that there was too much red now on the tables. For comparison, we already have a similar amount of red on the downloads page, so this change is consistent with the rest of the site.

<img width="504" alt="image" src="https://user-images.githubusercontent.com/6200170/130720248-14976cac-7db4-4778-9f04-06511b07d7d2.png">

Since the amount of red on that page is considered acceptable, I do not think that this is too much here either, and it helps with website consistency. Plus, red hyperlinks means the clickable words can now be easily distinguished from the unclickable words.