### PR TITLE
WEB: Adding null check before string replacement

### DIFF
--- a/include/Objects/File.php
+++ b/include/Objects/File.php
@@ -23,7 +23,7 @@ class File extends BasicObject
         $this->notes = isset($data['notes']) ? $data['notes'] : '';
         $this->subcategory = $data['subcategory'] ?? null;
         $this->user_agent = isset($data["user_agent"]) ? $data["user_agent"] : "";
-        $this->version = strtolower($data['version'] ?? null);
+        $this->version = isset($data['version']) ? strtolower($data['version']) : null;
 
         /* If it's not an array, we didn't get any attributes. */
         if (!is_array($data['url'])) {

--- a/include/OrmObjects/Download.php
+++ b/include/OrmObjects/Download.php
@@ -20,7 +20,7 @@ class Download extends BaseDownload
         $name = parent::getName();
         $version = $this->getVersion();
         // If it's not the latest version and not daily, prefix with the version number
-        if ($version != RELEASE && $version != 'Daily') {
+        if ($version != null && $version != RELEASE && $version != 'Daily') {
             return str_replace('{$version}', $version, "$version $name");
         }
         return $name;


### PR DESCRIPTION
Fixes errors such as

```
PHP Deprecated:  strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in /Users/Will/OpenSource/scummvm-web/include/Objects/File.php on line 26
```