### PR TITLE
IMAGES: Removing pixelated rendering class for thumbnails

### DIFF
--- a/scss/components/_card.scss
+++ b/scss/components/_card.scss
@@ -20,9 +20,6 @@
       max-width: 100%;
       height: auto;
       max-height: 250px;
-      &.pixelated {
-        image-rendering: pixelated;
-      }
     }
   }
 

--- a/templates/pages/screenshots_category.tpl
+++ b/templates/pages/screenshots_category.tpl
@@ -7,7 +7,7 @@
                 <div class="card">
                     <div class="image">
                         <a href="{$smarty.const.DIR_SCREENSHOTS}/{$fdata.filename}_full.png" title="{$fdata.caption}">
-                            <img class="pixelated" src="{$smarty.const.DIR_SCREENSHOTS}/{$fdata.filename}.jpg" alt="{$g->getName()} screenshot #{$smarty.foreach.cat_loop.iteration}">
+                            <img src="{$smarty.const.DIR_SCREENSHOTS}/{$fdata.filename}.jpg" alt="{$g->getName()} screenshot #{$smarty.foreach.cat_loop.iteration}">
                         </a>
                     </div>
                     <div class="caption">{$fdata.caption}</div>


### PR DESCRIPTION
It's still preserved for the monkey at the bottom of the menu.