### PR TITLE
WEB: Automatically determine filemask for screenshots

### DIFF
--- a/include/OrmObjects/Screenshot.php
+++ b/include/OrmObjects/Screenshot.php
@@ -20,7 +20,7 @@ class Screenshot extends BaseScreenshot
     public function getFiles()
     {
         if (!$this->files) {
-            foreach (glob("./" . DIR_SCREENSHOTS . "/" . $this->getGame()->getEngine()->getId() . "/" . $this->getGame()->getId() . "/*") as $file) {
+            foreach (glob("./" . DIR_SCREENSHOTS . "/" . $this->getGame()->getEngine()->getId() . "/" . $this->getGame()->getId() . "/" . $this->getFileMask()) as $file) {
                 if (\strpos($file, "_full.") !== false) {
                     continue;
                 }
@@ -86,6 +86,21 @@ class Screenshot extends BaseScreenshot
         }
 
         return $name;
+    }
+
+    public function getFileMask()
+    {
+        $mask = $this->getGame()->getId() . "_";
+        if ($this->getPlatform()) {
+            $mask .= $this->getPlatform()->getId() . "_";
+        }
+        if ($this->getLanguage()) {
+            $mask .= $this->getLanguage() . "_";
+        }
+        // TODO: Each variant of same platform/language has a sequential ID
+        $mask .= "1_";
+        $mask .= "*";
+        return $mask;
     }
 
     public function __toString()

--- a/include/OrmObjects/Screenshot.php
+++ b/include/OrmObjects/Screenshot.php
@@ -21,12 +21,10 @@ class Screenshot extends BaseScreenshot
     {
         if (!$this->files) {
             foreach (glob("./" . DIR_SCREENSHOTS . "/" . $this->getGame()->getEngine()->getId() . "/" . $this->getGame()->getId() . "/" . $this->getFileMask()) as $file) {
-                if (\strpos($file, "_full.") !== false) {
-                    continue;
-                }
-                // Remove the base folder and extension
+                // Remove the base folder
                 $name = str_replace("./" . DIR_SCREENSHOTS . "/", "", $file);
-                $name = \substr($name, 0, \strlen($name) - 4);
+                // Remove the suffix, eg. "_full.png"
+                $name = \substr($name, 0, \strlen($name) - 9);
                 $this->files[] = [
                     'filename' => $name,
                     'caption' => $this->getCaption(),
@@ -97,9 +95,8 @@ class Screenshot extends BaseScreenshot
         if ($this->getLanguage()) {
             $mask .= $this->getLanguage() . "_";
         }
-        // TODO: Each variant of same platform/language has a sequential ID
-        $mask .= "1_";
-        $mask .= "*";
+        $mask .= $this->getVariantId() . "_";
+        $mask .= "*_full.*";
         return $mask;
     }
 

--- a/include/OrmObjects/ScreenshotQuery.php
+++ b/include/OrmObjects/ScreenshotQuery.php
@@ -26,7 +26,7 @@ class ScreenshotQuery extends BaseScreenshotQuery
             $con = Propel::getServiceContainer()->getReadConnection(ScreenshotTableMap::DATABASE_NAME);
         }
 
-        $sql = 'SELECT id, variant, platform_id, language, auto_id FROM screenshot ORDER BY RANDOM() LIMIT 1';
+        $sql = 'SELECT id, variant, platform_id, language, variant_id, auto_id FROM screenshot ORDER BY RANDOM() LIMIT 1';
         try {
             $stmt = $con->prepare($sql);
             $stmt->execute();

--- a/schema.xml
+++ b/schema.xml
@@ -69,6 +69,7 @@
     <column name="variant" type="varchar" size="255" />
     <column name="platform_id" type="varchar" size="24" required="true"/>
     <column name="language" type="varchar" size="8" required="true"/>
+    <column name="variant_id" type="integer"/>
     <foreign-key foreignTable="game" onDelete="CASCADE">
       <reference local="id" foreign="id"/>
     </foreign-key>


### PR DESCRIPTION
This is an attempt at fixing the [regression](https://bugs.scummvm.org/ticket/13328) introduced by PR #207 .

The "filemask" column was removed, so now every game screenshot is (incorrectly) duplicated for each variant. This tries to automatically determine the filemask based on the screenshot column data instead. The format is `<game>_<platform>_<language>_<variant>_*`