### PR TITLE
DATA: Removing constants for Android & Ubuntu versions

### DIFF
--- a/include/Constants.php
+++ b/include/Constants.php
@@ -8,9 +8,6 @@ class Constants
         /* Current version. */
         define('RELEASE', '2.5.1');
         define('RELEASE_TOOLS', '2.5.0');
-        define('RELEASE_DEBIAN', '2.2.0');
-        define('RELEASE_SNAP_STORE', '2.5.1');
-        define('RELEASE_ANDROID_STORE', '2.5.0');
 
         /* News items on the front page. */
         define('NEWS_ITEMS', 5);

--- a/include/Models/DownloadsModel.php
+++ b/include/Models/DownloadsModel.php
@@ -107,6 +107,7 @@ class DownloadsModel extends BasicModel
         // If we found a user agent for this platform, then generate a download link
         if (!empty($downloads) && ($downloads[0] !== null)) {
             $download = $downloads[0];
+            $version = $download->getVersion();
 
             $name = strip_tags($download->getName());
             if (str_starts_with($download->getURL(), 'http')) {
@@ -114,7 +115,6 @@ class DownloadsModel extends BasicModel
                 $url = str_replace('{$version}', $version, $url);
             } else {
                 // Construct the URL and fill in the version
-                $version = $download->getVersion();
                 $file_name = str_replace('{$version}', $version, DOWNLOADS_URL . $download->getURL());
                 $url = DOWNLOADS_BASE .  "/" . $file_name;
                 if (FileUtils::exists($file_name)) {
@@ -122,17 +122,7 @@ class DownloadsModel extends BasicModel
                 }
             }
 
-            /*
-            Get the version information for our store releases for
-            Android and the Snap store. Since we can't rely on the
-            file names here, we set them via Constants.php
-            */
-            if ($os['name'] === 'Android') {
-                $version = RELEASE_ANDROID_STORE;
-            }
-
             if ($os['name'] === 'Ubuntu') {
-                $version = RELEASE_SNAP_STORE;
                 $extra_text = '(snap install scummvm)';
             }
 


### PR DESCRIPTION
Now that we have the "version" column on the spreadsheet, the constants are unnecessary. This was a holdover from back when versions were determined by the file names and these URLs didn't have them.