### PR TITLE
WEB: Changing menu link from "Games" to "Freeware Games"

### DIFF
--- a/data/en/menus.yaml
+++ b/data/en/menus.yaml
@@ -9,7 +9,7 @@
       href: 'https://forums.scummvm.org/'
     - name: '{#menuMainDownloads#}'
       href: /downloads/
-    - name: '{#menuMainGames#}'
+    - name: '{#menuMainFreewareGames#}'
       href: /games/
     - name: '{#menuMainBlogs#}'
       href: 'https://planet.scummvm.org'

--- a/data/en/strings.json
+++ b/data/en/strings.json
@@ -147,7 +147,7 @@
   "menuMainScreenshots": "Screenshots",
   "menuMainForums": "Forums",
   "menuMainDownloads": "Downloads",
-  "menuMainGames": "Games",
+  "menuMainFreewareGames": "Freeware Games",
   "menuMainBlogs": "ScummVM Blogs",
   "menuHeaderDocumentation": "Documentation",
   "menuDocumentationFaq": "F.A.Q.",

--- a/data/en/strings.json
+++ b/data/en/strings.json
@@ -147,7 +147,7 @@
   "menuMainScreenshots": "Screenshots",
   "menuMainForums": "Forums",
   "menuMainDownloads": "Downloads",
-  "menuMainFreewareGames": "Freeware Games",
+  "menuMainFreewareGames": "Freeware Games & Addons",
   "menuMainBlogs": "ScummVM Blogs",
   "menuHeaderDocumentation": "Documentation",
   "menuDocumentationFaq": "F.A.Q.",


### PR DESCRIPTION
"Games" could refer to either 

* Games that are freeware
* Games supported by ScummVM (i.e. Compatibility)

Changing to "Freeware Games" to avoid this ambiguity.

## Before
<img width="179" alt="image" src="https://user-images.githubusercontent.com/6200170/155052593-cd1a47c3-c7b4-412a-b700-b9c350cfff56.png">

## After
<img width="183" alt="image" src="https://user-images.githubusercontent.com/6200170/155052568-67352deb-741f-4723-be0d-dafdc87597a2.png">