### PR TITLE
WEB: Sorting same version downloads by priority

### DIFF
--- a/include/Objects/DownloadsSection.php
+++ b/include/Objects/DownloadsSection.php
@@ -29,14 +29,14 @@ class DownloadsSection extends BasicSection
     {
         if ($item->getCategoryIcon()) {
             $this->items[] = new File($item->toArray(TableMap::TYPE_FIELDNAME), '');
-            // If this item is for an old version, sort all items by version, descending, then by autoId
+            // If this item is for an old version, sort all items by version, descending, then by priority
             if ($this->hasOldVersion($item)) {
                 usort($this->items, function ($a, $b) {
                     // Return 0 if equal, -1 if $a->version is larger, 1 if $b->version is larger
                     $versionSortResult = -version_compare($a->version, $b->version);
                     if ($versionSortResult == 0) {
-                        // Return 0 if equal, -1 if $a->autoId is smaller, 1 if $b->autoId is smaller
-                        return $a->autoId <=> $b->autoId;
+                        // Return 0 if equal, -1 if $a->priority is smaller, 1 if $b->priority is smaller
+                        return $a->priority <=> $b->priority;
                     } else {
                         return $versionSortResult;
                     }

--- a/include/Objects/File.php
+++ b/include/Objects/File.php
@@ -21,6 +21,7 @@ class File extends BasicObject
         $this->category = $data['category'];
         $this->category_icon = $data['category_icon'];
         $this->notes = isset($data['notes']) ? $data['notes'] : '';
+        $this->priority = $data['priority'];
         $this->subcategory = $data['subcategory'] ?? null;
         $this->user_agent = isset($data["user_agent"]) ? $data["user_agent"] : "";
         $this->version = isset($data['version']) ? strtolower($data['version']) : null;

--- a/schema.xml
+++ b/schema.xml
@@ -103,6 +103,7 @@
   <table name="scummvm_downloads" phpName="Download">
     <column name="name" type="varchar" size="255" required="true"/>
     <column name="notes" type="varchar" size="255"/>
+    <column name="priority" type="integer"/>
     <column name="subcategory" type="varchar" size="24" required="true"/>
     <column name="category" type="varchar" size="24" required="true"/>
     <column name="category_icon" type="varchar" size="24"/>


### PR DESCRIPTION
Uses a new "priority" field to sort downloads that have the same version number instead of an arbitrary order as before.

## Before

Note that the two Raspberry Pi and the two IRIX entries are separated.

<img width="631" alt="Before" src="https://user-images.githubusercontent.com/6200170/162336790-ff8fec05-0277-4ee1-9bb1-dd7332b3bed6.png">

## After

The two Raspberry Pi and two IRIX entries are now together.

<img width="625" alt="After" src="https://user-images.githubusercontent.com/6200170/162336837-c79bd278-1d9f-47ed-92ae-2888913f28b4.png">

