### PR TITLE
WEB: Renaming "Patch Tracker" to "Pull Requests"

### DIFF
--- a/data/de/strings.json
+++ b/data/de/strings.json
@@ -141,7 +141,7 @@
     "menuMiscCredits": "Mitwirkende",
     "menuHeaderDevelopmentDevelopment": "Entwicklung",
     "menuDevelopmentBugTracker": "Fehlerberichte",
-    "menuDevelopmentPatchTracker": "Code beitragen",
+    "menuDevelopmentPullRequests": "",
     "menuDevelopmentTranslations": "ScummVM übersetzen",
     "menuDevelopmentDailies": "Entwickler-Versionen",
     "menuDevelopmentSourceCode": "Quellcode-Verzeichnis",

--- a/data/el/strings.json
+++ b/data/el/strings.json
@@ -148,7 +148,7 @@
     "menuMiscCredits": "Συντελεστές",
     "menuHeaderDevelopmentDevelopment": "Ανάπτυξη",
     "menuDevelopmentBugTracker": "Αναφορές Προβλημάτων",
-    "menuDevelopmentPatchTracker": "Αιτήματα Συγχώνευσης Κώδικα",
+    "menuDevelopmentPullRequests": "",
     "menuDevelopmentTranslations": "Μετάφραση του ScummVM",
     "menuDevelopmentDailies": "Ημερήσιες Εκδόσεις",
     "menuDevelopmentSourceCode": "Δένδρο Πηγαίου Κώδικα",

--- a/data/en/menus.yaml
+++ b/data/en/menus.yaml
@@ -31,7 +31,7 @@
       href: 'https://wiki.scummvm.org/index.php?title=Developer_Central'
     - name: '{#menuDevelopmentBugTracker#}'
       href: 'https://bugs.scummvm.org/'
-    - name: '{#menuDevelopmentPatchTracker#}'
+    - name: '{#menuDevelopmentPullRequests#}'
       href: 'https://github.com/scummvm/scummvm/pulls'
     - name: '{#menuDevelopmentTranslations#}'
       href: 'https://translations.scummvm.org/projects/scummvm/scummvm/'

--- a/data/en/strings.json
+++ b/data/en/strings.json
@@ -162,7 +162,7 @@
   "menuMiscCredits": "Credits",
   "menuHeaderDevelopmentDevelopment": "Development",
   "menuDevelopmentBugTracker": "Bug Tracker",
-  "menuDevelopmentPatchTracker": "Patch Tracker",
+  "menuDevelopmentPullRequests": "Pull Requests",
   "menuDevelopmentTranslations": "Translate ScummVM",
   "menuDevelopmentDailies": "Daily Builds",
   "menuDevelopmentSourceCode": "Source Code Tree",

--- a/data/es/strings.json
+++ b/data/es/strings.json
@@ -146,7 +146,7 @@
     "menuMiscCredits": "Créditos",
     "menuHeaderDevelopmentDevelopment": "Desarrollo",
     "menuDevelopmentBugTracker": "Gestor de fallos",
-    "menuDevelopmentPatchTracker": "Gestor de parches",
+    "menuDevelopmentPullRequests": "",
     "menuDevelopmentTranslations": "Traducir ScummVM",
     "menuDevelopmentDailies": "Compilaciones diarias",
     "menuDevelopmentSourceCode": "Código fuente",

--- a/data/fi/strings.json
+++ b/data/fi/strings.json
@@ -164,7 +164,7 @@
     "menuMiscCredits": "Tunnustuksellisuudet",
     "menuHeaderDevelopmentDevelopment": "Kehitystyö",
     "menuDevelopmentBugTracker": "Virheenseuranta",
-    "menuDevelopmentPatchTracker": "Paikkausten seuranta",
+    "menuDevelopmentPullRequests": "",
     "menuDevelopmentTranslations": "Suomenna ScummVM",
     "menuDevelopmentDailies": "Päivittäiset kokoomat",
     "menuDevelopmentSourceCode": "Lähdekoodipuu",

--- a/data/fr/strings.json
+++ b/data/fr/strings.json
@@ -143,7 +143,7 @@
     "menuMiscCredits": "Crédits",
     "menuHeaderDevelopmentDevelopment": "Développement",
     "menuDevelopmentBugTracker": "Base de Bogue",
