### PR TITLE
WEB: Remove trailing bullet if recommended download lacks a description

### DIFF
--- a/templates/components/recommended_download.tpl
+++ b/templates/components/recommended_download.tpl
@@ -5,7 +5,7 @@
             <a id="downloadButton" href={$recommendedDownload.url|download}>
                 <img src="/images/scummvm.png" alt="Download ScummVM icon">
                 <div class="downloadText">Download ScummVM</div>
-                <div id="downloadDetails">Version {$recommendedDownload.ver} • {$recommendedDownload.os} • {$recommendedDownload.desc}</div>
+                <div id="downloadDetails">Version {$recommendedDownload.ver} • {$recommendedDownload.os}{if $recommendedDownload.desc != ""} • {$recommendedDownload.desc}{/if}</div>
             </a>
         </div>
     </div>


### PR DESCRIPTION
The recommended download section includes the version, OS, and description, with each separated by a bullet (•). Before, the bullet following the OS would always appear, even if there was no description after it. Now the bullet will only appear if there is a description.

## Before
<img width="634" alt="Before" src="https://user-images.githubusercontent.com/6200170/148707670-e68480d7-28de-42eb-847b-af159fcad2b5.png">

## After
<img width="634" alt="After" src="https://user-images.githubusercontent.com/6200170/148707673-c0ef6c18-62cf-4b16-98b5-c9d892a48626.png">
