### PR TITLE
DATA: Add an old 1.6.0 download for OS X 10.3+

### DIFF
--- a/data/en/scummvm_downloads.yaml
+++ b/data/en/scummvm_downloads.yaml
@@ -233,6 +233,16 @@
     enabled: true
     category: scummvm
     subcategory: old
+    category_icon: macosppc
+    user_agent: ''
+    version: 1.6.0
+    url: 'scummvm-{$version}-macosx.dmg'
+    name: 'Mac OS X 10.3+ PPC/Intel 32 bits (without Sparkle) Disk Image'
+    notes: ''
+-
+    enabled: true
+    category: scummvm
+    subcategory: old
     category_icon: fedora
     user_agent: ''
     version: 1.6.0
@@ -347,7 +357,7 @@
     user_agent: ''
     version: 2.6.0
     url: 'scummvm-{$version}-macosx-i386.dmg'
-    name: 'Mac OS X 10.6+ intel 32 bits (without Sparkle) Disk Image'
+    name: 'Mac OS X 10.6+ Intel 32 bits (without Sparkle) Disk Image'
     notes: ''
 -
     enabled: true


### PR DESCRIPTION
The current 2.6.0 download for older OS X PowerPC systems requires 10.4 (since there is no easy way to build a C++11 toolchain on older versions), but some retro G3 systems can't run anything newer than OS X 10.3.9, and so some users are looking for a 10.3-compatible release.

User loudmind said on Discord on 2022-08-25 that ScummVM 1.6.0 worked on an old tangerine clamshell iBook from 2000 (this build also has an i386 layer). I can't personally test it, and maybe some later version also works on 10.3, but suggesting ScummVM 1.6.0 for 10.3 users is probably the most helpful thing we can do for now.