### PR TITLE
WEB: Moving daily download file path

### DIFF
--- a/include/Constants.php
+++ b/include/Constants.php
@@ -49,7 +49,6 @@ class Constants
         /* Downloads */
         define('DOWNLOADS_BASE', 'https://downloads.scummvm.org');
         define('DOWNLOADS_URL', 'frs/scummvm/{$version}/');
-        define('DOWNLOADS_DAILY_URL', 'frs/daily/');
         define('DOWNLOADS_EXTRAS_URL', 'frs/extras/');
 
         /* Themes */

--- a/include/Objects/File.php
+++ b/include/Objects/File.php
@@ -36,9 +36,7 @@ class File extends BasicObject
             $this->url = $url;
         } else {
             // Construct the URL based on its type
-            if ($this->version == 'daily') {
-                $fname = DOWNLOADS_DAILY_URL . $url;
-            } elseif ($this->category == 'games' || $this->category == 'addons') {
+            if ($this->category == 'games' || $this->category == 'addons') {
                 $fname = DOWNLOADS_EXTRAS_URL . $url;
             } elseif (str_starts_with($url, '/frs') || str_starts_with($url, 'http')) {
                 $fname = $url;


### PR DESCRIPTION
I have proposed moving daily downloads of ScummVM and ScummVM Tools from `frs/daily/` to `frs/scummvm/daily/` and `frs/scummvm-tools/daily` respectively. This PR contains simplifications to the code that would result from this. 

The download links can be found at https://www.scummvm.org/downloads/#daily

## Before

* https://downloads.scummvm.org/frs/daily/scummvm-snapshot-win32.exe
* https://downloads.scummvm.org/frs/daily/scummvm-tools-snapshot-win32.zip

## After

* https://downloads.scummvm.org/frs/scummvm/daily/scummvm-snapshot-win32.exe
* https://downloads.scummvm.org/frs/scummvm-tools/daily/scummvm-tools-snapshot-win32.zip