### PR TITLE
WEB: Adding "Available At" info to game compatibility pages

### DIFF
--- a/include/Constants.php
+++ b/include/Constants.php
@@ -32,6 +32,12 @@ class Constants
         }
         define('URL_BASE', $url);
 
+        /* External URLs */
+        define('GOG_URL_PREFIX', "https://www.gog.com/game/");
+        // ScummVM affiliate id
+        define('GOG_URL_SUFFIX', '?pp=22d200f8670dbdb3e253a90eee5098477c95c23d');
+        define('STEAM_URL_PREFIX', 'https://store.steampowered.com/app/');
+
         /* Paths */
         define('DIR_BASE', __DIR__  . '/..');
         define('DIR_DATA', DIR_BASE . '/data');

--- a/include/OrmObjects/Compatibility.php
+++ b/include/OrmObjects/Compatibility.php
@@ -69,6 +69,20 @@ class Compatibility extends BaseCompatibility
             $notes .= join("\n", $links);
         }
 
+        $availableSites = [];
+        $gogId = $this->getGame()->getGogId();
+        if ($gogId) {
+            $availableSites[] = "- [GOG.com](" . GOG_URL_PREFIX . $gogId . GOG_URL_SUFFIX . ") (affiliate link)";
+        }
+        $steamId = $this->getGame()->getSteamId();
+        if ($steamId) {
+            $availableSites[] = "- [Steam](" . STEAM_URL_PREFIX . $steamId. ")";
+        }
+        if ($availableSites) {
+            $notes .= "\n\n### Available At\n";
+            $notes .= join("\n", $availableSites);
+        }
+
         $config = \HTMLPurifier_Config::createDefault();
         $purifier = new \HTMLPurifier($config);
         $parsedown = new \Parsedown();

--- a/schema.xml
+++ b/schema.xml
@@ -10,6 +10,8 @@
     <column name="engine_id" type="varchar" size="24" required="true"/>
     <column name="company_id" type="varchar" size="24" required="true"/>
     <column name="moby_id" type="integer"/>
+    <column name="steam_id" type="integer"/>
+    <column name="gog_id" type="varchar"/>
     <column name="wikipedia_page" type="varchar"/>
     <column name="series_id" type="varchar"/>
     <foreign-key foreignTable="engine" onDelete="CASCADE">


### PR DESCRIPTION
This provides GOG.com and Steam links. In the future, we can expand this to additional websites, including free downloads from the developer sites.

## Before

<img width="646" alt="image" src="https://user-images.githubusercontent.com/6200170/168451395-adaaa09d-0ca6-40b4-9552-cd23e69a1afb.png">

## After

<img width="697" alt="image" src="https://user-images.githubusercontent.com/6200170/168451387-99b05c78-08a2-4c31-8d8e-8342980f6b61.png">