### PR TITLE
WEB: Upgrading minimum PHP version from 7.3.0 to 8.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     }
   ],
   "require": {
-    "php": ">=7.3.0",
+    "php": ">=8.1.0",
     "ext-intl": "*",
     "smarty/smarty": "^4.1.0",
     "ezyang/htmlpurifier": "^4.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "28c856bd1fce570dc304f94f3eeb4023",
+    "content-hash": "8085cc0006c2d71f12ef742e0bed3afd",
     "packages": [
         {
             "name": "altorouter/altorouter",
@@ -2915,7 +2915,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.3.0",
+        "php": ">=8.1.0",
         "ext-intl": "*"
     },
     "platform-dev": [],


### PR DESCRIPTION
This would allow us to use Phpfastcache 9.x, which fixes deprecation warnings we get under PHP 8.1.