### PR TITLE
WEB: Display file sizes by powers of ten

### DIFF
--- a/include/FileUtils.php
+++ b/include/FileUtils.php
@@ -31,18 +31,19 @@ class FileUtils
     {
         $path = FileUtils::toAbsolutePathIfOnServer($path);
         // Get the file size, rounded to the nearest kilobyte
-        $file_size = round((@filesize($path) / 1024));
+        // Use powers of ten per IEC standard
+        $file_size = round((@filesize($path) / 1000));
         
-        if ($file_size < 1024) {
-            $file_size = $file_size . "K";
+        if ($file_size < 1000) {
+            $file_size = $file_size . " kB";
         } else {
-            $file_size /= 1024;
+            $file_size /= 1000;
 
-            if ($file_size < 1024) {
-                $file_size = round($file_size, 1) . "M";
+            if ($file_size < 1000) {
+                $file_size = round($file_size, 1) . " MB";
             } else {
-                $file_size /= 1024;
-                $file_size = round($file_size, 2) . "G";
+                $file_size /= 1000;
+                $file_size = round($file_size, 2) . " GB";
             }
         }
         return $file_size;


### PR DESCRIPTION
[Per IEC](https://en.wikipedia.org/wiki/Byte#Multiple-byte_units), kilobyte, megabyte, and gigabyte refer to units based on powers of ten (as opposed to powers of two, which are referred to as kibibyte, mebibyte, and gibibyte).

This is used by 

## Before

<img width="541" alt="image" src="https://user-images.githubusercontent.com/6200170/162599541-e29d8767-a4a5-4f3e-80b1-5ef48f328646.png">

## After

<img width="552" alt="image" src="https://user-images.githubusercontent.com/6200170/162599729-65a51839-4f4e-46ee-ab31-8e9436cef282.png">
