### PR TITLE
WEB: Fixing sha256 formatting

### DIFF
--- a/templates/components/list_items.tpl
+++ b/templates/components/list_items.tpl
@@ -10,9 +10,8 @@
                         <span class="download-extras">
                             {if is_array($data)}
                                 (
-                                {$data.size} {$data.ext}{if $data.date != ""}{#listItemsDate#} {$data.date} {/if}
-                                &nbsp;
-                                {if $data.sha256 != ""} <span class="sha256-toggle" onclick="this.nextSibling.classList.toggle('hidden')"> sha256</span><span class="sha256-text hidden"> <a href="{{eval var=$item->getURL()}|release|download}.sha256">{$data.sha256}</a></span>{/if}
+                                {$data.size} {$data.ext}{if $data.date != ""}{#listItemsDate#} {$data.date}{/if}
+                                {if $data.sha256 != ""}, <span class="sha256-toggle" onclick="this.nextSibling.classList.toggle('hidden')">sha256</span><span class="sha256-text hidden"> <a href="{{eval var=$item->getURL()}|release|download}.sha256">{$data.sha256}</a></span>{/if}
                                 ) {if $data.msg != ""}{$data.msg}{/if}
                             {/if}
                         </span>


### PR DESCRIPTION
Removing extra spaces and adding a comma

## Before
<img width="525" alt="Before" src="https://user-images.githubusercontent.com/6200170/148863470-c4c9bde7-b500-41c0-9a34-75ce81326a1d.png">

## After
<img width="525" alt="After" src="https://user-images.githubusercontent.com/6200170/148863244-468e9c66-4a41-458e-9b67-6cc5bc49e460.png">