### PR TITLE
WEB: Removing file.getType() and related dead code

### DIFF
--- a/data/en/strings.json
+++ b/data/en/strings.json
@@ -125,7 +125,6 @@
   "linksContentTitle": "Links",
   "linksHeading": "Links",
   "linksIntro": "**Link to us:** If you want to link your site to us: please feel free to use this image.",
-  "listItemsBuildFromRepo": "build from repository,",
   "listItemsDate": ", last update:",
   "newsTitle": "Home",
   "newsContentTitle": "Latest Developments",

--- a/include/Objects/File.php
+++ b/include/Objects/File.php
@@ -8,7 +8,6 @@ class File extends BasicObject
 {
     private $category_icon;
     private $url;
-    private $type;
     private $extra_info;
     private $user_agent;
 
@@ -17,7 +16,6 @@ class File extends BasicObject
         parent::__construct($data);
         $this->category_icon = $data['category_icon'];
         $this->extra_info = $data['extra_info'] ?? null;
-        $this->type = strtolower($data['type'] ?? '');
         $this->user_agent = isset($data["user_agent"]) ? $data["user_agent"] : "";
 
         $fname = "";
@@ -34,14 +32,6 @@ class File extends BasicObject
         if (!preg_match('/^((https?)|(ftp)):\/\//', $url)) {
             if ($baseUrl !== null) {
                 $url = $baseUrl . $url;
-            } elseif ($attributes['type'] == 'downloads') {
-                $url = DIR_DOWNLOADS . "/{$url}";
-            } elseif ($attributes['type'] == 'tools') {
-                $url = DOWNLOADS_TOOLS_URL . $url;
-            } elseif ($attributes['type'] == 'extras') {
-                $url = DOWNLOADS_EXTRAS_URL . $url;
-            } elseif ($attributes['type'] == 'daily') {
-                $url = DOWNLOADS_DAILY_URL . $url;
             } else {
                 $url = DOWNLOADS_URL . $url;
             }
@@ -114,12 +104,6 @@ class File extends BasicObject
     public function getURL()
     {
         return $this->url;
-    }
-
-    /* Get the type. */
-    public function getType()
-    {
-        return $this->type;
     }
 
     /* Get the extra information. */

--- a/scss/pages/_downloads.scss
+++ b/scss/pages/_downloads.scss
@@ -14,12 +14,6 @@ ul.downloads {
 	}
 }
 
-span.daily_provider {
-	display: block;
-	font-size: 90%;
-	padding-left: 3em;
-}
-
 #downloadContainer {
 	position: relative;
 	width: 100%;

--- a/templates/components/list_items.tpl
+++ b/templates/components/list_items.tpl
@@ -10,26 +10,12 @@
                         <span class="download-extras">
                             {if is_array($data)}
                                 (
-                                {if $item->getType() == 'daily'}{#listItemsBuildFromRepo#} {/if}
                                 {$data.size} {if $data.ext == '.exe'}Win32 {/if}{$data.ext}{if $data.date != ""}{#listItemsDate#} {$data.date} {/if}
                                 &nbsp;
                                 {if $data.sha256 != ""} <span class="sha256-toggle" onclick="this.nextSibling.classList.toggle('hidden')"> sha256</span><span class="sha256-text hidden"> <a href="{{eval var=$item->getURL()}|release|download}.sha256">{$data.sha256}</a></span>{/if}
                                 ) {if $data.msg != ""}{$data.msg}{/if}
-                            {else}
-                                {if $item->getType() != 'daily'}
-                                    {eval var=$data|default:'&nbsp;'}
-                                {/if}
                             {/if}
                         </span>
-                        {if $item->getType() == 'daily'}
-                            <span class="daily_provider">
-                                {if is_array($data)}
-                                    {eval var=$data.info}
-                                {else}
-                                    {eval var=$data}
-                                {/if}
-                            </span>
-                        {/if}
                     {/strip}
                 </li>
             {elseif $item instanceof ScummVM\Objects\WebLink}


### PR DESCRIPTION
It appears that at one point the data spreadsheet included a `type` field. This is no longer the case and so all of this is not used, providing unnecessary confusion and maintenance.