### PR TITLE
I10N: Making Recommended Download button title text translatable

### DIFF
--- a/data/en/strings.json
+++ b/data/en/strings.json
@@ -54,6 +54,7 @@
   "downloadsContentP2": "The latest STABLE release of ScummVM is {release}, and can be downloaded below under '[Release Binaries](/downloads/#release)'. If you run Windows and are confused, download the 'Windows Installer'.",
   "downloadsContentP3": "For UNSTABLE experimental versions of ScummVM (for people who know what they are doing), please see the [Daily Builds](/downloads/#daily) section, near the end of this page.",
   "downloadsBadge": "Recommended download for your system",
+  "downloadsBadgeTitle": "Download ScummVM {version}",
   "downloadsXMLTitle": "Downloads for ScummVM",
   "downloadsXMLVersion": "version {release}",
   "downloadsBinaries": "{release} Release binaries",

--- a/templates/components/recommended_download.tpl
+++ b/templates/components/recommended_download.tpl
@@ -4,7 +4,7 @@
         <div id="downloadContainer">
             <a id="downloadButton" href={$recommendedDownload.url|download}>
                 <img src="/images/scummvm.png" alt="Download ScummVM icon">
-                <div class="downloadText">Download ScummVM {$recommendedDownload.ver}</div>
+                <div class="downloadText">{#downloadsBadgeTitle#|replace:'{version}':$recommendedDownload.ver}</div>
                 <div id="downloadDetails">{$recommendedDownload.os}{if $recommendedDownload.desc != ""} • {$recommendedDownload.desc}{/if}</div>
             </a>
         </div>


### PR DESCRIPTION
A new string, `downloadsBadgeTitle`, will need to be translated through Weblate.

## Before
<img width="624" alt="Before" src="https://user-images.githubusercontent.com/6200170/148860238-40b16baa-22fe-42cf-bfd8-df25f5b8429c.png">

## After
<img width="631" alt="After" src="https://user-images.githubusercontent.com/6200170/148860204-811b0af1-1e20-45d6-b01f-edcfb003a4ee.png">