### PR TITLE
WEB: Changing grid view to be more responsive

### DIFF
--- a/scss/components/_card.scss
+++ b/scss/components/_card.scss
@@ -3,12 +3,10 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  margin-bottom: 20px;
+  margin: 5px;
   padding: 10px;
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
   transition: 0.2s;
-  height: auto;
-  width: 100%;
   background: #fff;
 
   &:hover {
@@ -32,6 +30,7 @@
     display: flex;
     align-items: center;
     height: 10%;
+    max-width: 250px;
   }
 
   &.sponsor {

--- a/scss/pages/_screenshots.scss
+++ b/scss/pages/_screenshots.scss
@@ -9,14 +9,12 @@
 }
 
 .gallery {
+  display:flex;
+  /* Max of 4 per row. */
+  flex: 1 0 24%;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
   text-align: center;
-
-  .caption {
-    text-overflow: ellipsis;
-    overflow: hidden;
-    height: 38px;
-    display: inline-block;
-    text-align: center;
-    width: 100%;
-  }
 }

--- a/scss/pages/_screenshots.scss
+++ b/scss/pages/_screenshots.scss
@@ -9,7 +9,7 @@
 }
 
 .gallery {
-  display:flex;
+  display: flex;
   /* Max of 4 per row. */
   flex: 1 0 24%;
   flex-direction: row;

--- a/scss/pages/_screenshots.scss
+++ b/scss/pages/_screenshots.scss
@@ -10,8 +10,6 @@
 
 .gallery {
   display: flex;
-  /* Max of 4 per row. */
-  flex: 1 0 24%;
   flex-direction: row;
   flex-wrap: wrap;
   align-items: center;

--- a/templates/pages/screenshots_category.tpl
+++ b/templates/pages/screenshots_category.tpl
@@ -1,22 +1,18 @@
 {* List all screenshots for an entry or category. *}
 {capture "content"}
     {foreach from=$screenshots.games item=g name=cat_loop}
+        <h3 class="subhead"><a href="{'/screenshots/'|lang}{$category}/{$g->getCategory()}/">{$g->getName()}</a></h3>
         <div class="gallery">
-            <div class="row">
-                <h3 class="subhead"><a href="{'/screenshots/'|lang}{$category}/{$g->getCategory()}/">{$g->getName()}</a></h3>
-                {foreach from=$g->getFiles() item=fdata name=game_loop}
-                    <div class="col-1-4 col-md-1">
-                        <div class="card">
-                            <div class="image">
-                                <a href="{$smarty.const.DIR_SCREENSHOTS}/{$fdata.filename}_full.png" title="{$fdata.caption}">
-                                    <img class="pixelated" src="{$smarty.const.DIR_SCREENSHOTS}/{$fdata.filename}.jpg" alt="{$g->getName()} screenshot #{$smarty.foreach.cat_loop.iteration}">
-                                </a>
-                            </div>
-                            <div class="caption">{$fdata.caption}</div>
-                        </div>
+            {foreach from=$g->getFiles() item=fdata name=game_loop}
+                <div class="card">
+                    <div class="image">
+                        <a href="{$smarty.const.DIR_SCREENSHOTS}/{$fdata.filename}_full.png" title="{$fdata.caption}">
+                            <img class="pixelated" src="{$smarty.const.DIR_SCREENSHOTS}/{$fdata.filename}.jpg" alt="{$g->getName()} screenshot #{$smarty.foreach.cat_loop.iteration}">
+                        </a>
                     </div>
-                {/foreach}
-            </div>
+                    <div class="caption">{$fdata.caption}</div>
+                </div>
+            {/foreach}
         </div>
     {/foreach}
 {/capture}


### PR DESCRIPTION
Improvements are:

* Long captions are now always visible instead of being cut off
* Differently sized cards no longer cause gaps
* Images are now always at a visible size instead of becoming too small to see

## Before

![Before](https://user-images.githubusercontent.com/6200170/157727518-19f6dd78-2bab-4422-8380-f8dcb7bdbebf.gif)

### Description is not always readable
<img width="644" alt="image" src="https://user-images.githubusercontent.com/6200170/157728145-a7078040-c678-4691-8737-7c313312e368.png">

### Gaps can occur with differently sized cards
<img width="433" alt="image" src="https://user-images.githubusercontent.com/6200170/157728444-2f8d1aed-7c41-4b2f-b164-5fec4cbc3f1f.png">

## After
There are no gaps, images stay a consistently readable size, and captions are always shown in full. 

Images are centered on the page, preventing the possibility of a wide gap on the right side

![After](https://user-images.githubusercontent.com/6200170/157727966-b00b6dbc-6b8d-4081-b681-31f8fd978fbf.gif)

