### PR TITLE
WEB: Adding "ScummVM ID" to compatibility page

### DIFF
--- a/data/en/strings.json
+++ b/data/en/strings.json
@@ -14,7 +14,7 @@
   "compatibilityDetailsInto": "Game compatibility details",
   "compatibilityDetailsChartTitle": "Game Compatibility Chart",
   "compatibilityDetailsChartColGameFullName": "Game Full Name",
-  "compatibilityDetailsChartColGameShortName": "Game Short Name",
+  "compatibilityDetailsChartColScummVmId": "ScummVM ID",
   "compatibilityDetailsChartColSupportLevel": "Support Level",
   "compatibilityDetailsDetails": "Details",
   "compatibilityDetailsBack": "« Back",

--- a/include/OrmObjects/Compatibility.php
+++ b/include/OrmObjects/Compatibility.php
@@ -27,6 +27,17 @@ class Compatibility extends BaseCompatibility
         return $retVal;
     }
 
+    public function getScummVmId($version)
+    {
+        if ($version == "DEV" || version_compare($version, "2.2.0") > 0) {
+            // If version is > 2.2.0, return engine_id:game_id
+            return $this->getGame()->getEngineId() . ":" . $this->getGame()->getId();
+        } else {
+            // If version is <= 2.2.0, return the game_id
+            return $this->getGame()->getId();
+        }
+    }
+
     public function getNotes()
     {
         $notes = "### Support Level\n\n";

--- a/scss/pages/_compatibility.scss
+++ b/scss/pages/_compatibility.scss
@@ -5,9 +5,12 @@
 	}
 }
 
-.gameSupportLevel,
-.gameShortName,
-.gameDatafiles {
+.gameScummVmId {
+	width: 20%;
+	text-align: center;
+}
+
+.gameSupportLevel {
 	width: 15%;
 	text-align: center;
 }

--- a/templates/components/compatibility_details.tpl
+++ b/templates/components/compatibility_details.tpl
@@ -9,15 +9,15 @@
     <thead>
         <tr class="color4">
             <th>{#compatibilityDetailsChartColGameFullName#}</th>
-            <th>{#compatibilityDetailsChartColGameShortName#}</th>
+            <th>{#compatibilityDetailsChartColScummVmId#}</th>
             <th>{#compatibilityDetailsChartColSupportLevel#}</th>
         </tr>
     </thead>
     <tbody>
         <tr class="color0">
-            <td>{$game->getGame()->getName()}</td>
-            <td>{$game->getGame()->getId()}</td>
-            <td align="center" class="{$pct_class}">{$support_level}</td>
+            <td class="gameFullName">{$game->getGame()->getName()}</td>
+            <td class="gameScummVmId">{$game->getScummVmId($version)}</td>
+            <td class="gameSupportLevel {$pct_class}">{$support_level}</td>
         </tr>
         <tr class="color2">
             <td colspan="3" class="details">

--- a/templates/pages/compatibility.tpl
+++ b/templates/pages/compatibility.tpl
@@ -62,7 +62,7 @@
     <thead>
         <tr class="color4">
             <th class="gameFullName">{#compatibilityDetailsChartColGameFullName#}</th>
-            <th class="gameShortName">{#compatibilityDetailsChartColGameShortName#}</th>
+            <th class="gameScummVmId">{#compatibilityDetailsChartColScummVmId#}</th>
             <th class="gameSupportLevel">{#compatibilityDetailsChartColSupportLevel#}</th>
         </tr>
     </thead>
@@ -74,7 +74,7 @@
         {assign var="support_level_desc" value=$support_level_description.$x}
         <tr class="color{cycle values='2,0'}">
             <td class="gameFullName"><a href="{'/compatibility/'|lang}{$version}/{$game->getGame()->getId()}/">{$game->getGame()->getName()}</a></td>
-            <td class="gameShortName">{$game->getGame()->getId()}</td>
+            <td class="gameScummVmId">{$game->getScummVmId($version)}</td>
             <td class="gameSupportLevel {$pct_class}" title="{$support_level_desc}">{$support_level}</td>
         </tr>
         {/foreach}


### PR DESCRIPTION
This replaces "Game Short Name". When a version newer than 2.2.0 is displayed, the id will be in the format of `engine_id:game_id`. If version 2.2.0 or later is displayed, the id will be in the format of `game_id`.

## Table (Version > 2.2.0)

### Before

<img width="861" alt="Before 260 Table" src="https://user-images.githubusercontent.com/6200170/193433476-369fb453-7c6a-45f9-9130-edc8fc37f1e5.png">

### After

<img width="831" alt="After 260 Table" src="https://user-images.githubusercontent.com/6200170/193433479-02cb4e65-812e-485b-8b35-0defe9ab1eb2.png">

## Details  (Version > 2.2.0)

### Before

<img width="878" alt="Before 260 Detail" src="https://user-images.githubusercontent.com/6200170/193433485-a3b37d1c-f275-41b1-a9f9-dd08bdbe9c9d.png">

### After

<img width="873" alt="After 260 Detail" src="https://user-images.githubusercontent.com/6200170/193433490-8f89dd09-37d3-4714-93a6-007a659dc316.png">

## Table (Version <= 2.2.0)

### Before

<img width="852" alt="Before 220 Table" src="https://user-images.githubusercontent.com/6200170/193433412-492ea4c1-8ee3-4feb-baab-5af1ac0dd705.png">

### After

<img width="841" alt="After 220 Table" src="https://user-images.githubusercontent.com/6200170/193433431-ec55ddf3-d095-4295-80ef-019aab5a087f.png">

## Details  (Version <= 2.2.0)

### Before

<img width="873" alt="Before 220 Detail" src="https://user-images.githubusercontent.com/6200170/193433417-9353c416-4a3e-4f5d-ac4b-215d43210832.png">

### After

<img width="872" alt="After 220 Detail" src="https://user-images.githubusercontent.com/6200170/193433453-ae11c991-7252-4b75-b845-c51cd5fa6c68.png">
