### PR TITLE
DATA: Changing downloads table to use version column

### DIFF
--- a/include/Constants.php
+++ b/include/Constants.php
@@ -47,7 +47,7 @@ class Constants
 
         /* Downloads */
         define('DOWNLOADS_BASE', 'https://downloads.scummvm.org');
-        define('DOWNLOADS_URL', '/frs/scummvm/{$release}/');
+        define('DOWNLOADS_URL', '/frs/scummvm/{$version}/');
         define('DOWNLOADS_DAILY_URL', '/frs/daily/');
         define('DOWNLOADS_TOOLS_URL', '/frs/scummvm-tools/{$release_tools}/');
         define('DOWNLOADS_EXTRAS_URL', '/frs/extras/');

--- a/include/DataUtils.php
+++ b/include/DataUtils.php
@@ -31,7 +31,7 @@ class DataUtils
         'game_demos' => '713475305',
         'series' => '1095671818',
         'screenshots' => '1985243204',
-        'scummvm_downloads' => '373699606',
+        'scummvm_downloads' => '1057392663',
         'game_downloads' => '1287892109',
         'director_demos' => '1256563740',
     ];

--- a/include/Models/DownloadsModel.php
+++ b/include/Models/DownloadsModel.php
@@ -85,11 +85,15 @@ class DownloadsModel extends BasicModel
             ->setIgnoreCase(true)
             ->findByUserAgent($os['name']);
 
-        foreach ($downloads as $download) {
-            $url = str_replace('{$release}', RELEASE, $download->getURL());
-            sscanf($url, "/frs/scummvm/%s", $versionStr);
-            $version = substr($versionStr, 0, strpos($versionStr, "/"));
+        if (!empty($downloads)) {
+            $download = $downloads[0];
+
             $name = strip_tags($download->getName());
+            // Construct the URL and fill in the version
+            $url = DOWNLOADS_BASE . DOWNLOADS_URL . $download->getURL();
+            $version = $download->getVersion();
+            $url = str_replace('{$version}', $version, $url);
+
             $data = ""; //$download->getExtraInfo();
             if (is_array($data)) {
                 $extra_text = $data['size'] . " ";

--- a/include/Models/DownloadsModel.php
+++ b/include/Models/DownloadsModel.php
@@ -21,8 +21,29 @@ class DownloadsModel extends BasicModel
             $sections = [];
             $sectionsData = $this->getSectionData();
             foreach ($parsedData as $data) {
+                // Source and tools should be under the current section
+                // TODO Clean this up when we remove subcategories
+                if ($data->getVersion() == RELEASE) {
+                    $category = 'current';
+                    if ($data->getCategory() == 'source') {
+                        $subCategory = 'source';
+                    } else if ($data->getCategory() == 'tools') {
+                        $subCategory = 'tools';
+                    } else {
+                        $subCategory = 'release';
+                    }
+                } else if ($data->getVersion() == 'Daily') {
+                    $category = 'daily';
+                    $subCategory = 'daily_downloads';
+                } else if ($data->getVersion() == null) {
+                    $category = $data->getCategory();
+                    $subCategory = $data->getSubcategory();
+                } else {
+                    $category = 'legacy';
+                    $subCategory = 'old';
+                }
+
                 // Create Sections
-                $category = $data->getCategory();
                 if (!isset($sections[$category])) {
                     $sections[$category] = new DownloadsSection([
                         'anchor' => $category,
@@ -32,7 +53,6 @@ class DownloadsModel extends BasicModel
                 }
 
                 // Create Subsections
-                $subCategory = $data->getSubcategory();
                 if (!isset($sections[$category]->getSubSections()[$subCategory])) {
                     $sections[$category]->addSubsection(new DownloadsSection([
                         'anchor' => $subCategory,

--- a/include/Models/DownloadsModel.php
+++ b/include/Models/DownloadsModel.php
@@ -27,15 +27,15 @@ class DownloadsModel extends BasicModel
                     $category = 'current';
                     if ($data->getCategory() == 'source') {
                         $subCategory = 'source';
-                    } else if ($data->getCategory() == 'tools') {
+                    } elseif ($data->getCategory() == 'tools') {
                         $subCategory = 'tools';
                     } else {
                         $subCategory = 'release';
                     }
-                } else if ($data->getVersion() == 'Daily') {
+                } elseif ($data->getVersion() == 'Daily') {
                     $category = 'daily';
                     $subCategory = 'daily_downloads';
-                } else if ($data->getVersion() == null) {
+                } elseif ($data->getVersion() == null) {
                     $category = $data->getCategory();
                     $subCategory = $data->getSubcategory();
                 } else {

--- a/include/OrmObjects/Download.php
+++ b/include/OrmObjects/Download.php
@@ -15,5 +15,15 @@ use ScummVM\OrmObjects\Base\Download as BaseDownload;
  */
 class Download extends BaseDownload
 {
-
+    public function getName()
+    {
+        $name = parent::getName();
+        $version = $this->getVersion();
+        // If it's not the latest version, prefix with the version number
+        if ($version == RELEASE) {
+            return $name;
+        } else {
+            return "$version $name";
+        }
+    }
 }

--- a/include/OrmObjects/Download.php
+++ b/include/OrmObjects/Download.php
@@ -20,10 +20,9 @@ class Download extends BaseDownload
         $name = parent::getName();
         $version = $this->getVersion();
         // If it's not the latest version, prefix with the version number
-        if ($version == RELEASE) {
-            return $name;
-        } else {
+        if ($version != RELEASE) {
             return "$version $name";
         }
+        return $name;
     }
 }

--- a/schema.xml
+++ b/schema.xml
@@ -110,6 +110,7 @@
     <column name="enabled" type="boolean" />
     <column name="user_agent" type="varchar" size="255"/>
     <column name="url" type="varchar" size="255" required="true"/>
+    <column name="version" type="varchar" size="24" required="false"/>
   </table>
   <table name="game_downloads" phpName="GameDownload">
     <column name="category" type="varchar" size="24" required="true"/>


### PR DESCRIPTION
In order to simplify the process of updating version downloads, [downloads spreadsheet table](https://docs.google.com/spreadsheets/d/1QzwFleEKXOsE59cYMOcQB7C2f0Np48uAQOCG8kicX_s/edit#gid=1057392663) now includes a `version` column and the `url` field is much simpler. In order to update a new version, simply change the value in the `version` field.

Further improvements can be made, but for now this is an improvement that keeps parity with the previous code.

----

When this code gets merged, the following steps should be taken on the spreadsheet:

1. Delete the old `scummvm_downloads` table
2. Rename `Thunderforge_wip_scummvm_downloads` to `scummvm_downloads`

Because the code references sheet ids and not tab names, no further action needs to be taken.