### PR TITLE
Missing slash between DOWNLOADS_BASE and DOWNLOADS_URL

### DIFF
--- a/include/Models/DownloadsModel.php
+++ b/include/Models/DownloadsModel.php
@@ -113,7 +113,7 @@ class DownloadsModel extends BasicModel
                 $url = str_replace('{$version}', $version, $url);
             } else {
                 // Construct the URL and fill in the version
-                $url = DOWNLOADS_BASE . DOWNLOADS_URL . $download->getURL();
+                $url = DOWNLOADS_BASE . "/" . DOWNLOADS_URL . $download->getURL();
                 $version = $download->getVersion();
                 $url = str_replace('{$version}', $version, $url);
             }


### PR DESCRIPTION
fix wrong url for macos. download did not work because link is like this:
https://downloads.scummvm.orgfrs/scummvm/2.5.1/scummvm-2.5.1-macosx.dmg