### PR TITLE
WEB: install node modules from package-lock.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "build": [
       "composer install --no-dev",
       "@build-common",
-      "npm install --production"
+      "npm ci --production"
     ],
     "build-dev": [
       "composer install",


### PR DESCRIPTION
`npm ci` is used during producton installation to install
the packages from package-lock.json.

NPMs default is to install from package.json, updating the
package-lock.json in the process. This circumvents any pins in
package-lock.json and results in a git tree with an uncommitted change.