### PR TITLE
IMAGES: Only count full screenshots

### DIFF
--- a/include/Models/ScreenshotsModel.php
+++ b/include/Models/ScreenshotsModel.php
@@ -145,7 +145,7 @@ class ScreenshotsModel extends BasicModel
         $count = 0;
         // Iterate over each game and count the number of screenshot files
         foreach ($games as $game) {
-            $count += count(glob("./" . DIR_SCREENSHOTS . "/" . $game->getEngine()->getId() . "/" . $game->getId() . "/*"));
+            $count += count(glob("./" . DIR_SCREENSHOTS . "/" . $game->getEngine()->getId() . "/" . $game->getId() . "/*_full.png"));
         }
         return $count;
     }


### PR DESCRIPTION
Fixes [#13340](https://bugs.scummvm.org/ticket/13340).

When getting a count of the number of screenshots for a game or series, only count the full screenshots. This prevents doubling the count because both the small and large versions are included.

## Before

<img width="328" alt="image" src="https://user-images.githubusercontent.com/6200170/156897498-dffadf57-8c43-4197-b1a9-68f806659a6c.png">

## After

<img width="310" alt="image" src="https://user-images.githubusercontent.com/6200170/156897537-5d43d1a5-09d3-4865-ae24-ad553764b0e0.png">