### PR TITLE
WEB: Updating link to FAAD2

### DIFF
--- a/data/en/scummvm_downloads.yaml
+++ b/data/en/scummvm_downloads.yaml
@@ -1472,7 +1472,7 @@
     subcategory: optional
     category_icon: ''
     user_agent: ''
-    url: 'http://www.audiocoding.com/faad2.html'
+    url: 'https://github.com/knik0/faad2'
     name: FAAD2
     description: 'MPEG-4 and MPEG-2 AAC Decoder'
 -


### PR DESCRIPTION
The old website no longer exists. See https://www.videoproc.com/resource/what-happened-to-audiocoding.htm