### PR TITLE
WEB: Adding tooltips to compatibility ratings

### DIFF
--- a/templates/pages/compatibility.tpl
+++ b/templates/pages/compatibility.tpl
@@ -50,7 +50,7 @@
     <tbody>
         <tr class="color2">
             {foreach from=$support_level_header key=level item=desc}
-            <td class={$support_level_class.$level} align='center'>{$desc}</td>
+            <td class={$support_level_class.$level} align='center' title="{$support_level_description.$level}">{$desc}</td>
             {/foreach}
         </tr>
     </tbody>
@@ -71,10 +71,11 @@
         {assign var="x" value=$game->getSupport()}
         {assign var="pct_class" value=$support_level_class.$x}
         {assign var="support_level" value=$support_level_header.$x}
+        {assign var="support_level_desc" value=$support_level_description.$x}
         <tr class="color{cycle values='2,0'}">
             <td class="gameFullName"><a href="{'/compatibility/'|lang}{$version}/{$game->getGame()->getId()}/">{$game->getGame()->getName()}</a></td>
             <td class="gameShortName">{$game->getGame()->getId()}</td>
-            <td class="gameSupportLevel {$pct_class}">{$support_level}</td>
+            <td class="gameSupportLevel {$pct_class}" title="{$support_level_desc}">{$support_level}</td>
         </tr>
         {/foreach}
     </tbody>


### PR DESCRIPTION
Hovering over the compatibility ratings will now show a tooltip with the compatibility rating's description.

<img width="634" alt="Tooltip Legend" src="https://user-images.githubusercontent.com/6200170/171056376-65bc80cf-b381-4b75-9c9b-1b19a87ef17b.png">

<img width="835" alt="Tooltip Table" src="https://user-images.githubusercontent.com/6200170/171056384-b6aa0d26-6451-4fdd-b249-338a0203e6bb.png">

