### PR TITLE
WEB: Adding a caption to random screenshots

### DIFF
--- a/include/OrmObjects/Screenshot.php
+++ b/include/OrmObjects/Screenshot.php
@@ -28,6 +28,7 @@ class Screenshot extends BaseScreenshot
                 $this->files[] = [
                     'filename' => $name,
                     'caption' => $this->getCaption(),
+                    'url' => "compatibility/DEV/" . $this->getGame()->getId()
                 ];
             }
         }

--- a/scss/pages/_screenshots.scss
+++ b/scss/pages/_screenshots.scss
@@ -1,6 +1,4 @@
 .random-screenshot {
-  display: block;
-  margin: 0 auto;
   width: 100%;
 }
 

--- a/templates/components/random_screenshot.tpl
+++ b/templates/components/random_screenshot.tpl
@@ -4,9 +4,14 @@
 {assign var='rand_file' value=$rand_files[$rand_pos]}
 
 {capture "content"}
-<a href="{$smarty.const.DIR_SCREENSHOTS}/{$rand_file.filename}_full.png" title="{$rand_file.caption}">
-    <img class="random-screenshot" src="{$smarty.const.DIR_SCREENSHOTS}/{$rand_file.filename}_full.png" alt="{$rand_file.caption}">
-</a>
+<div class="image">
+    <a href="{$smarty.const.DIR_SCREENSHOTS}/{$rand_file.filename}_full.png" title="{$rand_file.caption}">
+        <img class="random-screenshot" src="{$smarty.const.DIR_SCREENSHOTS}/{$rand_file.filename}_full.png" alt="{$rand_file.caption}">
+    </a>
+</div>
+<div class="caption">
+    <a href="{$rand_file.url}">{$rand_file.caption}</a>
+</div>
 {/capture}
 {include file='components/roundbox.tpl' class="gallery" content=$smarty.capture.content}
 


### PR DESCRIPTION
The caption is a hyperlink that goes to the corresponding game page on https://www.scummvm.org/compatibility/ . This allows users to quickly look up compatibility info as well as see which platforms are supported.

## Before
<img width="1147" alt="Home Before" src="https://user-images.githubusercontent.com/6200170/159091466-dd38d22b-1183-444a-ac88-237dc11ad6bf.png">
<img width="1148" alt="Screenshots Before" src="https://user-images.githubusercontent.com/6200170/159091470-580caf80-0052-47aa-8d39-1a00d98f6268.png">

## After
<img width="1139" alt="Home After" src="https://user-images.githubusercontent.com/6200170/159091503-1f801275-4f81-4cb2-86c9-c0ad0e78f62a.png">
<img width="1138" alt="Screenshots After" src="https://user-images.githubusercontent.com/6200170/159091515-46230de2-ca8e-4a88-8db6-5b065c63ae9c.png">

