### PR TITLE
DATA: Restoring notes for links

### DIFF
--- a/data/en/links.yaml
+++ b/data/en/links.yaml
@@ -1,59 +1,59 @@
 - name: Libraries & Technologies
-  description: >-
+  notes: >-
     The following lists some libraries and technologies ScummVM makes use of
     (depending on which system your run it and which configuration is chosen).
   links:
     - name: SDL
-      description: >-
+      notes: >-
         SDL (Simple DirectMedia Layer) is a cross-platform multimedia library,
         and used by the primary backend of ScummVM.
       url: 'https://www.libsdl.org/'
     - name: MAD
-      description: >-
+      notes: >-
         MAD is a high-quality MPEG (MP3) audio decoder. ScummVM optionally
         supports playback of CD tracks and other audio data encoded using MP3.
       url: 'https://www.underbit.com/products/mad/'
     - name: Ogg Vorbis
-      description: >-
+      notes: >-
         Ogg Vorbis is a fully open, non-proprietary, patent-and-royalty-free,
         general-purpose compressed audio format. ScummVM optionally supports
         playback of CD tracks and other audio data encoded using Ogg Vorbis.
       url: 'https://xiph.org/vorbis/'
     - name: FLAC
-      description: >-
+      notes: >-
         FLAC stands for Free Lossless Audio Codec. Grossly oversimplified, FLAC
         is similar to MP3, but lossless, meaning that audio is compressed in
         FLAC without any loss in quality. ScummVM optionally supports playback
         of CD tracks and other audio data encoded using FLAC.
       url: 'https://xiph.org/flac/'
     - name: Scale2x/3x/4x
-      description: >-
+      notes: >-
         Scale2x is a real-time graphics effect able to increase the size of
         small bitmaps guessing the missing pixels without blurring the images.
         ScummVM optionally supports enlarging the game graphics using this
         scaler.
       url: 'http://www.scale2x.it/'
     - name: hq2x/3x/4x
-      description: >-
+      notes: >-
         The hq2x/3x/4x filters form a family of fast, high-quality magnification
         filters. ScummVM optionally supports enlarging the game graphics using
         these scaler.
       url: >-
         https://web.archive.org/web/20131114143602/http://www.hiend3d.com/hq3x.html
 - name: Other sites of interest
-  description: >-
+  notes: >-
     The following are links to sites that provide news and help on retro-gaming
     or are otherwise of interest.
   links:
     - name: 'VOGONS :: Very Old Games On New Systems'
-      description: >-
+      notes: >-
         VOGONS is a large forum site, offering supports and tips for people who
         need help running older classic games on their modern computers and
         operating systems. If you want to play a game that ScummVM doesn't
         support, this is the place to ask for help!
       url: 'https://www.vogons.org/'
     - name: 'MixNMojo :: The Purple LucasArts Fan Site'
-      description: >-
+      notes: >-
         MixNmojo is one of the longest running, and definitely largest,
         LucasArts sites out there. If your looking for information, hints,
         news... or even just a place to hang... with hosted and partnered sites
@@ -61,14 +61,14 @@
         very first stop.
       url: 'https://mixnmojo.com/'
     - name: 'DoubleFine :: Where taking over the word is a news scripts job'
-      description: >-
+      notes: >-
         DoubleFine is the company of the lovable Tim Schafer, the genius behind
         some of the best of the worst gags and games in LucasArts history. Go
         buy Psychonauts, their new game. Because if you don't, the rats will get
         you and eat your family, computer and house. And poop everywhere.
       url: 'https://www.doublefine.com/'
     - name: Revolution Software
-      description: >-
+      notes: >-
         Revolution Software are the people behind such wonderful titles as
         Beneath a Steel Sky and the Broken Sword series of games. Revolution
         have provided us with the source code to some of these games so that we
@@ -76,17 +76,17 @@
         Thanks guys!
       url: 'https://revolution.co.uk/'
     - name: Grumpy Gamer
-      description: >-
+      notes: >-
         The personal blog of Ron Gilbert, the man behind many great LucasArts
         adventures, like Maniac Mansion and Monkey Island.
       url: 'https://grumpygamer.com/'
     - name: ScummVM Music Enhancement Project by James Woodcock
-      description: >-
+      notes: >-
         A fanmade selection of recreated soundtracks based on the original MIDI files
         for several games supported by ScummVM.
       url: 'https://www.pixelrefresh.com/content/scummvm-music-enhancement-project/'
 - name: Technical information about SCUMM and other engines
-  description: >-
+  notes: >-
     SCUMM is a complex system that grew over many years. Understanding it can be
     quite difficult at times. Therefore we tried to collect some information
     about these engines in our <a href="http://wiki.scummvm.org">Wiki</a>. Sadly
@@ -94,10 +94,10 @@
     you with a bunch of information about some engines. Here are some of them.
   links:
     - name: SCUMM Hacking forum
-      description: Information and discussion on resource formats used in LucasArts games.
+      notes: Information and discussion on resource formats used in LucasArts games.
       url: 'https://forums.mixnmojo.com/forum/318-scumm/'
     - name: AGI Development Site
-      description: >-
+      notes: >-
         Large amounts of information surrounding Sierra's AGI system and home of
         the NAGI AGI interpreter.
       url: 'http://agiwiki.sierrahelp.com/'


### PR DESCRIPTION
The code expects "notes", but the data was stored as "descriptions". Changing to "notes".

## Before

<img width="1069" alt="image" src="https://user-images.githubusercontent.com/6200170/152705193-81638dac-6659-421b-9d38-b3b19ee24ac6.png">

## After

<img width="1064" alt="image" src="https://user-images.githubusercontent.com/6200170/152705201-b1a96fdf-296a-42ba-a54d-b7f982e3c1d0.png">