### PR TITLE
WEB: Removing Win32 label in extra info

### DIFF
--- a/include/Models/DownloadsModel.php
+++ b/include/Models/DownloadsModel.php
@@ -121,10 +121,6 @@ class DownloadsModel extends BasicModel
             $data = ""; //$download->getExtraInfo();
             if (is_array($data)) {
                 $extra_text = $data['size'] . " ";
-                if ($data['ext'] == '.exe') {
-                    $extra_text = $extra_text . 'Win32 ';
-                }
-
                 $extra_text .= $data['ext'] . " " . $data['msg'];
             } else {
                 $extra_text = $data;

--- a/templates/components/list_items.tpl
+++ b/templates/components/list_items.tpl
@@ -10,7 +10,7 @@
                         <span class="download-extras">
                             {if is_array($data)}
                                 (
-                                {$data.size} {if $data.ext == '.exe'}Win32 {/if}{$data.ext}{if $data.date != ""}{#listItemsDate#} {$data.date} {/if}
+                                {$data.size} {$data.ext}{if $data.date != ""}{#listItemsDate#} {$data.date} {/if}
                                 &nbsp;
                                 {if $data.sha256 != ""} <span class="sha256-toggle" onclick="this.nextSibling.classList.toggle('hidden')"> sha256</span><span class="sha256-text hidden"> <a href="{{eval var=$item->getURL()}|release|download}.sha256">{$data.sha256}</a></span>{/if}
                                 ) {if $data.msg != ""}{$data.msg}{/if}


### PR DESCRIPTION
Now that we have .exe files for 64-bit Windows, it's no longer accurate to say `Win32 .exe`. This was also unique behavior for Windows; we did not indicate bitness in this way for any other operating system.

## Before
<img width="722" alt="Before" src="https://user-images.githubusercontent.com/6200170/148707248-9ca619d2-45ab-4e1f-a8e1-7ef7f11c8db6.png">

## After
<img width="623" alt="After" src="https://user-images.githubusercontent.com/6200170/148707253-cde3947b-8c0c-4d9f-b9ef-39d572250e21.png">