### PR TITLE
WEB: Changing getLastModified($path) to return as ISO 8601 date

### DIFF
--- a/include/FileUtils.php
+++ b/include/FileUtils.php
@@ -1,6 +1,9 @@
 <?php
 namespace ScummVM;
 
+use DateTime;
+use DateTimeInterface;
+
 /**
 * Utility functions related to files on a file system.
 */
@@ -88,15 +91,16 @@ class FileUtils
     }
 
     /**
-    * Returns the date and time that the given file was last modified.
+    * Returns the date (in ISO 8601 format) that the given file was last modified.
     *
     * @param $path the path to the file that will be analyzed
-    * @return the date and time
+    * @return the date
     */
     public static function getLastModified($path)
     {
         $path = FileUtils::toAbsolutePathIfOnServer($path);
-        return date('F j, Y, g:i a', @filemtime($path));
+        $date = new DateTime();
+        return $date->setTimestamp(@filemtime($path))->format("Y-m-d");
     }
 
     /**


### PR DESCRIPTION
We don't need second precision when showing last updated, so reducing from datetime to date. Changing to ISO 8601 has the added benefit of reducing visual complexity and also preventing the need to translate the spelled out dates.

## Before
<img width="667" alt="Before" src="https://user-images.githubusercontent.com/6200170/148862367-2bd633c9-a37a-4310-9e4b-016f7bbca2ac.png">

## After
<img width="600" alt="After" src="https://user-images.githubusercontent.com/6200170/148862164-0d77a8a8-fd17-4557-b673-afbd73be82cb.png">
