### PR TITLE
WEB: Replacing {$version} in file name

### DIFF
--- a/include/OrmObjects/Download.php
+++ b/include/OrmObjects/Download.php
@@ -21,7 +21,7 @@ class Download extends BaseDownload
         $version = $this->getVersion();
         // If it's not the latest version, prefix with the version number
         if ($version != RELEASE) {
-            return "$version $name";
+            return str_replace('{$version}', $version, "$version $name");
         }
         return $name;
     }


### PR DESCRIPTION
Makes this appear properly

```
IRIX (6.5.{$version}, n32, mips3) package
IRIX (6.5.{$version}, n32, mips4) package
```

## Before

<img width="941" alt="image" src="https://user-images.githubusercontent.com/6200170/142509831-4b102191-095c-4ff9-8b15-366ec79df96a.png">

## After

<img width="565" alt="image" src="https://user-images.githubusercontent.com/6200170/142509926-42ba7593-acd4-47fd-9034-832e71236cd3.png">
