### PR TITLE
WEB: Removing "Updated" level from Compatibility legend

### DIFF
--- a/scss/pages/_compatibility.scss
+++ b/scss/pages/_compatibility.scss
@@ -22,7 +22,3 @@
 		background-color: adjust-hue(hsl(0, 100%, (66-$i) + 0%), $i * 4.5 * 5);
 	}
 }
-
-.updated {
-	background-color: cornflowerblue;
-}

--- a/templates/pages/compatibility.tpl
+++ b/templates/pages/compatibility.tpl
@@ -52,7 +52,6 @@
             {foreach from=$support_level_header key=level item=desc}
             <td class={$support_level_class.$level} align='center'>{$desc}</td>
             {/foreach}
-            <td class='updated' align='center'>Updated</td>
         </tr>
     </tbody>
 </table>
@@ -75,7 +74,7 @@
         <tr class="color{cycle values='2,0'}">
             <td class="gameFullName"><a href="{'/compatibility/'|lang}{$version}/{$game->getGame()->getId()}/">{$game->getGame()->getName()}</a></td>
             <td class="gameShortName">{$game->getGame()->getId()}</td>
-            <td class="gameSupportLevel {($game->getVersion() == $version) ? ' updated' : $pct_class}">{$support_level}</td>
+            <td class="gameSupportLevel {$pct_class}">{$support_level}</td>
         </tr>
         {/foreach}
     </tbody>


### PR DESCRIPTION
This seems to have been for some planned functionality to highlight recent changes, but it was never completed. Since it is unused, remove it.

## Before

<img width="1081" alt="image" src="https://user-images.githubusercontent.com/6200170/169895522-0a7dac7b-dc25-4d13-a2dc-fc22a3f94d77.png">

## After

<img width="1038" alt="image" src="https://user-images.githubusercontent.com/6200170/169895553-9c3bb318-2cb5-48eb-bc69-d2f25224e4ec.png">
