### PR TITLE
WEB: Displaying file sizes as MiB etc

### DIFF
--- a/include/FileUtils.php
+++ b/include/FileUtils.php
@@ -34,15 +34,15 @@ class FileUtils
         $file_size = round((@filesize($path) / 1024));
         
         if ($file_size < 1024) {
-            $file_size = $file_size . "K";
+            $file_size = $file_size . " KiB";
         } else {
             $file_size /= 1024;
 
             if ($file_size < 1024) {
-                $file_size = round($file_size, 1) . "M";
+                $file_size = round($file_size, 1) . " MiB";
             } else {
                 $file_size /= 1024;
-                $file_size = round($file_size, 2) . "G";
+                $file_size = round($file_size, 2) . " GiB";
             }
         }
         return $file_size;


### PR DESCRIPTION
This is a result of the discussion from PR #230 where the consensus was that the consistent and accurate, if inconvenient, units (KiB, MiB, GiB) were preferred over the ambiguous units (kB, MB, GB).

## Before

<img width="541" alt="image" src="https://user-images.githubusercontent.com/6200170/162599541-e29d8767-a4a5-4f3e-80b1-5ef48f328646.png">

## After

<img width="573" alt="image" src="https://user-images.githubusercontent.com/6200170/171057044-10a6a2d0-7eff-46b3-8139-1153841f551d.png">
