### PR TITLE
Dumper companion: more Mac extensions

### DIFF
--- a/dumper-companion/src/Dumper.tsx
+++ b/dumper-companion/src/Dumper.tsx
@@ -42,7 +42,7 @@ export default class Dumper extends Component<Props, State> {
 
                 <div>
                     <p>Select the game's disk image:</p>
-                    <input disabled={this.state.busy} class="file" type="file" accept=".dsk,.image,.img,.iso,.toast" onInput={this.handleImage.bind(this)}/>
+                    <input disabled={this.state.busy} class="file" type="file" accept=".dsk,.image,.img,.iso,.toast,.cdr,.diskcopy,.dcpy" onInput={this.handleImage.bind(this)}/>
                 </div>
 
                 <div>


### PR DESCRIPTION
I was working with a `.cdr` file today, and realized that several Mac-specific file extensions were missing.