### PR TITLE
WEB: Moving location of recommended download version

### DIFF
--- a/templates/components/recommended_download.tpl
+++ b/templates/components/recommended_download.tpl
@@ -4,8 +4,8 @@
         <div id="downloadContainer">
             <a id="downloadButton" href={$recommendedDownload.url|download}>
                 <img src="/images/scummvm.png" alt="Download ScummVM icon">
-                <div class="downloadText">Download ScummVM</div>
-                <div id="downloadDetails">Version {$recommendedDownload.ver} • {$recommendedDownload.os}{if $recommendedDownload.desc != ""} • {$recommendedDownload.desc}{/if}</div>
+                <div class="downloadText">Download ScummVM {$recommendedDownload.ver}</div>
+                <div id="downloadDetails">{$recommendedDownload.os}{if $recommendedDownload.desc != ""} • {$recommendedDownload.desc}{/if}</div>
             </a>
         </div>
     </div>


### PR DESCRIPTION
The button now reads "Download ScummVM 2.5.1" instead of "Download ScummVM" and the next line beginning with "Version 2.5.1".

This also has an advantage of reducing the number of words that need to be translated into foreign languages.

## Before
<img width="631" alt="Before" src="https://user-images.githubusercontent.com/6200170/148856843-78d49c43-a6c9-40bc-b615-d24d0731c676.png">

## After
<img width="623" alt="After" src="https://user-images.githubusercontent.com/6200170/148856979-bc2866d9-293c-4f34-b83b-f674574502e0.png">