-    "menuDevelopmentPatchTracker": "Base de Patches",
+    "menuDevelopmentPullRequests": "",
     "menuDevelopmentTranslations": "Traduire ScummVM",
     "menuDevelopmentDailies": "Compilations quotidiennes",
     "menuDevelopmentSourceCode": "Code source",

--- a/data/he/strings.json
+++ b/data/he/strings.json
@@ -148,7 +148,7 @@
   "menuMiscCredits": "נקודות זכות",
   "menuHeaderDevelopmentDevelopment": "התפתחות",
   "menuDevelopmentBugTracker": "מעקב באגים",
-  "menuDevelopmentPatchTracker": "מעקב אחר טלאים",
+  "menuDevelopmentPullRequests": "",
   "menuDevelopmentTranslations": "תרגם ScummVM",
   "menuDevelopmentDailies": "תמונות יומי",
   "menuDevelopmentSourceCode": "עץ קוד המקור",

--- a/data/it/strings.json
+++ b/data/it/strings.json
@@ -135,7 +135,7 @@
     "menuMiscCredits": "Credits",
     "menuHeaderDevelopmentDevelopment": "Sviluppo",
     "menuDevelopmentBugTracker": "Bug Tracker",
-    "menuDevelopmentPatchTracker": "Patch Tracker",
+    "menuDevelopmentPullRequests": "",
     "menuDevelopmentTranslations": "Traduci ScummVM",
     "menuDevelopmentDailies": "Build giornalieri",
     "menuDevelopmentSourceCode": "Codice Sorgente",

--- a/data/pl/strings.json
+++ b/data/pl/strings.json
@@ -151,7 +151,7 @@
   "menuMiscCredits": "",
   "menuHeaderDevelopmentDevelopment": "",
   "menuDevelopmentBugTracker": "",
-  "menuDevelopmentPatchTracker": "",
+  "menuDevelopmentPullRequests": "",
   "menuDevelopmentTranslations": "",
   "menuDevelopmentDailies": "",
   "menuDevelopmentSourceCode": "",

--- a/data/pt-BR/strings.json
+++ b/data/pt-BR/strings.json
@@ -148,7 +148,7 @@
     "menuMiscCredits": "Créditos",
     "menuHeaderDevelopmentDevelopment": "Desenvolvimento",
     "menuDevelopmentBugTracker": "Rastreador de Bugs",
-    "menuDevelopmentPatchTracker": "Rastreador de Correção",
+    "menuDevelopmentPullRequests": "",
     "menuDevelopmentTranslations": "Traduzir ScummVM",
     "menuDevelopmentDailies": "Compilações Diárias",
     "menuDevelopmentSourceCode": "Código Fonte",

--- a/data/pt-PT/strings.json
+++ b/data/pt-PT/strings.json
@@ -155,7 +155,7 @@
   "menuMiscCredits": "Créditos",
   "menuHeaderDevelopmentDevelopment": "Desenvolvimento",
   "menuDevelopmentBugTracker": "Relatar Erros",
-  "menuDevelopmentPatchTracker": "Relatar correções",
+  "menuDevelopmentPullRequests": "",
   "menuDevelopmentTranslations": "Traduzir o ScummVM",
   "menuDevelopmentDailies": "Compilações Diárias",
   "menuDevelopmentSourceCode": "Código Fonte",

--- a/data/ru/strings.json
+++ b/data/ru/strings.json
@@ -138,7 +138,7 @@
   "menuMiscCredits": "Об авторах",
   "menuHeaderDevelopmentDevelopment": "Pазработка",
   "menuDevelopmentBugTracker": "Багтрекер",
-  "menuDevelopmentPatchTracker": "Патчи",
+  "menuDevelopmentPullRequests": "",
   "menuDevelopmentTranslations": "Переводы ScummVM",
   "menuDevelopmentDailies": "Ежедневные сборки",
   "menuDevelopmentSourceCode": "Исходные коды",


### PR DESCRIPTION
"Patch Tracker" was a term that once made sense, but since we moved to GitHub, it no longer means anything. Changing to the GitHub terminology of "Pull Requests".

This will unfortunately require a re-translation in all localizations.

## Before

<img width="175" alt="image" src="https://user-images.githubusercontent.com/6200170/142566127-c80a964a-dd5e-42d7-96c9-f75fa35f89d0.png">

## After

<img width="178" alt="image" src="https://user-images.githubusercontent.com/6200170/142565934-e3c7b8d7-20dc-4251-b68c-2f2de2acba89.png">
