### PR TITLE
WEB: Adding link to The Fat Man remastered soundtracks

### DIFF
--- a/data/en/links.yaml
+++ b/data/en/links.yaml
@@ -45,6 +45,11 @@
     The following are links to projects that modify games in ways that were not possible in the original game engines,
     but are possible now thanks to ScummVM.
   links:
+    - name: Remastered Soundtracks by The Fat Man and Team Fat
+      notes: >-
+        ScummVM-compatible music sets by the original composer of several supported games, inlcuding instructions on 
+        how to hear the remastered music while playing.
+      url: 'https://thefatmanandteamfat.bandcamp.com'
     - name: The Longest Journey HD
       notes: >-
         A mod that includes neural network upscaled backgrounds and sprites, redrawn user interface and a lot of other 


### PR DESCRIPTION
Adds a link to [the remastered soundtracks of The Fat Man](https://thefatmanandteamfat.bandcamp.com).

## Before
<img width="679" alt="image" src="https://user-images.githubusercontent.com/6200170/174672990-1d76cd07-ff9c-4b02-9fc2-ad6ab3c7bccd.png">

## After
<img width="687" alt="image" src="https://user-images.githubusercontent.com/6200170/174672963-aef5d14c-0954-4a55-bf1e-ca07edb4084d.png">
