### PR TITLE
WEB: Redirecting to compatibility page when no game id exists

### DIFF
--- a/include/Pages/CompatibilityPage.php
+++ b/include/Pages/CompatibilityPage.php
@@ -78,6 +78,12 @@ class CompatibilityPage extends Controller
     public function getGame($target, $version)
     {
         $game = $this->compatibilityModel->getGameData($version, $target);
+        // Redirect to main compatibility page if the requested game doesn't exist
+        if ($game->getId() === null) {
+            // TODO make this more resilient with support for languages and local domains
+            header('Location: https://scummvm.org/compatibility', true, 307);
+            die();
+        }
 
         $this->template = 'components/compatibility_details.tpl';
 


### PR DESCRIPTION
Part of the migration to using full game ids (i.e. `monkey` becomes `scumm:monkey`).

## Before

https://www.scummvm.org/compatibility/DEV/foobar/ results in an error page

## After

https://www.scummvm.org/compatibility/DEV/foobar/ redirects to https://www.scummvm.org/compatibility