### PR TITLE
WEB: Escaping special characters in the variant name

### DIFF
--- a/include/OrmObjects/Screenshot.php
+++ b/include/OrmObjects/Screenshot.php
@@ -71,7 +71,7 @@ class Screenshot extends BaseScreenshot
         $name = str_replace("\"", "&quot;", $this->getGame()->getName());
         $extras = [];
         if ($this->getVariant()) {
-            $extras[] = $this->getVariant();
+            $extras[] = htmlspecialchars($this->getVariant());
         }
         if ($this->getPlatform()) {
             $extras[] = $this->getPlatform()->getName();


### PR DESCRIPTION
Fixes an issue where the variant of `2.0F 1987-05-05 5.25"/3.5"` was truncated to `2.0F 1987-05-05 5.25`

## Before
<img width="272" alt="image" src="https://user-images.githubusercontent.com/6200170/156899953-3746466a-d5d6-4062-890c-9ae4b12ccf9a.png">

## After
<img width="276" alt="image" src="https://user-images.githubusercontent.com/6200170/156899962-7b391325-c57d-4ffc-8fae-8f34b16f4ce6.png">
