### PR TITLE
WEB: Removing SCUMM hacking forum link and moving AGI Development Site

### DIFF
--- a/data/en/links.yaml
+++ b/data/en/links.yaml
@@ -71,6 +71,11 @@
         operating systems. If you want to play a game that ScummVM doesn't
         support, this is the place to ask for help!
       url: 'https://www.vogons.org/'
+    - name: AGI Development Site
+      notes: >-
+        Large amounts of information surrounding Sierra's AGI system and home of
+        the NAGI AGI interpreter.
+      url: 'http://agiwiki.sierrahelp.com/'
     - name: 'MixNMojo :: The Purple LucasArts Fan Site'
       notes: >-
         MixNmojo is one of the longest running, and definitely largest,
@@ -99,19 +104,3 @@
         The personal blog of Ron Gilbert, the man behind many great LucasArts
         adventures, like Maniac Mansion and Monkey Island.
       url: 'https://grumpygamer.com/'
-- name: Technical information about SCUMM and other engines
-  notes: >-
-    SCUMM is a complex system that grew over many years. Understanding it can be
-    quite difficult at times. Therefore we tried to collect some information
-    about these engines in our <a href="http://wiki.scummvm.org">Wiki</a>. Sadly
-    not everything is in there. But there are other sites out there that provide
-    you with a bunch of information about some engines. Here are some of them.
-  links:
-    - name: SCUMM Hacking forum
-      notes: Information and discussion on resource formats used in LucasArts games.
-      url: 'https://forums.mixnmojo.com/forum/318-scumm/'
-    - name: AGI Development Site
-      notes: >-
-        Large amounts of information surrounding Sierra's AGI system and home of
-        the NAGI AGI interpreter.
-      url: 'http://agiwiki.sierrahelp.com/'


### PR DESCRIPTION
The SCUMM hacking forum is a sub-site of MixNMojo, which is already listed, and it's been archived for six years. I don't think we need a separate link.

Then with the AGI site being the only one in the category, I'm merging it with the larger category of external sites.

## Before

<img width="401" alt="image" src="https://user-images.githubusercontent.com/6200170/168672091-c6c9ad6d-2ee0-4466-a6aa-8d8971c66fb7.png">

## After

<img width="386" alt="image" src="https://user-images.githubusercontent.com/6200170/168672028-092be8ff-ae4b-433a-b41a-9cecd8428931.png">