### PR TITLE
WEB: Fixing issue redirecting games with hyphens

### DIFF
--- a/public_html/index.php
+++ b/public_html/index.php
@@ -102,7 +102,7 @@ set_exception_handler(array('ScummVM\ExceptionHandler', 'handleException'));
 $pages = array(
     'compatibility'                         => '\ScummVM\Pages\CompatibilityPage',
     'compatibility/[cId:version]'           => '\ScummVM\Pages\CompatibilityPage',
-    'compatibility/[cId:version]/[a:game]'  => '\ScummVM\Pages\CompatibilityPage',
+    'compatibility/[cId:version]/[:game]'   => '\ScummVM\Pages\CompatibilityPage',
     'contact'                               => '\ScummVM\Pages\SimplePage',
     'credits'                               => '\ScummVM\Pages\SimplePage',
     'demos'                                 => '\ScummVM\Pages\DemosPage',


### PR DESCRIPTION
Fixing an issue that prevented loading the compatibility page for games with hyphens in their short name, such as `private-eye` and `agi-fanmade`. Previously, attempting to go to the link for such a page would result in redirecting to the index page. Now the page is properly loaded.
