### PR TITLE
WEB: Fixing extra info not appearing for ScummVM download links

### DIFF
--- a/include/Constants.php
+++ b/include/Constants.php
@@ -47,9 +47,9 @@ class Constants
 
         /* Downloads */
         define('DOWNLOADS_BASE', 'https://downloads.scummvm.org');
-        define('DOWNLOADS_URL', '/frs/scummvm/{$version}/');
-        define('DOWNLOADS_DAILY_URL', '/frs/daily/');
-        define('DOWNLOADS_TOOLS_URL', '/frs/scummvm-tools/{$release_tools}/');
+        define('DOWNLOADS_URL', 'frs/scummvm/{$version}/');
+        define('DOWNLOADS_DAILY_URL', 'frs/daily/');
+        define('DOWNLOADS_TOOLS_URL', 'frs/scummvm-tools/{$release_tools}/');
 
         /* Themes */
         define('THEMES', [

--- a/include/Objects/File.php
+++ b/include/Objects/File.php
@@ -15,7 +15,6 @@ class File extends BasicObject
     {
         parent::__construct($data);
         $this->category_icon = $data['category_icon'];
-        $this->extra_info = $data['extra_info'] ?? null;
         $this->subcategory = $data['subcategory'] ?? null;
         $this->user_agent = isset($data["user_agent"]) ? $data["user_agent"] : "";
         $this->version = strtolower($data['version'] ?? null);
@@ -80,22 +79,10 @@ class File extends BasicObject
                 }
 
                 $this->extra_info['ext'] = $ext;
-                $this->extra_info['msg'] = $data['extra_msg'];
+                $this->extra_info['date'] = date('F j, Y, g:i a', @filemtime($fname));
+                $this->extra_info['msg'] = isset($data['notes']) ? $data['notes'] : '';
             }
             $this->url = $fname;
-        }
-        /**
-         * Get the filesize/last modified information and put it in
-         * $this->extra_info.
-         */
-        if (isset($attributes['extra_info'])
-            && $attributes['extra_info'] == 'true') {
-            if (is_file($fname) && is_readable($fname)) {
-                $this->extra_info['date'] = date('F j, Y, g:i a', @filemtime($fname));
-                if (!is_null($data['extra_info'])) {
-                    $this->extra_info['info'] = $data['extra_info'];
-                }
-            }
         }
     }
 


### PR DESCRIPTION
## Before

No extra file information appears after hyperlinks.

<img width="875" alt="Screen Shot 2022-01-08 at 6 50 54 PM" src="https://user-images.githubusercontent.com/6200170/148664862-cda1966b-c4ce-4902-a570-49d44a6895b9.png">

## After

Several pieces of file information appear after hyperlinks. Clicking on `sha256` results in the file hash appearing.

<img width="1076" alt="Screen Shot 2022-01-08 at 6 50 45 PM" src="https://user-images.githubusercontent.com/6200170/148664866-fbed7c16-6407-45b3-841b-d08e06532767.png">

