### PR TITLE
I10N: Changing translations link to general project page

### DIFF
--- a/data/en/menus.yaml
+++ b/data/en/menus.yaml
@@ -34,7 +34,7 @@
     - name: '{#menuDevelopmentPullRequests#}'
       href: 'https://github.com/scummvm/scummvm/pulls'
     - name: '{#menuDevelopmentTranslations#}'
-      href: 'https://translations.scummvm.org/projects/scummvm/scummvm/'
+      href: 'https://translations.scummvm.org/projects/'
     - name: '{#menuDevelopmentDailies#}'
       href: '/downloads/#daily'
     - name: '{#menuDevelopmentSourceCode#}'

--- a/data/en/strings.json
+++ b/data/en/strings.json
@@ -158,7 +158,7 @@
   "menuHeaderDevelopmentDevelopment": "Development",
   "menuDevelopmentBugTracker": "Bug Tracker",
   "menuDevelopmentPullRequests": "Pull Requests",
-  "menuDevelopmentTranslations": "Translate ScummVM",
+  "menuDevelopmentTranslations": "Translations",
   "menuDevelopmentDailies": "Daily Builds",
   "menuDevelopmentSourceCode": "Source Code Tree",
   "menuDevelopmentBuildbot": "Buildbot",


### PR DESCRIPTION
There are several translation projects aside from the ScummVM, such as the website and several game translations. Instead of linking to only the ScummVM project, now I link to the overall project that shows them all.

## Before

A two-line hyperlink labeled "Translate ScummVM" goes to https://translations.scummvm.org/projects/scummvm/scummvm/

<img width="179" alt="image" src="https://user-images.githubusercontent.com/6200170/143724293-9d95bf09-1c67-4ba9-8294-26443bd82546.png">

## After

A one-line hyperlink labeled "Translations" goes to https://translations.scummvm.org/projects/

<img width="179" alt="image" src="https://user-images.githubusercontent.com/6200170/143724329-2baedd73-9275-4e52-b2ff-f6311fc1f2ae.png">
