### PR TITLE
WEB: Escaping special characters in the entire caption

### DIFF
--- a/include/OrmObjects/Screenshot.php
+++ b/include/OrmObjects/Screenshot.php
@@ -68,7 +68,7 @@ class Screenshot extends BaseScreenshot
     public function getCaption()
     {
         // Escape quotes and such in the name, such as for `Spy Fox in "Dry Cereal"`
-        $name = htmlspecialchars($this->getGame()->getName());
+        $name = $this->getGame()->getName();
         $extras = [];
         if ($this->getVariant()) {
             $extras[] = $this->getVariant();
@@ -82,10 +82,10 @@ class Screenshot extends BaseScreenshot
 
         if (count($extras) > 0) {
             $extra = \join("/", $extras);
-            return "$name ($extra)";
+            return htmlspecialchars("$name ($extra)");
         }
 
-        return $name;
+        return htmlspecialchars($name);
     }
 
     public function __toString()


### PR DESCRIPTION
Fixes an issue where the caption of `King's Quest I: Quest for the Crown (2.0F 1987-05-05 5.25"/3.5"/DOS/English)` was truncated to `King's Quest I: Quest for the Crown (2.0F 1987-05-05 5.25`.

Replaces #215.

## Before
<img width="272" alt="image" src="https://user-images.githubusercontent.com/6200170/156899953-3746466a-d5d6-4062-890c-9ae4b12ccf9a.png">

## After
<img width="276" alt="image" src="https://user-images.githubusercontent.com/6200170/156899962-7b391325-c57d-4ffc-8fae-8f34b16f4ce6.png">