### PR TITLE
DATA: Removing other game engines from links

### DIFF
--- a/data/en/links.yaml
+++ b/data/en/links.yaml
@@ -80,39 +80,6 @@
         The personal blog of Ron Gilbert, the man behind many great LucasArts
         adventures, like Maniac Mansion and Monkey Island.
       url: 'https://grumpygamer.com/'
-- name: Other classic game engine open source projects
-  description: >-
-    The following are links to other classic game engine open source projects
-    similar to ScummVM. Know any other classic game projects that should be
-    linked here? <a href="https://www.scummvm.org/contact/">Let us know!</a>
-  links:
-    - name: 'XU4 :: Ultima IV'
-      description: XU4 is the recreation of Ultima IV - Quest of the Avatar.
-      url: 'http://xu4.sourceforge.net/'
-    - name: 'Nuvie :: Ultima VI'
-      description: >-
-        Nuvie, pronounced 'New-Vee' is an open sourced game engine for playing
-        Origin's games Ultima 6, Martian Dreams and Savage Empire on modern
-        operating systems.
-      url: 'http://nuvie.sourceforge.net/'
-    - name: 'Exult :: Ultima VII'
-      description: >-
-        Exult is the recreation of the Ultima VII engine used in <i>The Black
-        Gate</i> and <i>The Serpent Isle</i>
-      url: 'http://exult.sourceforge.net/'
-    - name: 'Pentagram :: Ultima VIII'
-      description: >-
-        Pentagram is a project aiming to create an Ultima 8 engine for use on
-        modern operating systems.
-      url: 'http://pentagram.sourceforge.net/'
-    - name: DOSBox
-      description: >-
-        DOSBox does not really quite fit in here since it emulates a classic
-        operating system (namely DOS) and even a PC to run it on; but since it
-        can be used to run many classic DOS games (at least if you are using a
-        sufficiently powerful desktop computer), we mention it here anyway. Plus
-        it's a cool project, too :).
-      url: 'https://www.dosbox.com/'
 - name: Technical information about SCUMM and other engines
   description: >-
     SCUMM is a complex system that grew over many years. Understanding it can be


### PR DESCRIPTION
All the Ultima engines have been merged with ScummVM. That leaves DOSBox, which has a description that says "DOSBox does not really quite fit in here", which means it's not really worth keeping.