### PR TITLE
WEB: Fixing when there is no download link for the user agent

### DIFF
--- a/include/Models/DownloadsModel.php
+++ b/include/Models/DownloadsModel.php
@@ -107,7 +107,8 @@ class DownloadsModel extends BasicModel
             ->setIgnoreCase(true)
             ->findByUserAgent($os['name']);
 
-        if (!empty($downloads)) {
+        // If we found a user agent for this platform, then generate a download link
+        if (!empty($downloads) && !is_null($downloads[0])) {
             $download = $downloads[0];
 
             $name = strip_tags($download->getName());


### PR DESCRIPTION
If there is no recommended download for the given agent, the page now loads as expected. Tested with user agent

```
Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.2.4) Gecko/20100625 Gentoo Firefox/3.6.4
```

## Before

<img width="1148" alt="image" src="https://user-images.githubusercontent.com/6200170/142789000-a6aa34e2-01dc-4a48-bee9-f9a6dfc2aa40.png">

## After

<img width="1150" alt="image" src="https://user-images.githubusercontent.com/6200170/142788980-b31574f8-c855-4854-809f-5388b905a14c.png">
