### PR TITLE
WEB: Fixing captions for games with quotes in name

### DIFF
--- a/include/OrmObjects/Screenshot.php
+++ b/include/OrmObjects/Screenshot.php
@@ -67,7 +67,8 @@ class Screenshot extends BaseScreenshot
 
     public function getCaption()
     {
-        $name =  $this->getGame()->getName();
+        // Escape quotes in the name, such as for `Spy Fox in "Dry Cereal"`
+        $name = str_replace("\"", "&quot;", $this->getGame()->getName());
         $extras = [];
         if ($this->getVariant()) {
             $extras[] = $this->getVariant();


### PR DESCRIPTION
`Spy Fox in "Dry Cereal"` was appearing as `Spy Fox in`. Replacing the quotes with `&quot;` so it renders properly in HTML.

## Before
<img width="369" alt="Before" src="https://user-images.githubusercontent.com/6200170/149462299-c38c320a-cf85-4d62-9d31-41848151cf94.png">

## After
<img width="370" alt="After" src="https://user-images.githubusercontent.com/6200170/149462314-abadb468-d544-4404-bed5-383cf601474a.png">