### PR TITLE
WEB: Fixing when the recommended download link is an external URL

### DIFF
--- a/include/Models/DownloadsModel.php
+++ b/include/Models/DownloadsModel.php
@@ -111,10 +111,15 @@ class DownloadsModel extends BasicModel
             $download = $downloads[0];
 
             $name = strip_tags($download->getName());
-            // Construct the URL and fill in the version
-            $url = DOWNLOADS_BASE . DOWNLOADS_URL . $download->getURL();
-            $version = $download->getVersion();
-            $url = str_replace('{$version}', $version, $url);
+            if (str_starts_with($download->getURL(), 'http')) {
+                $url = $download->getURL();
+                $url = str_replace('{$version}', $version, $url);
+            } else {
+                // Construct the URL and fill in the version
+                $url = DOWNLOADS_BASE . DOWNLOADS_URL . $download->getURL();
+                $version = $download->getVersion();
+                $url = str_replace('{$version}', $version, $url);
+            }
 
             $data = ""; //$download->getExtraInfo();
             if (is_array($data)) {


### PR DESCRIPTION
If the download button appears and links to an external URL, it now properly generates the  URL

<img width="658" alt="image" src="https://user-images.githubusercontent.com/6200170/142789402-c1bf55f5-4b7f-435a-8595-bca83a228116.png">

Tested on with user agent

```
Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.157 Safari/537.36
```

## Before
The link is https://downloads.scummvm.org/frs/scummvm/2.5.0/https://snapcraft.io/scummvm

## After
The link is https://snapcraft.io/scummvm