### PR TITLE
WEB: Changing "Daily Snapshots" link to "Daily Builds"

### DIFF
--- a/data/en/strings.json
+++ b/data/en/strings.json
@@ -165,7 +165,7 @@
   "menuDevelopmentBugTracker": "Bug Tracker",
   "menuDevelopmentPatchTracker": "Patch Tracker",
   "menuDevelopmentTranslations": "Translate ScummVM",
-  "menuDevelopmentDailies": "Daily Snapshots",
+  "menuDevelopmentDailies": "Daily Builds",
   "menuDevelopmentSourceCode": "Source Code Tree",
   "menuDevelopmentBuildbot": "Buildbot",
   "menuDevelopmentDoxygen": "API Reference",


### PR DESCRIPTION
The URL goes to [a section](https://www.scummvm.org/downloads/#daily) that has "Daily Builds" as its header, so the link name should be consistent.

## Before

<img width="180" alt="image" src="https://user-images.githubusercontent.com/6200170/134110818-6e7416e5-9a19-4ecd-bc80-ff5ae9492704.png">

## After

<img width="191" alt="image" src="https://user-images.githubusercontent.com/6200170/134110779-22daa862-ab57-465a-beeb-eab782ee4437.png">
