### PR TITLE
WEB: Sorting downloads by version after a new one is inserted

### DIFF
--- a/include/Objects/DownloadsSection.php
+++ b/include/Objects/DownloadsSection.php
@@ -29,6 +29,10 @@ class DownloadsSection extends BasicSection
     {
         if ($item->getCategoryIcon()) {
             $this->items[] = new File($item->toArray(TableMap::TYPE_FIELDNAME), '');
+            // Sort items by version, descending
+            usort($this->items, function ($a, $b) {
+                return -version_compare($a->version, $b->version);
+            });
         } else {
             $this->items[] = new WebLink($item->toArray(TableMap::TYPE_FIELDNAME));
         }


### PR DESCRIPTION
Previously, downloads always got added to the end of the list. Now, the download is added to the end and then the list is sorted by version, meaning that the download will be moved to be the last one of all the downloads with that version.

## Before

Version 0.11.1 was at the bottom of the list.

<img width="557" alt="image" src="https://user-images.githubusercontent.com/6200170/143401815-5dfbf97f-4b69-43d2-ae14-c76e453bec38.png">

## After

Version 0.11.1 is now properly after 1.0.0, but before 0.9.1.

<img width="546" alt="image" src="https://user-images.githubusercontent.com/6200170/143401885-cc3a13e8-17a9-4579-a62b-d9c4a277f0e6.png">
