### PR TITLE
WEB: Add a Wikipedia link for games

### DIFF
--- a/include/OrmObjects/Compatibility.php
+++ b/include/OrmObjects/Compatibility.php
@@ -54,6 +54,9 @@ class Compatibility extends BaseCompatibility
         if ($this->getGame()->getDataFiles()) {
             $links[] = "- [ScummVM Wiki]({$this->getGame()->getDataFiles()})";
         }
+        if ($this->getGame()->getWikipediaPage()) {
+            $links[] = "- [Wikipedia](https://en.wikipedia.org/wiki/{$this->getGame()->getWikipediaPage()})";
+        }
         if ($links) {
             $notes .= "\n\n**Links:**\n";
             $notes .= join("\n", $links);

--- a/include/OrmObjects/Compatibility.php
+++ b/include/OrmObjects/Compatibility.php
@@ -54,8 +54,15 @@ class Compatibility extends BaseCompatibility
         if ($this->getGame()->getDataFiles()) {
             $links[] = "- [ScummVM Wiki]({$this->getGame()->getDataFiles()})";
         }
-        if ($this->getGame()->getWikipediaPage()) {
+        $wikipediaPage = $this->getGame()->getWikipediaPage();
+        if ($wikipediaPage) {
+          // If we have a full URL, such as for a non-English Wikipedia page, use that
+          // Otherwise, assume it's a page for English Wikipedia
+          if (str_starts_with($wikipediaPage, "https://")) {
+            $links[] = "- [Wikipedia]({$this->getGame()->getWikipediaPage()})";
+          } else {
             $links[] = "- [Wikipedia](https://en.wikipedia.org/wiki/{$this->getGame()->getWikipediaPage()})";
+          }
         }
         if ($links) {
             $notes .= "\n\n**Links:**\n";

--- a/schema.xml
+++ b/schema.xml
@@ -10,6 +10,7 @@
     <column name="engine_id" type="varchar" size="24" required="true"/>
     <column name="company_id" type="varchar" size="24" required="true"/>
     <column name="moby_id" type="integer"/>
+    <column name="wikipedia_page" type="varchar"/>
     <column name="series_id" type="varchar"/>
     <foreign-key foreignTable="engine" onDelete="CASCADE">
       <reference local="engine_id" foreign="id"/>


### PR DESCRIPTION
Add a new field to the game table called `wikipedia_page`, which is the URL page title for the game's corresponding page on English Wikipedia.

The field has been filed out for a few games (such as *Martian Memorandum* and *Manhunter: New York*), but more will need to be filled out.

<img width="473" alt="image" src="https://user-images.githubusercontent.com/6200170/131601902-45382aad-4b94-4d12-9122-054f9414308a.png">
