### PR TITLE
WEB: Adding engine to compatibility page

### DIFF
--- a/data/en/strings.json
+++ b/data/en/strings.json
@@ -15,6 +15,7 @@
   "compatibilityDetailsChartTitle": "Game Compatibility Chart",
   "compatibilityDetailsChartColGameFullName": "Game Full Name",
   "compatibilityDetailsChartColGameShortName": "Game Short Name",
+  "compatibilityDetailsChartColGameEngine": "Engine",
   "compatibilityDetailsChartColSupportLevel": "Support Level",
   "compatibilityDetailsDetails": "Details",
   "compatibilityDetailsBack": "« Back",

--- a/scss/pages/_compatibility.scss
+++ b/scss/pages/_compatibility.scss
@@ -6,6 +6,7 @@
 }
 
 .gameSupportLevel,
+.gameEngine,
 .gameShortName,
 .gameDatafiles {
 	width: 15%;

--- a/templates/components/compatibility_details.tpl
+++ b/templates/components/compatibility_details.tpl
@@ -9,6 +9,7 @@
     <thead>
         <tr class="color4">
             <th>{#compatibilityDetailsChartColGameFullName#}</th>
+            <th>{#compatibilityDetailsChartColGameEngine#}</th>
             <th>{#compatibilityDetailsChartColGameShortName#}</th>
             <th>{#compatibilityDetailsChartColSupportLevel#}</th>
         </tr>
@@ -16,11 +17,12 @@
     <tbody>
         <tr class="color0">
             <td>{$game->getGame()->getName()}</td>
+            <td>{$game->getGame()->getEngineId()}</td>
             <td>{$game->getGame()->getId()}</td>
             <td align="center" class="{$pct_class}">{$support_level}</td>
         </tr>
         <tr class="color2">
-            <td colspan="3" class="details">
+            <td colspan="4" class="details">
                 {$game->getNotes()|regex_replace:"/%.+%/":$support_description}
             </td>
         </tr>

--- a/templates/pages/compatibility.tpl
+++ b/templates/pages/compatibility.tpl
@@ -62,6 +62,7 @@
     <thead>
         <tr class="color4">
             <th class="gameFullName">{#compatibilityDetailsChartColGameFullName#}</th>
+            <th class="gameEngine">{#compatibilityDetailsChartColGameEngine#}</th>
             <th class="gameShortName">{#compatibilityDetailsChartColGameShortName#}</th>
             <th class="gameSupportLevel">{#compatibilityDetailsChartColSupportLevel#}</th>
         </tr>
@@ -74,6 +75,7 @@
         {assign var="support_level_desc" value=$support_level_description.$x}
         <tr class="color{cycle values='2,0'}">
             <td class="gameFullName"><a href="{'/compatibility/'|lang}{$version}/{$game->getGame()->getId()}/">{$game->getGame()->getName()}</a></td>
+            <td class="gameEngine">{$game->getGame()->getEngineId()}</td>
             <td class="gameShortName">{$game->getGame()->getId()}</td>
             <td class="gameSupportLevel {$pct_class}" title="{$support_level_desc}">{$support_level}</td>
         </tr>


### PR DESCRIPTION
Adds an "Engine" column to the game compatibility info.

## Before

<img width="1043" alt="image" src="https://user-images.githubusercontent.com/6200170/193430991-a8583333-022d-4d7f-8336-bb0eb5a09a9e.png">

<img width="1124" alt="image" src="https://user-images.githubusercontent.com/6200170/193431012-f9a406ca-e149-4e9c-be5b-0527a5cd6981.png">

## After

<img width="1045" alt="image" src="https://user-images.githubusercontent.com/6200170/193430981-e06352b2-06d2-4ef2-ac90-7bf42fb8987c.png">

<img width="1129" alt="image" src="https://user-images.githubusercontent.com/6200170/193431029-8db1fc2b-df81-4178-b5af-0dfd9d5d0ec8.png">
