### PR TITLE
WEB: Don't stretch menu banners

### DIFF
--- a/scss/base/_base.scss
+++ b/scss/base/_base.scss
@@ -52,11 +52,6 @@ a:hover {
 	display: block;
 }
 
-.banners a img {
-	width: 88px;
-	height: 37px;
-}
-
 #intro_header {
 	font-size: 0.9em;
 	line-height: 1.2213em;


### PR DESCRIPTION
For some reason the menu banners are vertically stretched. I assume it's some obsolete formatting, as there's no point in forcing an image size via CSS, so I removed that rule.

Before:
![image](https://user-images.githubusercontent.com/603444/168723461-fba94161-a65d-4325-b167-0659edd0ddb7.png)

After:
![image](https://user-images.githubusercontent.com/603444/168723500-e66433e5-9822-40ad-ac70-c9e899b15dc7.png)
