### PR TITLE
WEB: Using full game id across the site

### DIFF
--- a/data/en/compatibility.yaml
+++ b/data/en/compatibility.yaml
@@ -1,4766 +1,4766 @@
 # This is a generated file, please do not edit manually
 -
-    id: amazon
+    id: 'access:amazon'
     support: untested
     notes: '- Demo version is not supported'
     since_version: 1.8.0
     stable_platforms: dos
     unstable_platforms: dos
 -
-    id: amazon
+    id: 'access:amazon'
     support: good
     notes: ''
     since_version: 2.1.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: amazon
+    id: 'access:amazon'
     support: good
     notes: '- English and Spanish versions supported'
     since_version: 2.5.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: hires0
+    id: 'adl:hires0'
     support: good
     notes: ''
     since_version: 1.9.0
     stable_platforms: apple2
     unstable_platforms: ''
 -
-    id: hires1
+    id: 'adl:hires1'
     support: good
     notes: ''
     since_version: 1.9.0
     stable_platforms: apple2
     unstable_platforms: ''
 -
-    id: hires2
+    id: 'adl:hires2'
     support: good
     notes: ''
     since_version: 1.9.0
     stable_platforms: apple2
     unstable_platforms: ''
 -
-    id: hires3
+    id: 'adl:hires3'
     support: good
     notes: ''
     since_version: 2.0.0
     stable_platforms: apple2
     unstable_platforms: ''
 -
-    id: hires4
+    id: 'adl:hires4'
     support: good
     notes: ''
     since_version: 2.0.0
     stable_platforms: apple2
     unstable_platforms: ''
 -
-    id: hires5
+    id: 'adl:hires5'
     support: good
     notes: ''
     since_version: 2.0.0
     stable_platforms: apple2
     unstable_platforms: ''
 -
-    id: hires6
+    id: 'adl:hires6'
     support: good
     notes: ''
     since_version: 2.0.0
     stable_platforms: apple2
     unstable_platforms: ''
 -
-    id: bc
+    id: 'agi:bc'
     support: good
     notes: '- Apple IIgs version has no sound'
     since_version: 0.10.0
     stable_platforms: 'amiga,apple2gs,coco3,dos'
     unstable_platforms: ''
 -
-    id: bc
+    id: 'agi:bc'
     support: good
     notes: ''
     since_version: 1.9.0
     stable_platforms: 'amiga,apple2gs,coco3,dos'
     unstable_platforms: ''
 -
-    id: ddp
+    id: 'agi:ddp'
     support: good
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'amiga,atarist,pcbooter'
     unstable_platforms: 'apple2,c64,coco'
 -
-    id: goldrush
+    id: 'agi:goldrush'
     support: broken
     notes: '- Apple IIgs version has no sound'
     since_version: 0.10.0
     stable_platforms: 'apple2gs,atarist,coco3,dos,mac'
     unstable_platforms: amiga
 -
-    id: goldrush
+    id: 'agi:goldrush'
     support: good
     notes: '- Apple IIgs version has no sound'
     since_version: 0.11.0
     stable_platforms: 'apple2gs,atarist,coco3,dos,mac'
     unstable_platforms: amiga
 -
-    id: goldrush
+    id: 'agi:goldrush'
     support: good
     notes: '- Apple IIgs version has no sound'
     since_version: 0.12.0
     stable_platforms: 'amiga,apple2gs,atarist,coco3,dos,mac'
     unstable_platforms: ''
 -
-    id: goldrush
+    id: 'agi:goldrush'
     support: good
     notes: ''
     since_version: 1.9.0
     stable_platforms: 'amiga,apple2gs,atarist,coco3,dos,mac'
     unstable_platforms: ''
 -
-    id: kq1
+    id: 'agi:kq1'
     support: good
     notes: '- Apple IIgs version has no sound'
     since_version: 0.10.0
     stable_platforms: 'amiga,apple2gs,atarist,coco3,dos,mac'
     unstable_platforms: ''
 -
-    id: kq1
+    id: 'agi:kq1'
     support: good
     notes: ''
     since_version: 1.9.0
     stable_platforms: 'amiga,apple2gs,atarist,coco3,dos,mac'
     unstable_platforms: ''
 -
-    id: kq2
+    id: 'agi:kq2'
     support: good
     notes: '- Apple IIgs version has no sound'
     since_version: 0.10.0
     stable_platforms: 'amiga,apple2gs,coco3,dos,mac'
     unstable_platforms: ''
 -
-    id: kq2
+    id: 'agi:kq2'
     support: good
     notes: ''
     since_version: 1.9.0
     stable_platforms: 'amiga,apple2gs,coco3,dos,mac'
     unstable_platforms: ''
 -
-    id: kq2
+    id: 'agi:kq2'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'amiga,apple2gs,coco3,dos,mac'
     unstable_platforms: ''
 -
-    id: kq3
+    id: 'agi:kq3'
     support: good
     notes: '- Apple IIgs version has no sound'
     since_version: 0.10.0
     stable_platforms: 'amiga,apple2gs,atarist,coco3,dos,mac'
     unstable_platforms: ''
 -
-    id: kq3
+    id: 'agi:kq3'
     support: good
     notes: ''
     since_version: 1.9.0
     stable_platforms: 'amiga,apple2gs,atarist,coco3,dos,mac'
     unstable_platforms: ''
 -
-    id: kq4
+    id: 'agi:kq4'
     support: good
     notes: '- Apple IIgs version has no sound'
     since_version: 0.10.0
     stable_platforms: 'apple2gs,coco3,dos'
     unstable_platforms: ''
 -
-    id: kq4
+    id: 'agi:kq4'
     support: good
     notes: ''
     since_version: 1.9.0
     stable_platforms: 'apple2gs,coco3,dos'
     unstable_platforms: ''
 -
-    id: lsl1
+    id: 'agi:lsl1'
     support: good
     notes: '- Apple IIgs version has no sound'
     since_version: 0.10.0
     stable_platforms: 'amiga,apple2gs,atarist,coco3,dos,mac'
     unstable_platforms: ''
 -
-    id: lsl1
+    id: 'agi:lsl1'
     support: good
     notes: ''
     since_version: 1.9.0
     stable_platforms: 'amiga,apple2gs,atarist,coco3,dos,mac'
     unstable_platforms: ''
 -
-    id: mh1
+    id: 'agi:mh1'
     support: good
     notes: '- Apple IIgs version has no sound'
     since_version: 0.10.0
     stable_platforms: 'amiga,apple2gs,atarist,coco3,dos'
     unstable_platforms: ''
 -
-    id: mh1
+    id: 'agi:mh1'
     support: good
     notes: ''
     since_version: 1.9.0
     stable_platforms: 'amiga,apple2gs,atarist,coco3,dos'
     unstable_platforms: ''
 -
-    id: mh2
+    id: 'agi:mh2'
     support: good
     notes: '- Apple IIgs version has no sound'
     since_version: 0.10.0
     stable_platforms: 'amiga,atarist,coco3,dos'
     unstable_platforms: ''
 -
-    id: mh2
+    id: 'agi:mh2'
     support: good
     notes: ''
     since_version: 1.9.0
     stable_platforms: 'amiga,atarist,coco3,dos'
     unstable_platforms: ''
 -
-    id: mickey
+    id: 'agi:mickey'
     support: good
     notes: ''
     since_version: 0.11.0
     stable_platforms: dos
     unstable_platforms: coco
 -
-    id: mixedup
+    id: 'agi:mixedup'
     support: good
     notes: '- Apple IIgs version has no sound'
     since_version: 0.10.0
     stable_platforms: 'apple2gs,coco3,dos'
     unstable_platforms: ''
 -
-    id: mixedup
+    id: 'agi:mixedup'
     support: good
     notes: ''
     since_version: 1.9.0
     stable_platforms: 'apple2gs,coco3,dos'
     unstable_platforms: ''
 -
-    id: pq1
+    id: 'agi:pq1'
     support: good
     notes: '- Apple IIgs version has no sound'
     since_version: 0.10.0
     stable_platforms: 'amiga,apple2gs,coco3,dos,mac'
     unstable_platforms: ''
 -
-    id: pq1
+    id: 'agi:pq1'
     support: good
     notes: ''
     since_version: 1.9.0
     stable_platforms: 'amiga,apple2gs,coco3,dos,mac'
     unstable_platforms: ''
 -
-    id: qfg1
+    id: 'agi:qfg1'
     support: excellent
     notes: '- Music in the Amiga versions may have glitches'
     since_version: 1.2.0
     stable_platforms: 'amiga,atarist,dos,pc98'
     unstable_platforms: ''
 -
-    id: sq1
+    id: 'agi:sq1'
     support: good
     notes: '- Apple IIgs version has no sound'
     since_version: 0.10.0
     stable_platforms: 'amiga,apple2gs,atarist,coco3,dos,mac'
     unstable_platforms: ''
 -
-    id: sq1
+    id: 'agi:sq1'
     support: good
     notes: ''
     since_version: 1.9.0
     stable_platforms: 'amiga,apple2gs,atarist,coco3,dos,mac'
     unstable_platforms: ''
 -
-    id: sq2
+    id: 'agi:sq2'
     support: good
     notes: '- Apple IIgs version has no sound'
     since_version: 0.10.0
     stable_platforms: 'amiga,apple2gs,atarist,coco3,dos,mac'
     unstable_platforms: ''
 -
-    id: sq2
+    id: 'agi:sq2'
     support: good
     notes: ''
     since_version: 1.9.0
     stable_platforms: 'amiga,apple2gs,atarist,coco3,dos,mac'
     unstable_platforms: ''
 -
-    id: troll
+    id: 'agi:troll'
     support: good
     notes: '- Game lacks sound'
     since_version: 0.11.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: winnie
+    id: 'agi:winnie'
     support: good
     notes: '- Game lacks sound'
     since_version: 0.11.0
     stable_platforms: 'amiga,apple2,c64,dos'
     unstable_platforms: coco
 -
-    id: winnie
+    id: 'agi:winnie'
     support: good
     notes: ''
     since_version: 1.4.0
     stable_platforms: 'amiga,apple2,c64,dos'
     unstable_platforms: coco
 -
-    id: dimp
+    id: 'agos:dimp'
     support: good
     notes: '- Demon takes longer to die, compared to original'
     since_version: 0.10.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: elvira1
+    id: 'agos:elvira1'
     support: good
     notes: '- Commodore 64 version doesn''t use AGOS. - No music in the Atari ST version. - No text descriptions in the Atari ST version.'
     since_version: 0.11.0
     stable_platforms: 'amiga,atarist,dos'
     unstable_platforms: c64
 -
-    id: elvira1
+    id: 'agos:elvira1'
     support: good
     notes: '- Commodore 64 version doesn''t use AGOS - No music in the Atari ST version'
     since_version: 0.13.0
     stable_platforms: 'amiga,atarist,dos'
     unstable_platforms: c64
 -
-    id: elvira1
+    id: 'agos:elvira1'
     support: good
     notes: ''
     since_version: 2.5.0
     stable_platforms: 'amiga,atarist,dos,pc98'
     unstable_platforms: c64
 -
-    id: elvira2
+    id: 'agos:elvira2'
     support: good
     notes: '- Commodore 64 version doesn''t use AGOS. - No music in the Atari ST version. - No sound effects in the DOS version. - Palette issues in the Atari ST version.'
     since_version: 0.11.0
     stable_platforms: 'amiga,atarist,dos'
     unstable_platforms: c64
 -
-    id: elvira2
+    id: 'agos:elvira2'
     support: good
     notes: '- Commodore 64 version doesn''t use AGOS - No music in the Atari ST version. - No sound effects in the DOS version.'
     since_version: 1.0.0
     stable_platforms: 'amiga,atarist,dos'
     unstable_platforms: c64
 -
-    id: feeble
+    id: 'agos:feeble'
     support: excellent
     notes: '- DOS version is demo only - Minor graphical glitches'
     since_version: 0.9.0
     stable_platforms: 'amiga,dos,mac,win'
     unstable_platforms: ''
 -
-    id: feeble
+    id: 'agos:feeble'
     support: excellent
     notes: '- DOS version is demo only'
     since_version: 0.10.0
     stable_platforms: 'amiga,dos,mac,win'
     unstable_platforms: ''
 -
-    id: jumble
+    id: 'agos:jumble'
     support: good
     notes: '- No support for displaying, entering, loading and saving high scores'
     since_version: 0.10.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: pn
+    id: 'agos:pn'
     support: untested
     notes: '- Minor spacing glitches with charset - No day to night fading in Amiga and Atari ST versions'
     since_version: 1.3.0
     stable_platforms: 'amiga,atarist,dos'
     unstable_platforms: ''
 -
-    id: pn
+    id: 'agos:pn'
     support: good
     notes: '- Minor spacing glitches with charset - No day to night fading in Amiga and Atari ST versions'
     since_version: 2.1.0
     stable_platforms: 'amiga,atarist,dos'
     unstable_platforms: ''
 -
-    id: puzzle
+    id: 'agos:puzzle'
     support: good
     notes: '- No support for displaying, entering, loading and saving high scores'
     since_version: 0.10.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: simon1
+    id: 'agos:simon1'
     support: excellent
     notes: ''
     since_version: 0.2.0
     stable_platforms: win
     unstable_platforms: 'amiga,amigacd32,acorn,dos'
 -
-    id: simon1
+    id: 'agos:simon1'
     support: excellent
     notes: '- Minor graphical glitches when using ring  - Minor graphical glitch with Sordid statue after leaving room - DOS issues    - Freezes briefly when Swampling leaves his house    - Freezes briefly when talking to demons in Sordid''s Tower   - No inventory scrolling arrows shown, can still move around inventory though'
     since_version: 0.3.0
     stable_platforms: 'acorn,dos,win'
     unstable_platforms: 'amiga,amigacd32'
 -
-    id: simon1
+    id: 'agos:simon1'
     support: excellent
     notes: '- Minor graphical glitches when using ring  - Minor graphical glitch with Sordid statue after leaving room - Amiga issues:   - All graphics are decoded incorrectly    - pkd compression format is unknown (CD)   - No music - DOS issues    - Freezes briefly when Swampling leaves his house    - Freezes briefly when talking to demons in Sordid''s Tower   - No inventory scrolling arrows shown, can still move around inventory though'
     since_version: 0.4.0
     stable_platforms: 'acorn,dos,win'
     unstable_platforms: 'amiga,amigacd32'
 -
-    id: simon1
+    id: 'agos:simon1'
     support: excellent
     notes: '- Acorn Disk version not supported - Minor palette glitches in Amiga versions'
     since_version: 0.6.0
     stable_platforms: 'acorn,dos,win'
     unstable_platforms: amiga
 -
-    id: simon1
+    id: 'agos:simon1'
     support: excellent
     notes: '- No music in Acorn disk version - Minor palette glitches in Amiga versions'
     since_version: 0.10.0
     stable_platforms: 'acorn,amiga,dos,win'
     unstable_platforms: ''
 -
-    id: simon1
+    id: 'agos:simon1'
     support: excellent
     notes: '- No music in Acorn disk version'
     since_version: 0.12.0
     stable_platforms: 'acorn,amiga,dos,win'
     unstable_platforms: ''
 -
-    id: simon2
+    id: 'agos:simon2'
     support: excellent
     notes: '- Various minor graphical glitches - Text in Copy Protection screen is only shown for short time - Freezes briefly when Pirate Captain is talking to Mate, when Simon tries to escape - Some music is missing or wrong'
     since_version: 0.3.0
     stable_platforms: 'dos,win'
     unstable_platforms: 'amiga,mac'
 -
-    id: simon2
+    id: 'agos:simon2'
     support: excellent
     notes: '- Minor graphical glitch when giving items to baby - Text in Copy Protection screen is only shown for short time - Freezes briefly when Pirate Captain is talking to Mate, when Simon tries to escape - Some music is missing or wrong - F10 key animation is different in Amiga & Macintosh versions'
     since_version: 0.4.0
     stable_platforms: 'dos,amiga,mac,win'
     unstable_platforms: ''
 -
-    id: simon2
+    id: 'agos:simon2'
     support: excellent
     notes: '- Minor graphical glitch when giving items to baby - Text in Copy Protection screen is only shown for short time - Freezes briefly when Pirate Captain is talking to Mate, when Simon tries to escape - F10 key animation is different in Amiga & Macintosh versions'
     since_version: 0.4.1
     stable_platforms: 'dos,amiga,mac,win'
     unstable_platforms: ''
 -
-    id: simon2
+    id: 'agos:simon2'
     support: excellent
     notes: '- Text in Copy Protection screen is only shown for short time - Freezes briefly when Pirate Captain is talking to Mate, when Simon tries to escape - F10 key animation is different in Amiga & Macintosh versions'
     since_version: 0.5.0
     stable_platforms: 'dos,amiga,mac,win'
     unstable_platforms: ''
 -
-    id: simon2
+    id: 'agos:simon2'
     support: excellent
     notes: '- F10 key animation is different in Amiga & Macintosh versions'
     since_version: 0.6.0
     stable_platforms: 'dos,amiga,mac,win'
     unstable_platforms: ''
 -
-    id: simon2
+    id: 'agos:simon2'
     support: excellent
     notes: '- Only the default language (English) in Amiga & Macintosh versions is supported - F10 key animation is different in Amiga & Macintosh versions'
     since_version: 0.7.0
     stable_platforms: 'dos,amiga,mac,win'
     unstable_platforms: ''
 -
-    id: swampy
+    id: 'agos:swampy'
     support: good
     notes: '- No support for displaying explanation, when clicking on items - No support for displaying, entering, loading and saving high scores'
     since_version: 0.10.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: waxworks
+    id: 'agos:waxworks'
     support: untested
     notes: '- Amiga version has not been confirmed as completable. '
     since_version: 0.11.0
     stable_platforms: amiga
     unstable_platforms: dos
 -
-    id: waxworks
+    id: 'agos:waxworks'
     support: untested
     notes: '- Amiga version has not been confirmed as completable. - DOS version doesn''t load or save items states correctly, leading to various bugs - No music in the DOS version.'
     since_version: 0.12.0
     stable_platforms: 'amiga,dos'
     unstable_platforms: ''
 -
-    id: waxworks
+    id: 'agos:waxworks'
     support: untested
     notes: '- Amiga version has not been confirmed as completable. - DOS version doesn''t load or save items states correctly, leading to various bugs'
     since_version: 1.0.0
     stable_platforms: 'amiga,dos'
     unstable_platforms: ''
 -
-    id: waxworks
+    id: 'agos:waxworks'
     support: good
     notes: '- Amiga version has not been confirmed as completable. - DOS version doesn''t load or save items states correctly, leading to various bugs'
     since_version: 2.1.0
     stable_platforms: 'amiga,dos'
     unstable_platforms: ''
 -
-    id: ags
+    id: 'ags:ags'
     support: good
     notes: '- Only AGS games 2.5 and after are supported'
     since_version: 2.5.0
     stable_platforms: 'win,linux,mac,android,ios'
     unstable_platforms: ''
 -
-    id: blackwell1
+    id: 'ags:blackwell1'
     support: good
     notes: ''
     since_version: 2.5.0
     stable_platforms: 'win,mac'
     unstable_platforms: ''
 -
-    id: blackwell2
+    id: 'ags:blackwell2'
     support: good
     notes: ''
     since_version: 2.5.0
     stable_platforms: 'win,mac'
     unstable_platforms: ''
 -
-    id: blackwell3
+    id: 'ags:blackwell3'
     support: good
     notes: ''
     since_version: 2.5.0
     stable_platforms: 'win,mac'
     unstable_platforms: ''
 -
-    id: blackwell4
+    id: 'ags:blackwell4'
     support: good
     notes: ''
     since_version: 2.5.0
     stable_platforms: 'win,mac'
     unstable_platforms: ''
 -
-    id: blackwell5
+    id: 'ags:blackwell5'
     support: good
     notes: ''
     since_version: 2.5.0
     stable_platforms: 'win,mac'
     unstable_platforms: ''
 -
-    id: goldenwake
+    id: 'ags:goldenwake'
     support: good
     notes: ''
     since_version: 2.5.0
     stable_platforms: 'win,linux,mac'
     unstable_platforms: ''
 -
-    id: kathyrain
+    id: 'ags:kathyrain'
     support: good
     notes: ''
     since_version: 2.5.0
     stable_platforms: 'win,mac'
     unstable_platforms: ''
 -
-    id: resonance
+    id: 'ags:resonance'
     support: good
     notes: ''
     since_version: 2.5.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: shivah
+    id: 'ags:shivah'
     support: good
     notes: ''
     since_version: 2.5.0
     stable_platforms: 'win,mac'
     unstable_platforms: ''
 -
-    id: sq45
+    id: 'ags:sq45'
     support: good
     notes: ''
     since_version: 2.5.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: sqdote
+    id: 'ags:sqdote'
     support: good
     notes: ''
     since_version: 2.5.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: sqinc
+    id: 'ags:sqinc'
     support: good
     notes: ''
     since_version: 2.5.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: sqvsb
+    id: 'ags:sqvsb'
     support: good
     notes: ''
     since_version: 2.5.0
     stable_platforms: 'win,linux,mac'
     unstable_platforms: ''
 -
-    id: sanitarium
+    id: 'asylum:sanitarium'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: bbvs
+    id: 'bbvs:bbvs'
     support: untested
     notes: ''
     since_version: 1.8.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: bbvs
+    id: 'bbvs:bbvs'
     support: good
     notes: ''
     since_version: 2.1.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: bladerunner
+    id: 'bladerunner:bladerunner'
     support: good
     notes: '- Enhanced Edition is not supported'
     since_version: 2.1.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: buried
+    id: 'buried:buried'
     support: excellent
     notes: ''
     since_version: 2.5.0
     stable_platforms: win
     unstable_platforms: mac
 -
-    id: soltys
+    id: 'cge:soltys'
     support: good
     notes: ''
     since_version: 1.5.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: sfinx
+    id: 'cge2:sfinx'
     support: untested
     notes: ''
     since_version: 1.8.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: sfinx
+    id: 'cge2:sfinx'
     support: good
     notes: ''
     since_version: 2.1.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: chewy
+    id: 'chewy:chewy'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: fw
+    id: 'cine:fw'
     support: good
     notes: '- Occasional graphical glitches'
     since_version: 0.10.0
     stable_platforms: 'amiga,atarist,dos'
     unstable_platforms: ''
 -
-    id: os
+    id: 'cine:os'
     support: good
     notes: ''
     since_version: 2.2.0
     stable_platforms: 'amiga,atarist,dos'
     unstable_platforms: ''
 -
-    id: babayaga
+    id: 'composer:babayaga'
     support: untested
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: darby
+    id: 'composer:darby'
     support: good
     notes: ''
     since_version: 1.5.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: gregory
+    id: 'composer:gregory'
     support: good
     notes: ''
     since_version: 1.5.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: imoking
+    id: 'composer:imoking'
     support: untested
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: liam
+    id: 'composer:liam'
     support: good
     notes: ''
     since_version: 1.5.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: littlesamurai
+    id: 'composer:littlesamurai'
     support: untested
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: princess
+    id: 'composer:princess'
     support: good
     notes: ''
     since_version: 1.5.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: sleepingcub
+    id: 'composer:sleepingcub'
     support: good
     notes: ''
     since_version: 1.5.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: cruise
+    id: 'cruise:cruise'
     support: excellent
     notes: '- Only AdLib music and sound effects are supported'
     since_version: 1.0.0
     stable_platforms: 'amiga,atarist,dos'
     unstable_platforms: ''
 -
-    id: versailles
+    id: 'cryomni3d:versailles'
     support: good
     notes: ''
     since_version: 2.1.0
     stable_platforms: 'dos,mac,win'
     unstable_platforms: ''
 -
-    id: versailles
+    id: 'cryomni3d:versailles'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'dos,mac,win'
     unstable_platforms: ''
 -
-    id: betterd
+    id: 'director:betterd'
     support: bugged
     notes: 'PACo videos don''t play'
     since_version: DEV
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: lzone
+    id: 'director:lzone'
     support: good
     notes: ''
     since_version: 2.5.0
     stable_platforms: 'win,mac'
     unstable_platforms: 'macintosh2,fmtowns,pippin'
 -
-    id: lzone
+    id: 'director:lzone'
     support: good
     notes: ''
     since_version: DEV
     stable_platforms: 'win,mac,pippin'
     unstable_platforms: 'macintosh2,fmtowns'
 -
-    id: warlock
+    id: 'director:warlock'
     support: good
     notes: '- Japanese version is not yet supported'
     since_version: 2.5.0
     stable_platforms: 'win,mac'
     unstable_platforms: ''
 -
-    id: draci
+    id: 'draci:draci'
     support: good
     notes: ''
     since_version: 1.1.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: dragons
+    id: 'dragons:dragons'
     support: good
     notes: ''
     since_version: 2.2.0
     stable_platforms: psx
     unstable_platforms: ''
 -
-    id: drascula
+    id: 'drascula:drascula'
     support: excellent
     notes: '- Requires the drascula.dat resource file to be placed in the game directory'
     since_version: 0.12.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: drascula
+    id: 'drascula:drascula'
     support: excellent
     notes: ''
     since_version: 1.6.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: dreamweb
+    id: 'dreamweb:dreamweb'
     support: excellent
     notes: ''
     since_version: 1.5.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: driller
+    id: 'freescape:driller'
     support: good
     notes: '- Minor missing features (UI details, special effects)  - CGA/EGA version is supported from DOS release'
     since_version: DEV
     stable_platforms: 'dos,amiga,atarist,zx,cpc'
     unstable_platforms: ''
 -
-    id: adrift
+    id: 'glk:adrift'
     support: good
     notes: '- Version 5 is not yet supported'
     since_version: 2.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: advsys
+    id: 'glk:advsys'
     support: good
     notes: ''
     since_version: 2.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: agt
+    id: 'glk:agt'
     support: good
     notes: ''
     since_version: 2.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: alan
+    id: 'glk:alan'
     support: good
     notes: ''
     since_version: 2.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: archetype
+    id: 'glk:archetype'
     support: good
     notes: ''
     since_version: 2.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: corruption
+    id: 'glk:corruption'
     support: good
     notes: ''
     since_version: 2.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: crimsoncrown
+    id: 'glk:crimsoncrown'
     support: good
     notes: '- Animations during scene rendering are not supported'
     since_version: 2.5.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: fish
+    id: 'glk:fish'
     support: good
     notes: ''
     since_version: 2.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: glulx
+    id: 'glk:glulx'
     support: good
     notes: ''
     since_version: 2.5.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: guild
+    id: 'glk:guild'
     support: good
     notes: ''
     since_version: 2.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: hugo
+    id: 'glk:hugo'
     support: good
     notes: ''
     since_version: 2.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: jacl
+    id: 'glk:jacl'
     support: good
     notes: ''
     since_version: 2.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: jinxter
+    id: 'glk:jinxter'
     support: good
     notes: ''
     since_version: 2.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: level9
+    id: 'glk:level9'
     support: good
     notes: ''
     since_version: 2.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: myth
+    id: 'glk:myth'
     support: good
     notes: ''
     since_version: 2.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: ootopos
+    id: 'glk:ootopos'
     support: good
     notes: '- Animations during scene rendering are not supported'
     since_version: 2.5.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: pawn
+    id: 'glk:pawn'
     support: good
     notes: ''
     since_version: 2.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: quest
+    id: 'glk:quest'
     support: good
     notes: ''
     since_version: 2.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: scottadams
+    id: 'glk:scottadams'
     support: good
     notes: ''
     since_version: 2.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: scottadams
+    id: 'glk:scottadams'
     support: good
     notes: ''
     since_version: DEV
     stable_platforms: 'dos,c64,zx,ti994'
     unstable_platforms: ''
 -
-    id: transylvania
+    id: 'glk:transylvania'
     support: good
     notes: '- Animations during scene rendering are not supported'
     since_version: 2.5.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: wonderland
+    id: 'glk:wonderland'
     support: good
     notes: ''
     since_version: 2.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: zcode
+    id: 'glk:zcode'
     support: good
     notes: ''
     since_version: 2.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: gnap
+    id: 'gnap:gnap'
     support: untested
     notes: ''
     since_version: 1.9.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: gnap
+    id: 'gnap:gnap'
     support: good
     notes: ''
     since_version: 2.1.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: adibou2
+    id: 'gob:adibou2'
     support: good
     notes: ''
     since_version: 2.7.0
     stable_platforms: win
     unstable_platforms: mac
 -
-    id: bambou
+    id: 'gob:bambou'
     support: good
     notes: ''
     since_version: 1.3.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: bambou
+    id: 'gob:bambou'
     support: excellent
     notes: ''
     since_version: 1.5.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: bargon
+    id: 'gob:bargon'
     support: excellent
     notes: '- Issues with the mouse cursor visibility'
     since_version: 0.10.0
     stable_platforms: 'amiga,atarist,dos'
     unstable_platforms: ''
 -
-    id: crousti
+    id: 'gob:crousti'
     support: untested
     notes: ''
     since_version: 2.6.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: fascination
+    id: 'gob:fascination'
     support: good
     notes: '- AdLib player is not supported in DOS floppy version'
     since_version: 1.2.0
     stable_platforms: 'amiga,atarist,dos'
     unstable_platforms: ''
 -
-    id: fascination
+    id: 'gob:fascination'
     support: good
     notes: ''
     since_version: 1.5.0
     stable_platforms: 'amiga,atarist,dos'
     unstable_platforms: ''
 -
-    id: fascination
+    id: 'gob:fascination'
     support: excellent
     notes: ''
     since_version: 1.7.0
     stable_platforms: 'amiga,atarist,dos'
     unstable_platforms: ''
 -
-    id: geisha
+    id: 'gob:geisha'
     support: good
     notes: ''
     since_version: 1.5.0
     stable_platforms: 'amiga,atarist,dos'
     unstable_platforms: ''
 -
-    id: gob1
+    id: 'gob:gob1'
     support: good
     notes: '- Problems with music in the Macintosh version'
     since_version: 0.8.0
     stable_platforms: 'amiga,cdi,dos,mac,win'
     unstable_platforms: ''
 -
-    id: gob1
+    id: 'gob:gob1'
     support: excellent
     notes: '- Problems with music in the Macintosh version'
     since_version: 0.9.0
     stable_platforms: 'amiga,cdi,dos,mac,win'
     unstable_platforms: ''
 -
-    id: gob2
+    id: 'gob:gob2'
     support: excellent
     notes: '- A few wrong instruments during music playback'
     since_version: 0.10.0
     stable_platforms: 'amiga,atarist,dos,mac,win'
     unstable_platforms: ''
 -
-    id: gob3
+    id: 'gob:gob3'
     support: good
     notes: '- Issues with the mouse cursor visibility - No support for original font and music files in Macintosh version - The number of used jokers isn''t saved correctly. You''ll always have 5 to spend again after loading'
     since_version: 0.10.0
     stable_platforms: 'amiga,dos,mac,win'
     unstable_platforms: ''
 -
-    id: gob3
+    id: 'gob:gob3'
     support: excellent
     notes: '- Issues with the mouse cursor visibility - No support for original font and music files in Macintosh version - The number of used jokers isn''t saved correctly. You''ll always have 5 to spend again after loading'
     since_version: 0.12.0
     stable_platforms: 'amiga,dos,mac,win'
     unstable_platforms: ''
 -
-    id: lit
+    id: 'gob:lit'
     support: excellent
     notes: '- Versions that split part one and two are untested - Issues with the mouse cursor visibility'
     since_version: 0.12.0
     stable_platforms: 'dos,win'
     unstable_platforms: ''
 -
-    id: lit
+    id: 'gob:lit'
     support: excellent
     notes: '- Issues with the mouse cursor visibility'
     since_version: 1.7.0
     stable_platforms: 'dos,win'
     unstable_platforms: ''
 -
-    id: littlered
+    id: 'gob:littlered'
     support: good
     notes: ''
     since_version: 1.5.0
     stable_platforms: 'amiga,dos,win'
     unstable_platforms: ''
 -
-    id: urban
+    id: 'gob:urban'
     support: good
     notes: ''
     since_version: 1.3.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: urban
+    id: 'gob:urban'
     support: excellent
     notes: ''
     since_version: 1.5.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: ween
+    id: 'gob:ween'
     support: excellent
     notes: '- Issues with the mouse cursor visibility'
     since_version: 0.10.0
     stable_platforms: 'amiga,atarist,dos'
     unstable_platforms: ''
 -
-    id: woodruff
+    id: 'gob:woodruff'
     support: good
     notes: '- Issues with the mouse cursor visibility - Some object videos flicker the very first frame'
     since_version: 0.12.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: woodruff
+    id: 'gob:woodruff'
     support: excellent
     notes: '- Issues with the mouse cursor visibility'
     since_version: 1.0.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: griffon
+    id: 'griffon:griffon'
     support: good
     notes: ''
     since_version: 2.2.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: grim
+    id: 'grim:grim'
     support: good
     notes: '- Remastered version is not supported'
     since_version: 2.5.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: monkey4
+    id: 'grim:monkey4'
     support: bugged
     notes: ''
     since_version: 2.6.0
     stable_platforms: win
     unstable_platforms: ps2
 -
-    id: 11h
+    id: 'groovie:11h'
     support: good
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'dos,win,mac'
     unstable_platforms: ''
 -
-    id: clandestiny
+    id: 'groovie:clandestiny'
     support: good
     notes: ''
     since_version: 2.6.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: t7g
+    id: 'groovie:t7g'
     support: excellent
     notes: '- The MT-32 instrument definitions aren''t supported yet, so it will play with wrong instruments - The CD-i version doesn''t use Groovie - There are some issues with music not playing when it should'
     since_version: 0.13.0
     stable_platforms: 'dos,win'
     unstable_platforms: 'cdi,ios,mac'
 -
-    id: t7g
+    id: 'groovie:t7g'
     support: excellent
     notes: '- The MT-32 instrument definitions aren''t supported yet, so it will play with wrong instruments - The CD-i version doesn''t use Groovie'
     since_version: 1.0.0
     stable_platforms: 'dos,win'
     unstable_platforms: 'cdi,ios,mac'
 -
-    id: t7g
+    id: 'groovie:t7g'
     support: excellent
     notes: '- The CD-i version doesn''t use Groovie'
     since_version: 1.2.0
     stable_platforms: 'dos,ios,mac,win'
     unstable_platforms: cdi
 -
-    id: tlc
+    id: 'groovie:tlc'
     support: good
     notes: '- CD-ROM editions only. DVD, Steam, GOG not supported.'
     since_version: 2.6.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: unclehenry
+    id: 'groovie:unclehenry'
     support: good
     notes: ''
     since_version: 2.6.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: hadesch
+    id: 'hadesch:hadesch'
     support: good
     notes: '- Minotaur, Troy and Medusa minigames are skipped'
     since_version: 2.6.0
     stable_platforms: 'win,mac'
     unstable_platforms: ''
 -
-    id: hdb
+    id: 'hdb:hdb'
     support: excellent
     notes: ''
     since_version: 2.1.0
     stable_platforms: 'linux,pocketpc,win'
     unstable_platforms: ''
 -
-    id: hopkins
+    id: 'hopkins:hopkins'
     support: good
     notes: ''
     since_version: 1.6.0
     stable_platforms: 'beos,linux,os2,win'
     unstable_platforms: ''
 -
-    id: hugo1
+    id: 'hugo:hugo1'
     support: good
     notes: '- Playback is not supported - No support for one of the original fonts used during the intro of the DOS version'
     since_version: 1.3.0
     stable_platforms: 'dos,win'
     unstable_platforms: ''
 -
-    id: hugo2
+    id: 'hugo:hugo2'
     support: good
     notes: '- Playback is not supported'
     since_version: 1.3.0
     stable_platforms: 'dos,win'
     unstable_platforms: ''
 -
-    id: hugo3
+    id: 'hugo:hugo3'
     support: good
     notes: '- Playback is not supported'
     since_version: 1.3.0
     stable_platforms: 'dos,win'
     unstable_platforms: ''
 -
-    id: sinistersix
+    id: 'hypno:sinistersix'
     support: good
     notes: '- English, Spanish, Italian and German releases supported - Minor missing features (back to menu)'
     since_version: 2.6.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: soldierboyz
+    id: 'hypno:soldierboyz'
     support: good
     notes: '- Minor missing features (back to menu, switch to flasback mode, difficulties)  - Minor user interface issues (not pixel perfect reproduction) - Some sounds are missing and volume for music/sfx should be adjusted'
     since_version: DEV
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: wetlands
+    id: 'hypno:wetlands'
     support: good
     notes: '- Minor missing features (back to menu, highscores)  - Minor user interface issues (not pixel perfect reproduction)'
     since_version: 2.6.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: icb
+    id: 'icb:icb'
     support: broken
     notes: ''
     since_version: 2.6.0
     stable_platforms: win
     unstable_platforms: psx
 -
-    id: duckman
+    id: 'illusions:duckman'
     support: good
     notes: ''
     since_version: 2.1.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: eob
+    id: 'kyra:eob'
     support: good
     notes: ''
     since_version: 1.6.0
     stable_platforms: dos
     unstable_platforms: 'amiga,pc98'
 -
-    id: eob
+    id: 'kyra:eob'
     support: good
     notes: ''
     since_version: 2.1.0
     stable_platforms: 'amiga,dos'
     unstable_platforms: 'pc98,segacd'
 -
-    id: eob
+    id: 'kyra:eob'
     support: excellent
     notes: ''
     since_version: 2.2.0
     stable_platforms: 'amiga,dos,pc98,segacd'
     unstable_platforms: ''
 -
-    id: eob2
+    id: 'kyra:eob2'
     support: good
     notes: ''
     since_version: 1.6.0
     stable_platforms: dos
     unstable_platforms: 'amiga,fmtowns,pc98'
 -
-    id: eob2
+    id: 'kyra:eob2'
     support: excellent
     notes: ''
     since_version: 2.1.0
     stable_platforms: 'amiga,dos,fmtowns'
     unstable_platforms: pc98
 -
-    id: kyra1
+    id: 'kyra:kyra1'
     support: good
     notes: '- Requires the kyra.dat resource file to be placed in the game directory - MT-32 (MIDI) music and sfx are not supported - Occasional graphics glitches '
     since_version: 0.9.0
     stable_platforms: dos
     unstable_platforms: 'amiga,fmtowns'
 -
-    id: kyra1
+    id: 'kyra:kyra1'
     support: good
     notes: '- Requires the kyra.dat resource file to be placed in the game directory - MT-32 (MIDI) music and sfx are not supported - Occasional graphics glitches '
     since_version: 0.10.0
     stable_platforms: 'dos,fmtowns'
     unstable_platforms: amiga
 -
-    id: kyra1
+    id: 'kyra:kyra1'
     support: good
     notes: '- Requires the kyra.dat resource file to be placed in the game directory - No music or sound effects in the Macintosh floppy versions - MT-32 (MIDI) music and sfx are not supported - PC-98 version lacks support for music and sound effects - Occasional graphics glitches '
     since_version: 0.11.0
     stable_platforms: 'dos,fmtowns,mac,pc98'
     unstable_platforms: amiga
 -
-    id: kyra1
+    id: 'kyra:kyra1'
     support: good
     notes: '- Requires the kyra.dat resource file to be placed in the game directory - No music or sound effects in the Macintosh floppy versions - MT-32 (MIDI) music and sfx are not supported - PC-98 version lacks support for sound effects - Occasional graphics glitches '
     since_version: 0.12.0
     stable_platforms: 'dos,fmtowns,mac,pc98'
     unstable_platforms: amiga
 -
-    id: kyra1
+    id: 'kyra:kyra1'
     support: good
     notes: '- Requires the kyra.dat resource file to be placed in the game directory - No music or sound effects in the Macintosh floppy versions - PC-98 version lacks support for sound effects - Occasional graphics glitches '
     since_version: 0.13.0
     stable_platforms: 'dos,fmtowns,mac,pc98'
     unstable_platforms: amiga
 -
-    id: kyra1
+    id: 'kyra:kyra1'
     support: good
     notes: '- Requires the kyra.dat resource file to be placed in the game directory - No music or sound effects in the Amiga and Macintosh floppy versions - Macintosh CD is using included DOS music and sound effects for now - PC-98 version lacks support for sound effects - Occasional graphics glitches '
     since_version: 1.0.0
     stable_platforms: 'amiga,dos,fmtowns,mac,pc98'
     unstable_platforms: ''
 -
-    id: kyra1
+    id: 'kyra:kyra1'
     support: good
     notes: '- Requires the kyra.dat resource file to be placed in the game directory - No music or sound effects in the Macintosh floppy versions - Macintosh CD is using included DOS music and sound effects for now - PC-98 version lacks support for sound effects - Occasional graphics glitches '
     since_version: 1.1.0
     stable_platforms: 'amiga,dos,fmtowns,mac,pc98'
     unstable_platforms: ''
 -
-    id: kyra1
+    id: 'kyra:kyra1'
     support: excellent
     notes: '- Requires the kyra.dat resource file to be placed in the game directory - No music or sound effects in the Macintosh floppy versions - Macintosh CD is using included DOS music and sound effects for now'
     since_version: 1.2.0
     stable_platforms: 'amiga,dos,fmtowns,mac,pc98'
     unstable_platforms: ''
 -
-    id: kyra1
+    id: 'kyra:kyra1'
     support: excellent
     notes: '- No music or sound effects in the Macintosh floppy versions - Macintosh CD is using included DOS music and sound effects for now'
     since_version: 1.6.0
     stable_platforms: 'amiga,dos,fmtowns,mac,pc98'
     unstable_platforms: ''
 -
-    id: kyra1
+    id: 'kyra:kyra1'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'amiga,dos,fmtowns,mac,pc98'
     unstable_platforms: ''
 -
-    id: kyra2
+    id: 'kyra:kyra2'
     support: excellent
     notes: '- Requires the kyra.dat resource file to be placed in the game directory - MIDI music and sfx are not supported'
     since_version: 0.12.0
     stable_platforms: 'dos,fmtowns,pc98'
     unstable_platforms: ''
 -
-    id: kyra2
+    id: 'kyra:kyra2'
     support: excellent
     notes: '- Requires the kyra.dat resource file to be placed in the game directory'
     since_version: 0.13.0
     stable_platforms: 'dos,fmtowns,pc98'
     unstable_platforms: ''
 -
-    id: kyra2
+    id: 'kyra:kyra2'
     support: excellent
     notes: ''
     since_version: 1.6.0
     stable_platforms: 'dos,fmtowns,pc98'
     unstable_platforms: ''
 -
-    id: kyra3
+    id: 'kyra:kyra3'
     support: excellent
     notes: '- Requires the kyra.dat resource file to be placed in the game directory'
     since_version: 0.12.0
     stable_platforms: 'dos,mac'
     unstable_platforms: ''
 -
-    id: kyra3
+    id: 'kyra:kyra3'
     support: excellent
     notes: ''
     since_version: 1.6.0
     stable_platforms: 'dos,mac'
     unstable_platforms: ''
 -
-    id: lol
+    id: 'kyra:lol'
     support: good
     notes: '- Requires the kyra.dat resource file to be placed in the game directory'
     since_version: 1.4.0
     stable_platforms: 'dos,pc98'
     unstable_platforms: ''
 -
-    id: lol
+    id: 'kyra:lol'
     support: good
     notes: ''
     since_version: 1.6.0
     stable_platforms: 'dos,pc98'
     unstable_platforms: ''
 -
-    id: lol
+    id: 'kyra:lol'
     support: excellent
     notes: ''
     since_version: 2.2.0
     stable_platforms: 'dos,fmtowns,pc98'
     unstable_platforms: ''
 -
-    id: lab
+    id: 'lab:lab'
     support: good
     notes: ''
     since_version: 1.8.0
     stable_platforms: 'dos,win'
     unstable_platforms: amiga
 -
-    id: lure
+    id: 'lure:lure'
     support: good
     notes: '- Sound support is incomplete and there is no Roland MT-32 support - EGA version is not supported'
     since_version: 0.11.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: lure
+    id: 'lure:lure'
     support: good
     notes: '- Sound support is incomplete and there is no Roland MT-32 support'
     since_version: 0.13.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: lure
+    id: 'lure:lure'
     support: good
     notes: '- MT-32 is supported. - AdLib support is incomplete.'
     since_version: 2.5.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: lgop2
+    id: 'made:lgop2'
     support: good
     notes: '- Only soundblaster music is played. MIDI music playing/MT32 instrument mapping needs more work'
     since_version: 1.0.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: manhole
+    id: 'made:manhole'
     support: good
     notes: ''
     since_version: 1.0.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: rodney
+    id: 'made:rodney'
     support: good
     notes: ''
     since_version: 1.0.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: rtz
+    id: 'made:rtz'
     support: good
     notes: '- Only soundblaster music is played. MIDI music playing/MT32 instrument mapping needs more work'
     since_version: 1.0.0
     stable_platforms: 'dos,fmtowns,pc98'
     unstable_platforms: '3do,mac,pcfx,psx,saturn'
 -
-    id: nebular
+    id: 'mads:nebular'
     support: untested
     notes: '- Original floppy version must be installed using DosBox before game is playable.'
     since_version: 1.8.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: nebular
+    id: 'mads:nebular'
     support: good
     notes: '- Original floppy version must be installed using DosBox before game is playable.'
     since_version: 2.1.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: nebular
+    id: 'mads:nebular'
     support: good
     notes: ''
     since_version: DEV
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: arthur
+    id: 'mohawk:arthur'
     support: good
     notes: ''
     since_version: 1.3.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: arthurbday
-    support: good
-    notes: '- The 2.0 version is not supported yet'
-    since_version: 1.3.0
-    stable_platforms: 'mac,win'
-    unstable_platforms: ''
--
-    id: beardark
-    support: good
-    notes: ''
-    since_version: 1.3.0
-    stable_platforms: 'mac,win'
-    unstable_platforms: ''
--
-    id: bearfight
-    support: good
-    notes: ''
-    since_version: 1.3.0
-    stable_platforms: 'mac,win'
-    unstable_platforms: ''
--
-    id: create
-    support: untested
-    notes: ''
-    since_version: 2.6.0
-    stable_platforms: 'mac,win'
-    unstable_platforms: ''
--
-    id: daniel
-    support: untested
-    notes: ''
-    since_version: 2.6.0
-    stable_platforms: 'mac,win'
-    unstable_platforms: ''
--
-    id: grandma
+    id: 'mohawk:arthurbday'
     support: good
     notes: '- The 2.0 version is not supported yet'
     since_version: 1.3.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: greeneggs
+    id: 'mohawk:beardark'
+    support: good
+    notes: ''
+    since_version: 1.3.0
+    stable_platforms: 'mac,win'
+    unstable_platforms: ''
+-
+    id: 'mohawk:bearfight'
+    support: good
+    notes: ''
+    since_version: 1.3.0
+    stable_platforms: 'mac,win'
+    unstable_platforms: ''
+-
+    id: 'mohawk:create'
+    support: untested
+    notes: ''
+    since_version: 2.6.0
+    stable_platforms: 'mac,win'
+    unstable_platforms: ''
+-
+    id: 'mohawk:daniel'
+    support: untested
+    notes: ''
+    since_version: 2.6.0
+    stable_platforms: 'mac,win'
+    unstable_platforms: ''
+-
+    id: 'mohawk:grandma'
+    support: good
+    notes: '- The 2.0 version is not supported yet'
+    since_version: 1.3.0
+    stable_platforms: 'mac,win'
+    unstable_platforms: ''
+-
+    id: 'mohawk:greeneggs'
     support: good
     notes: '- Minigames are not supported yet'
     since_version: 1.3.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: harryhh
+    id: 'mohawk:harryhh'
     support: good
     notes: ''
     since_version: 1.3.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: lilmonster
+    id: 'mohawk:lilmonster'
     support: good
     notes: ''
     since_version: 1.3.0
     stable_platforms: 'mac,win'
     unstable_platforms: cdi
 -
-    id: myst
+    id: 'mohawk:myst'
     support: untested
     notes: ''
     since_version: 1.9.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: myst
+    id: 'mohawk:myst'
     support: excellent
     notes: ''
     since_version: 2.0.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: newkid
+    id: 'mohawk:newkid'
     support: good
     notes: ''
     since_version: 1.3.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: riven
+    id: 'mohawk:riven'
     support: good
     notes: ''
     since_version: 2.0.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: ruff
+    id: 'mohawk:ruff'
     support: good
     notes: ''
     since_version: 1.3.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: seussabc
+    id: 'mohawk:seussabc'
     support: good
     notes: ''
     since_version: 1.3.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: sheila
+    id: 'mohawk:sheila'
     support: good
     notes: ''
     since_version: 1.3.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: stellaluna
+    id: 'mohawk:stellaluna'
     support: good
     notes: ''
     since_version: 1.3.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: tortoise
+    id: 'mohawk:tortoise'
     support: good
     notes: ''
     since_version: 1.3.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: mortevielle
+    id: 'mortevielle:mortevielle'
     support: untested
     notes: '- No speech synthesis'
     since_version: 1.7.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: mortevielle
+    id: 'mortevielle:mortevielle'
     support: good
     notes: '- No speech synthesis'
     since_version: 2.1.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: mortevielle
+    id: 'mortevielle:mortevielle'
     support: good
     notes: ''
     since_version: 2.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: obsidian
+    id: 'mtropolis:obsidian'
     support: excellent
     notes: ''
     since_version: DEV
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: myst3
+    id: 'myst3:myst3'
     support: good
     notes: ''
     since_version: 2.5.0
     stable_platforms: win
     unstable_platforms: 'ps2,xbox'
 -
-    id: neverhood
+    id: 'neverhood:neverhood'
     support: good
     notes: ''
     since_version: 1.7.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: fullpipe
+    id: 'ngi:fullpipe'
     support: good
     notes: ''
     since_version: 2.0.0
     stable_platforms: 'steam,win'
     unstable_platforms: 'android,ios'
 -
-    id: nippon
+    id: 'parallaction:nippon'
     support: good
     notes: ''
     since_version: 0.10.0
     stable_platforms: dos
     unstable_platforms: amiga
 -
-    id: nippon
+    id: 'parallaction:nippon'
     support: good
     notes: ''
     since_version: 0.11.0
     stable_platforms: 'amiga,dos'
     unstable_platforms: ''
 -
-    id: nippon
+    id: 'parallaction:nippon'
     support: broken
     notes: '- Regression broke the game'
     since_version: 1.0.0
     stable_platforms: 'amiga,dos'
     unstable_platforms: ''
 -
-    id: nippon
+    id: 'parallaction:nippon'
     support: good
     notes: '- Occasional graphical glitches'
     since_version: 1.2.0
     stable_platforms: 'amiga,dos'
     unstable_platforms: ''
 -
-    id: pegasus
+    id: 'pegasus:pegasus'
     support: good
     notes: '- Occasional video graphical glitches'
     since_version: 1.6.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: petka1
+    id: 'petka:petka1'
     support: good
     notes: ''
     since_version: 2.5.0
     stable_platforms: win
     unstable_platforms: 'ios,android'
 -
-    id: petka2
+    id: 'petka:petka2'
     support: good
     notes: ''
     since_version: 2.5.0
     stable_platforms: win
     unstable_platforms: 'ios,android'
 -
-    id: peril
+    id: 'pink:peril'
     support: good
     notes: ''
     since_version: DEV
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: pokus
+    id: 'pink:pokus'
     support: good
     notes: ''
     since_version: DEV
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: plumbers
+    id: 'plumbers:plumbers'
     support: untested
     notes: ''
     since_version: 2.0.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: plumbers
+    id: 'plumbers:plumbers'
     support: good
     notes: ''
     since_version: 2.1.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: plumbers
+    id: 'plumbers:plumbers'
     support: good
     notes: ''
     since_version: 2.5.0
     stable_platforms: 'win,3do'
     unstable_platforms: ''
 -
-    id: prince
+    id: 'prince:prince'
     support: untested
     notes: ''
     since_version: 2.1.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: private-eye
+    id: 'private:private-eye'
     support: good
     notes: '- All releases are supported except Japanese and Korean.'
     since_version: 2.5.0
     stable_platforms: 'win,mac'
     unstable_platforms: ''
 -
-    id: private-eye
+    id: 'private:private-eye'
     support: good
     notes: '- All releases are supported except Japanese.'
     since_version: 2.6.0
     stable_platforms: 'win,mac'
     unstable_platforms: ''
 -
-    id: private-eye
+    id: 'private:private-eye'
     support: good
     notes: '- All releases are supported except Japanese Windows.'
     since_version: 2.7.0
     stable_platforms: 'win,mac'
     unstable_platforms: ''
 -
-    id: queen
+    id: 'queen:queen'
     support: good
     notes: '- Some versions may require the queen.tbl resource file to be placed in the game directory. This is not required for the freeware releases.'
     since_version: 0.6.0
     stable_platforms: dos
     unstable_platforms: amiga
 -
-    id: queen
+    id: 'queen:queen'
     support: excellent
     notes: '- Some versions may require the queen.tbl resource file to be placed in the game directory. This is not required for the freeware releases.'
     since_version: 0.7.0
     stable_platforms: dos
     unstable_platforms: amiga
 -
-    id: queen
+    id: 'queen:queen'
     support: excellent
     notes: '- Some versions may require the queen.tbl resource file to be placed in the game directory. This is not required for the freeware releases.'
     since_version: 0.10.0
     stable_platforms: 'amiga,dos'
     unstable_platforms: ''
 -
-    id: queen
+    id: 'queen:queen'
     support: excellent
     notes: ''
     since_version: 1.6.0
     stable_platforms: 'amiga,dos'
     unstable_platforms: ''
 -
-    id: fta2
+    id: 'saga:fta2'
     support: good
     notes: ''
     since_version: DEV
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: ihnm
+    id: 'saga:ihnm'
     support: good
     notes: '- No music in the Macintosh version'
     since_version: 0.11.0
     stable_platforms: 'dos,mac'
     unstable_platforms: ''
 -
-    id: ihnm
+    id: 'saga:ihnm'
     support: good
     notes: ''
     since_version: 1.6.0
     stable_platforms: 'dos,mac'
     unstable_platforms: ''
 -
-    id: ite
+    id: 'saga:ite'
     support: good
     notes: '- Occasional graphical glitches'
     since_version: 0.8.0
     stable_platforms: 'dos,linux,mac,macos,pc98,win'
     unstable_platforms: amiga
 -
-    id: ite
+    id: 'saga:ite'
     support: excellent
     notes: ''
     since_version: 0.11.0
     stable_platforms: 'dos,linux,mac,macos,pc98,win'
     unstable_platforms: amiga
 -
-    id: astrochicken
+    id: 'sci:astrochicken'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: camelot
+    id: 'sci:camelot'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: dos
     unstable_platforms: 'amiga,atarist'
 -
-    id: camelot
+    id: 'sci:camelot'
     support: excellent
     notes: '- Music in the Amiga version may have glitches'
     since_version: 1.3.0
     stable_platforms: 'amiga,atarist,dos'
     unstable_platforms: ''
 -
-    id: castlebrain
+    id: 'sci:castlebrain'
     support: excellent
     notes: '- Music in Macintosh and Amiga versions may have glitches - No support for Macintosh hi-res fonts'
     since_version: 1.2.0
     stable_platforms: dos
     unstable_platforms: 'amiga,mac,pc98'
 -
-    id: castlebrain
+    id: 'sci:castlebrain'
     support: excellent
     notes: '- Music in Macintosh and Amiga versions may have glitches - No support for Macintosh hi-res fonts'
     since_version: 1.3.0
     stable_platforms: 'amiga,dos,mac,pc98'
     unstable_platforms: ''
 -
-    id: chest
+    id: 'sci:chest'
     support: broken
     notes: ''
     since_version: 2.0.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: chest
+    id: 'sci:chest'
     support: good
     notes: ''
     since_version: 2.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: chest
+    id: 'sci:chest'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: ecoquest
+    id: 'sci:ecoquest'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: ecoquest
+    id: 'sci:ecoquest'
     support: excellent
     notes: ''
     since_version: 1.4.0
     stable_platforms: 'dos,win'
     unstable_platforms: ''
 -
-    id: ecoquest2
+    id: 'sci:ecoquest2'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: fairytales
+    id: 'sci:fairytales'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: freddypharkas
+    id: 'sci:freddypharkas'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: 'dos,mac,win'
     unstable_platforms: ''
 -
-    id: gk1
+    id: 'sci:gk1'
     support: good
     notes: ''
     since_version: 2.0.0
     stable_platforms: 'dos,win'
     unstable_platforms: mac
 -
-    id: gk1
+    id: 'sci:gk1'
     support: good
     notes: ''
     since_version: 2.5.0
     stable_platforms: 'dos,win,mac'
     unstable_platforms: ''
 -
-    id: gk1
+    id: 'sci:gk1'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'dos,win,mac'
     unstable_platforms: ''
 -
-    id: gk2
+    id: 'sci:gk2'
     support: excellent
     notes: '- Video files in the original (1.0) release are corrupt (bad A/V sync)'
     since_version: 2.0.0
     stable_platforms: 'dos,win'
     unstable_platforms: mac
 -
-    id: hoyle1
+    id: 'sci:hoyle1'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: dos
     unstable_platforms: 'amiga,atarist'
 -
-    id: hoyle1
+    id: 'sci:hoyle1'
     support: excellent
     notes: '- Music in the Amiga version may have glitches'
     since_version: 1.3.0
     stable_platforms: 'amiga,atarist,dos'
     unstable_platforms: ''
 -
-    id: hoyle2
+    id: 'sci:hoyle2'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: dos
     unstable_platforms: 'amiga,atarist,mac'
 -
-    id: hoyle2
+    id: 'sci:hoyle2'
     support: excellent
     notes: '- Music in the Amiga version may have glitches'
     since_version: 1.3.0
     stable_platforms: 'amiga,atarist,dos,mac'
     unstable_platforms: ''
 -
-    id: hoyle3
+    id: 'sci:hoyle3'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: dos
     unstable_platforms: amiga
 -
-    id: hoyle3
+    id: 'sci:hoyle3'
     support: excellent
     notes: '- Music in the Amiga version may have glitches'
     since_version: 1.3.0
     stable_platforms: 'amiga,dos'
     unstable_platforms: ''
 -
-    id: hoyle4
+    id: 'sci:hoyle4'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: 'dos,mac'
     unstable_platforms: ''
 -
-    id: hoyle5
+    id: 'sci:hoyle5'
     support: broken
     notes: ''
     since_version: 2.0.0
     stable_platforms: win
     unstable_platforms: mac
 -
-    id: hoyle5
+    id: 'sci:hoyle5'
     support: good
     notes: '- The poker game of the Hoyle Classic Games collection is not yet supported'
     since_version: 2.1.0
     stable_platforms: win
     unstable_platforms: mac
 -
-    id: hoyle5solitaire
+    id: 'sci:hoyle5solitaire'
     support: good
     notes: ''
     since_version: 2.1.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: hoyle5solitaire
+    id: 'sci:hoyle5solitaire'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: iceman
+    id: 'sci:iceman'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: dos
     unstable_platforms: 'amiga,atarist'
 -
-    id: iceman
+    id: 'sci:iceman'
     support: excellent
     notes: '- Music in the Amiga version may have glitches'
     since_version: 1.3.0
     stable_platforms: 'amiga,atarist,dos'
     unstable_platforms: ''
 -
-    id: islandbrain
+    id: 'sci:islandbrain'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: jones
+    id: 'sci:jones'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: jones
+    id: 'sci:jones'
     support: excellent
     notes: ''
     since_version: 1.4.0
     stable_platforms: 'dos,win'
     unstable_platforms: ''
 -
-    id: kq1sci
+    id: 'sci:kq1sci'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: dos
     unstable_platforms: amiga
 -
-    id: kq1sci
+    id: 'sci:kq1sci'
     support: excellent
     notes: '- Music in the Amiga version may have glitches'
     since_version: 1.3.0
     stable_platforms: 'amiga,dos'
     unstable_platforms: ''
 -
-    id: kq4sci
+    id: 'sci:kq4sci'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: dos
     unstable_platforms: 'amiga,atarist'
 -
-    id: kq4sci
+    id: 'sci:kq4sci'
     support: excellent
     notes: '- Music in the Amiga version may have glitches'
     since_version: 1.3.0
     stable_platforms: 'amiga,atarist,dos'
     unstable_platforms: ''
 -
-    id: kq5
+    id: 'sci:kq5'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: dos
     unstable_platforms: win
 -
-    id: kq5
+    id: 'sci:kq5'
     support: excellent
     notes: '- Music in the Macintosh and Amiga versions may have glitches - No support for Macintosh hi-res fonts'
     since_version: 1.3.0
     stable_platforms: 'amiga,dos,fmtowns,mac,pc98'
     unstable_platforms: win
 -
-    id: kq5
+    id: 'sci:kq5'
     support: excellent
     notes: '- Music in the Macintosh and Amiga versions may have glitches - No support for Macintosh hi-res fonts'
     since_version: 1.4.0
     stable_platforms: 'amiga,dos,fmtowns,mac,pc98,win'
     unstable_platforms: ''
 -
-    id: kq6
+    id: 'sci:kq6'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: 'dos,mac,win'
     unstable_platforms: ''
 -
-    id: kq7
+    id: 'sci:kq7'
     support: good
     notes: ''
     since_version: 2.0.0
     stable_platforms: 'dos,win'
     unstable_platforms: mac
 -
-    id: kquestions
+    id: 'sci:kquestions'
     support: good
     notes: ''
     since_version: 2.0.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: kquestions
+    id: 'sci:kquestions'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: laurabow
+    id: 'sci:laurabow'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: dos
     unstable_platforms: 'amiga,atarist'
 -
-    id: laurabow
+    id: 'sci:laurabow'
     support: excellent
     notes: '- Music in the Amiga version may have glitches'
     since_version: 1.3.0
     stable_platforms: 'amiga,atarist,dos'
     unstable_platforms: ''
 -
-    id: laurabow2
+    id: 'sci:laurabow2'
     support: excellent
     notes: ''
     since_version: 1.3.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: lighthouse
+    id: 'sci:lighthouse'
     support: good
     notes: ''
     since_version: 2.0.0
     stable_platforms: dos
     unstable_platforms: mac
 -
-    id: longbow
+    id: 'sci:longbow'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: dos
     unstable_platforms: amiga
 -
-    id: longbow
+    id: 'sci:longbow'
     support: excellent
     notes: '- Music in the Amiga version may have glitches'
     since_version: 1.4.0
     stable_platforms: 'amiga,dos'
     unstable_platforms: ''
 -
-    id: lsl1sci
+    id: 'sci:lsl1sci'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: dos
     unstable_platforms: 'amiga,mac'
 -
-    id: lsl1sci
+    id: 'sci:lsl1sci'
     support: excellent
     notes: '- Music in the Macintosh and Amiga versions may have glitches - No support for Macintosh hi-res fonts'
     since_version: 1.3.0
     stable_platforms: 'amiga,dos,mac'
     unstable_platforms: ''
 -
-    id: lsl2
+    id: 'sci:lsl2'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: dos
     unstable_platforms: 'amiga,atarist'
 -
-    id: lsl2
+    id: 'sci:lsl2'
     support: excellent
     notes: '- Music in the Amiga versions may have glitches'
     since_version: 1.3.0
     stable_platforms: 'amiga,atarist,dos'
     unstable_platforms: ''
 -
-    id: lsl3
+    id: 'sci:lsl3'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: dos
     unstable_platforms: 'amiga,atarist'
 -
-    id: lsl3
+    id: 'sci:lsl3'
     support: excellent
     notes: '- Music in the Amiga versions may have glitches'
     since_version: 1.3.0
     stable_platforms: 'amiga,atarist,dos'
     unstable_platforms: ''
 -
-    id: lsl5
+    id: 'sci:lsl5'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: 'amiga,dos,mac'
     unstable_platforms: ''
 -
-    id: lsl5
+    id: 'sci:lsl5'
     support: excellent
     notes: '- Music in the Macintosh and Amiga versions may have glitches - No support for Macintosh hi-res fonts'
     since_version: 1.3.0
     stable_platforms: 'amiga,dos,mac'
     unstable_platforms: ''
 -
-    id: lsl6
+    id: 'sci:lsl6'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: dos
     unstable_platforms: mac
 -
-    id: lsl6hires
+    id: 'sci:lsl6hires'
     support: good
     notes: ''
     since_version: 2.0.0
     stable_platforms: 'dos,win'
     unstable_platforms: mac
 -
-    id: lsl6hires
+    id: 'sci:lsl6hires'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'dos,win'
     unstable_platforms: mac
 -
-    id: lsl7
+    id: 'sci:lsl7'
     support: excellent
     notes: ''
     since_version: 2.0.0
     stable_platforms: dos
     unstable_platforms: mac
 -
-    id: mothergoose
+    id: 'sci:mothergoose'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: dos
     unstable_platforms: amiga
 -
-    id: mothergoose
+    id: 'sci:mothergoose'
     support: excellent
     notes: '- Music in the Amiga versions may have glitches'
     since_version: 1.3.0
     stable_platforms: 'amiga,dos'
     unstable_platforms: ''
 -
-    id: mothergoose256
+    id: 'sci:mothergoose256'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: mothergoosehires
+    id: 'sci:mothergoosehires'
     support: good
     notes: ''
     since_version: 2.0.0
     stable_platforms: win
     unstable_platforms: mac
 -
-    id: mothergoosehires
+    id: 'sci:mothergoosehires'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: win
     unstable_platforms: mac
 -
-    id: pepper
+    id: 'sci:pepper'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: phantasmagoria
+    id: 'sci:phantasmagoria'
     support: good
     notes: ''
     since_version: 2.0.0
     stable_platforms: 'dos,win'
     unstable_platforms: mac
 -
-    id: phantasmagoria2
+    id: 'sci:phantasmagoria2'
     support: excellent
     notes: ''
     since_version: 2.0.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: pq1sci
+    id: 'sci:pq1sci'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: pq2
+    id: 'sci:pq2'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: dos
     unstable_platforms: 'amiga,atarist,pc98'
 -
-    id: pq2
+    id: 'sci:pq2'
     support: excellent
     notes: '- Music in the Amiga versions may have glitches'
     since_version: 1.3.0
     stable_platforms: 'amiga,atarist,dos,pc98'
     unstable_platforms: ''
 -
-    id: pq3
+    id: 'sci:pq3'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: dos
     unstable_platforms: amiga
 -
-    id: pq3
+    id: 'sci:pq3'
     support: excellent
     notes: '- Music in the Amiga versions may have glitches'
     since_version: 1.3.0
     stable_platforms: 'amiga,dos'
     unstable_platforms: ''
 -
-    id: pq4
+    id: 'sci:pq4'
     support: broken
     notes: ''
     since_version: 2.0.0
     stable_platforms: dos
     unstable_platforms: mac
 -
-    id: pq4
+    id: 'sci:pq4'
     support: good
     notes: ''
     since_version: 2.1.0
     stable_platforms: dos
     unstable_platforms: mac
 -
-    id: pqswat
+    id: 'sci:pqswat'
     support: untested
     notes: ''
     since_version: 2.0.0
     stable_platforms: dos
     unstable_platforms: mac
 -
-    id: pqswat
+    id: 'sci:pqswat'
     support: good
     notes: ''
     since_version: 2.1.0
     stable_platforms: dos
     unstable_platforms: mac
 -
-    id: qfg1vga
+    id: 'sci:qfg1vga'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: 'dos,mac'
     unstable_platforms: ''
 -
-    id: qfg2
+    id: 'sci:qfg2'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: dos
     unstable_platforms: amiga
 -
-    id: qfg2
+    id: 'sci:qfg2'
     support: excellent
     notes: '- Music in the Amiga versions may have glitches'
     since_version: 1.3.0
     stable_platforms: 'amiga,dos'
     unstable_platforms: ''
 -
-    id: qfg3
+    id: 'sci:qfg3'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: qfg4
+    id: 'sci:qfg4'
     support: broken
     notes: ''
     since_version: 2.0.0
     stable_platforms: 'dos,win'
     unstable_platforms: ''
 -
-    id: qfg4
+    id: 'sci:qfg4'
     support: good
     notes: ''
     since_version: 2.1.0
     stable_platforms: 'dos,win'
     unstable_platforms: ''
 -
-    id: qfg4
+    id: 'sci:qfg4'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'dos,win'
     unstable_platforms: ''
 -
-    id: rama
+    id: 'sci:rama'
     support: good
     notes: ''
     since_version: 2.0.0
     stable_platforms: dos
     unstable_platforms: mac
 -
-    id: shivers
+    id: 'sci:shivers'
     support: excellent
     notes: ''
     since_version: 2.0.0
     stable_platforms: win
     unstable_platforms: mac
 -
-    id: slater
+    id: 'sci:slater'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: 'dos,mac'
     unstable_platforms: ''
 -
-    id: sq1sci
+    id: 'sci:sq1sci'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: dos
     unstable_platforms: 'amiga,mac'
 -
-    id: sq1sci
+    id: 'sci:sq1sci'
     support: excellent
     notes: '- Music in Macintosh and Amiga versions may have glitches - No support for Macintosh hi-res fonts'
     since_version: 1.3.0
     stable_platforms: 'amiga,dos,mac'
     unstable_platforms: ''
 -
-    id: sq3
+    id: 'sci:sq3'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: dos
     unstable_platforms: 'mac,amiga,atarist'
 -
-    id: sq3
+    id: 'sci:sq3'
     support: excellent
     notes: '- Music in the Amiga version may have glitches'
     since_version: 1.3.0
     stable_platforms: 'amiga,atarist,dos'
     unstable_platforms: mac
 -
-    id: sq4
+    id: 'sci:sq4'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: dos
     unstable_platforms: 'win,amiga,mac,pc98'
 -
-    id: sq4
+    id: 'sci:sq4'
     support: excellent
     notes: '- Music in Macintosh and Amiga versions may have glitches - No support for Macintosh hi-res fonts'
     since_version: 1.3.0
     stable_platforms: 'amiga,dos,mac,pc98'
     unstable_platforms: win
 -
-    id: sq4
+    id: 'sci:sq4'
     support: excellent
     notes: '- Music in Macintosh and Amiga versions may have glitches - No support for Macintosh hi-res fonts'
     since_version: 1.4.0
     stable_platforms: 'amiga,dos,mac,pc98,win'
     unstable_platforms: ''
 -
-    id: sq5
+    id: 'sci:sq5'
     support: excellent
     notes: ''
     since_version: 1.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: sq6
+    id: 'sci:sq6'
     support: good
     notes: ''
     since_version: 2.0.0
     stable_platforms: 'dos,win'
     unstable_platforms: mac
 -
-    id: torin
+    id: 'sci:torin'
     support: excellent
     notes: ''
     since_version: 2.0.0
     stable_platforms: win
     unstable_platforms: mac
 -
-    id: activity
+    id: 'scumm:activity'
     support: excellent
     notes: ''
     since_version: 0.8.0
     stable_platforms: 'dos,mac,win'
     unstable_platforms: ''
 -
-    id: airport
+    id: 'scumm:airport'
     support: bugged
     notes: '- Settings aren''t saved - Various bugs & issues'
     since_version: 0.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: airport
+    id: 'scumm:airport'
     support: good
     notes: '- Minor graphical glitches'
     since_version: 0.8.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: airport
+    id: 'scumm:airport'
     support: good
     notes: ''
     since_version: 0.9.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: airport
+    id: 'scumm:airport'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: arttime
+    id: 'scumm:arttime'
     support: good
     notes: ''
     since_version: 1.1.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: arttime
+    id: 'scumm:arttime'
     support: bugged
     notes: ''
     since_version: DEV
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: atlantis
+    id: 'scumm:atlantis'
     support: good
     notes: '- Music loud on some systems, run with -m30 to lower music volume'
     since_version: 0.1.0
     stable_platforms: dos
     unstable_platforms: 'fmtowns,mac,amiga'
 -
-    id: atlantis
+    id: 'scumm:atlantis'
     support: excellent
     notes: '- Music loud on some systems, run with -m30 to lower music volume'
     since_version: 0.2.0
     stable_platforms: dos
     unstable_platforms: 'fmtowns,mac,amiga'
 -
-    id: atlantis
+    id: 'scumm:atlantis'
     support: excellent
     notes: '- Loading of original instrument samples for Amiga version not implemented, so music differs from original interpreter - Music loud on some systems, run with -m30 to lower music volume - Various graphical glitches with Amiga version - No sound effects with Amiga version'
     since_version: 0.5.0
     stable_platforms: 'amiga,dos'
     unstable_platforms: 'fmtowns,mac'
 -
-    id: atlantis
+    id: 'scumm:atlantis'
     support: excellent
     notes: '- FM-TOWNS Kanji version requires the FM-TOWNS Font ROM - Loading of original instrument samples for Amiga version not implemented, so music differs from original interpreter - Music loud on some systems, run with -m30 to lower music volume - Various graphical glitches with Amiga version'
     since_version: 0.6.0
     stable_platforms: 'amiga,dos,fmtowns,mac'
     unstable_platforms: ''
 -
-    id: atlantis
+    id: 'scumm:atlantis'
     support: excellent
     notes: '- FM-TOWNS Kanji version requires the FM-TOWNS Font ROM - Loading of original instrument samples for Amiga version not implemented, so music differs from original interpreter - Music loud on some systems, run with -m30 to lower music volume'
     since_version: 0.7.0
     stable_platforms: 'amiga,dos,fmtowns,mac'
     unstable_platforms: ''
 -
-    id: atlantis
+    id: 'scumm:atlantis'
     support: excellent
     notes: '- FM-TOWNS Kanji version requires the FM-TOWNS Font ROM - Loading of original instrument samples for Amiga version not implemented, so music differs from original interpreter.'
     since_version: 0.8.0
     stable_platforms: 'amiga,dos,fmtowns,mac'
     unstable_platforms: ''
 -
-    id: atlantis
+    id: 'scumm:atlantis'
     support: excellent
     notes: '- FM-TOWNS Kanji version requires the FM-TOWNS Font ROM'
     since_version: 2.1.0
     stable_platforms: 'amiga,dos,fmtowns,mac'
     unstable_platforms: ''
 -
-    id: balloon
+    id: 'scumm:balloon'
     support: bugged
     notes: '- Settings aren''t saved - Various bugs & issues'
     since_version: 0.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: balloon
+    id: 'scumm:balloon'
     support: good
     notes: '- Minor Graphical glitches'
     since_version: 0.8.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: balloon
+    id: 'scumm:balloon'
     support: good
     notes: ''
     since_version: 0.8.2
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: balloon
+    id: 'scumm:balloon'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: baseball
+    id: 'scumm:baseball'
     support: bugged
     notes: '- Array out of bounds errors sometimes - Minor graphical glitches'
     since_version: 0.8.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: baseball
+    id: 'scumm:baseball'
     support: good
     notes: ''
     since_version: 1.3.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: baseball2001
+    id: 'scumm:baseball2001'
     support: broken
     notes: '- Demo version only - Only shows introduction'
     since_version: 0.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: baseball2001
+    id: 'scumm:baseball2001'
     support: bugged
     notes: '- No support for multiplayer - Array out of bounds errors sometimes - Minor graphical glitches'
     since_version: 1.1.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: baseball2001
+    id: 'scumm:baseball2001'
     support: good
     notes: '- No support for multiplayer'
     since_version: 1.3.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: baseball2003
+    id: 'scumm:baseball2003'
     support: bugged
     notes: '- Array out of bounds errors sometimes - Minor graphical glitches'
     since_version: 1.1.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: baseball2003
+    id: 'scumm:baseball2003'
     support: bugged
     notes: '- Minor graphical glitches'
     since_version: 1.3.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: baseball2003
+    id: 'scumm:baseball2003'
     support: good
     notes: ''
     since_version: 1.5.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: blues123time
+    id: 'scumm:blues123time'
     support: untested
     notes: ''
     since_version: 0.12.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: blues123time
+    id: 'scumm:blues123time'
     support: good
     notes: ''
     since_version: 0.13.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: bluesabctime
+    id: 'scumm:bluesabctime'
     support: untested
     notes: '- Demo version only'
     since_version: 0.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: bluesabctime
+    id: 'scumm:bluesabctime'
     support: good
     notes: ''
     since_version: 0.13.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: bluesbirthday
+    id: 'scumm:bluesbirthday'
     support: bugged
     notes: ''
     since_version: 0.9.0
     stable_platforms: win
     unstable_platforms: mac
 -
-    id: bluesbirthday
+    id: 'scumm:bluesbirthday'
     support: bugged
     notes: ''
     since_version: 0.10.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: bluesbirthday
+    id: 'scumm:bluesbirthday'
     support: good
     notes: '- Minor graphical glitches'
     since_version: 1.4.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: bluestreasurehunt
+    id: 'scumm:bluestreasurehunt'
     support: untested
     notes: ''
     since_version: 0.13.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: bluestreasurehunt
+    id: 'scumm:bluestreasurehunt'
     support: bugged
     notes: ''
     since_version: 2.2.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: brstorm
+    id: 'scumm:brstorm'
     support: excellent
     notes: ''
     since_version: 0.11.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: chase
+    id: 'scumm:chase'
     support: broken
     notes: '- Only shows introduction'
     since_version: 0.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: chase
+    id: 'scumm:chase'
     support: good
     notes: ''
     since_version: 0.8.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: chase
+    id: 'scumm:chase'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: comi
+    id: 'scumm:comi'
     support: broken
     notes: '- Not implemented yet. ScummVM doesn''t understand new-style MAXS block, among other things'
     since_version: 0.2.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: comi
+    id: 'scumm:comi'
     support: bugged
     notes: '- Ship-to-ship is broken and several graphical glitches are present'
     since_version: 0.4.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: comi
+    id: 'scumm:comi'
     support: good
     notes: ''
     since_version: 0.7.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: comi
+    id: 'scumm:comi'
     support: excellent
     notes: ''
     since_version: DEV
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: dig
+    id: 'scumm:dig'
     support: broken
     notes: '- Freezes occasionally due to actors not walking correctly - No in-game music, and some animations play incorrectly - Crashes due to missing SCUMM opcodes'
     since_version: 0.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: dig
+    id: 'scumm:dig'
     support: good
     notes: ''
     since_version: 0.3.0
     stable_platforms: 'dos,steam'
     unstable_platforms: ''
 -
-    id: dig
+    id: 'scumm:dig'
     support: excellent
     notes: ''
     since_version: DEV
     stable_platforms: 'dos,mac,steam,win'
     unstable_platforms: ''
 -
-    id: dog
+    id: 'scumm:dog'
     support: bugged
     notes: '- Settings aren''t saved - Various bugs & issues'
     since_version: 0.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: dog
+    id: 'scumm:dog'
     support: good
     notes: ''
     since_version: 0.8.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: dog
+    id: 'scumm:dog'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: farm
+    id: 'scumm:farm'
     support: bugged
     notes: '- Settings aren''t saved - Various bugs & issues'
     since_version: 0.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: farm
+    id: 'scumm:farm'
     support: good
     notes: '- Minor graphical glitches'
     since_version: 0.8.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: farm
+    id: 'scumm:farm'
     support: good
     notes: ''
     since_version: 0.9.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: farm
+    id: 'scumm:farm'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: fbear
+    id: 'scumm:fbear'
     support: broken
     notes: '- Various errors and asserts that prevent the game from being finishable  - talkie data not synced/properly implemented'
     since_version: 0.4.0
     stable_platforms: '3do,dos,win'
     unstable_platforms: mac
 -
-    id: fbear
+    id: 'scumm:fbear'
     support: good
     notes: '- Piano sounds aren''t the correct pitch in DOS version - Cursors aren''t scaled correctly - Decorations on birthday cake aren''t remembered - Several sound effects are missing'
     since_version: 0.6.0
     stable_platforms: '3do,dos,win'
     unstable_platforms: mac
 -
-    id: fbear
+    id: 'scumm:fbear'
     support: excellent
     notes: '- Piano sounds aren''t the correct pitch in DOS version - Cursors aren''t scaled correctly'
     since_version: 0.7.0
     stable_platforms: '3do,dos,win'
     unstable_platforms: mac
 -
-    id: fbear
+    id: 'scumm:fbear'
     support: excellent
     notes: '- Piano sounds aren''t the correct pitch in DOS version'
     since_version: 0.8.1
     stable_platforms: '3do,dos,mac,win'
     unstable_platforms: ''
 -
-    id: fbear
+    id: 'scumm:fbear'
     support: excellent
     notes: ''
     since_version: 1.1.0
     stable_platforms: '3do,dos,mac,win'
     unstable_platforms: ''
 -
-    id: fbpack
+    id: 'scumm:fbpack'
     support: bugged
     notes: '- Mini games seem to have various problems   - Reversi/Go Fish/Lines and Boxes: o6_actorOps: case 218 graphics glitches   - Coloring/Tangrams: Error(6:209:0x40D5): Invalid opcode ''db'' (readFile) '
     since_version: 0.4.0
     stable_platforms: '3do,dos'
     unstable_platforms: ''
 -
-    id: fbpack
+    id: 'scumm:fbpack'
     support: bugged
     notes: '- Mini games seem to have various problems   - Reversi/Go Fish/Lines and Boxes: o6_actorOps: case 218 graphics glitches   - Coloring: Painting has no effect   - Tangrams: Can only use central tangram piece - Talkie data not synced/properly implemented'
     since_version: 0.6.0
     stable_platforms: '3do,dos'
     unstable_platforms: ''
 -
-    id: fbpack
+    id: 'scumm:fbpack'
     support: excellent
     notes: ''
     since_version: 0.6.1
     stable_platforms: '3do,dos'
     unstable_platforms: ''
 -
-    id: football
+    id: 'scumm:football'
     support: bugged
     notes: '- Freezes when computer chooses a player, when selecting teams - Minor graphical glitches'
     since_version: 0.8.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: football
+    id: 'scumm:football'
     support: good
     notes: ''
     since_version: 1.3.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: football2002
+    id: 'scumm:football2002'
     support: broken
     notes: '- Demo version only - Only shows introduction'
     since_version: 0.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: football2002
+    id: 'scumm:football2002'
     support: bugged
     notes: '- Minor graphical glitches - No support for multiplayer - No videos - Array out of bounds error when computer chooses a player, when selecting teams'
     since_version: 1.1.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: football2002
+    id: 'scumm:football2002'
     support: good
     notes: '- Minor graphical glitches - No support for multiplayer - No videos'
     since_version: 1.3.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: freddi
+    id: 'scumm:freddi'
     support: good
     notes: ''
     since_version: 0.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: freddi
+    id: 'scumm:freddi'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'ios,mac,win'
     unstable_platforms: ''
 -
-    id: freddi2
+    id: 'scumm:freddi2'
     support: good
     notes: '- Minor graphical glitches - No songs'
     since_version: 0.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: freddi2
+    id: 'scumm:freddi2'
     support: good
     notes: '- Minor graphical glitches - Animation isn''t synced during songs'
     since_version: 0.8.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: freddi2
+    id: 'scumm:freddi2'
     support: good
     notes: '- Minor graphical glitches'
     since_version: 0.8.1
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: freddi2
+    id: 'scumm:freddi2'
     support: good
     notes: ''
     since_version: 0.9.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: freddi2
+    id: 'scumm:freddi2'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'ios,mac,win'
     unstable_platforms: ''
 -
-    id: freddi3
+    id: 'scumm:freddi3'
     support: good
     notes: ''
     since_version: 0.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: freddi3
+    id: 'scumm:freddi3'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'ios,mac,win'
     unstable_platforms: ''
 -
-    id: freddi4
+    id: 'scumm:freddi4'
     support: broken
     notes: '- No inventory controls - Various bugs & issues'
     since_version: 0.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: freddi4
+    id: 'scumm:freddi4'
     support: good
     notes: ''
     since_version: 0.8.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: freddi4
+    id: 'scumm:freddi4'
     support: excellent
     notes: ''
     since_version: DEV
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: freddicove
+    id: 'scumm:freddicove'
     support: broken
     notes: '- No inventory controls - Various bugs & issues'
     since_version: 0.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: freddicove
+    id: 'scumm:freddicove'
     support: good
     notes: ''
     since_version: 0.8.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: ft
+    id: 'scumm:ft'
     support: broken
     notes: 'Somewhat playable with #define FULL_THROTTLE'
     since_version: 0.1.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: ft
+    id: 'scumm:ft'
     support: broken
     notes: '- Game is missing action sequences - Music is not continuous, and may pause, restart, and otherwise act oddly - SMUSH audio (movie cutscenes) is a lot quieter than in-game voice, which is abnormally loud - Lack of INSANE subsystem prevents action sequences, which skips a substantial portion of the game - Derby scene is only properly controllable using the mouse - No in-game music, and some animations play incorrectly - Crashes due to missing SCUMM opcodes'
     since_version: 0.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: ft
+    id: 'scumm:ft'
     support: bugged
     notes: '- Music is not continuous, and may pause, restart, and otherwise act oddly - SMUSH audio (movie cutscenes) is a lot quieter than in-game voice, which is abnormally loud'
     since_version: 0.6.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: ft
+    id: 'scumm:ft'
     support: good
     notes: ''
     since_version: 0.6.1
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: ft
+    id: 'scumm:ft'
     support: excellent
     notes: ''
     since_version: DEV
     stable_platforms: 'dos,mac'
     unstable_platforms: ''
 -
-    id: funpack
+    id: 'scumm:funpack'
     support: broken
     notes: '- Mini games seem to have various problems   - Puzzle blocks/Pinball/Remember/Cheese King/Tic-Tac-Toe: Works but colour isn''t set properly so game is black and white    - Checkers: The checkers have some graphical glitches (actorOps case 218) - talkie data not synced/properly implemented'
     since_version: 0.4.0
     stable_platforms: '3do,dos'
     unstable_platforms: ''
 -
-    id: funpack
+    id: 'scumm:funpack'
     support: broken
     notes: '- Mini games seem to have various problems   - Cheese King: Triggers an assertion   - Checkers: The checkers have some graphical glitches (actorOps case 218)'
     since_version: 0.6.0
     stable_platforms: '3do,dos'
     unstable_platforms: ''
 -
-    id: funpack
+    id: 'scumm:funpack'
     support: broken
     notes: '- Mini games seem to have various problems   - Cheese King: Triggers an assertion'
     since_version: 0.6.1
     stable_platforms: '3do,dos'
     unstable_platforms: ''
 -
-    id: funpack
+    id: 'scumm:funpack'
     support: excellent
     notes: ''
     since_version: 0.7.0
     stable_platforms: '3do,dos'
     unstable_platforms: ''
 -
-    id: indy3
+    id: 'scumm:indy3'
     support: broken
     notes: '- The intro freezes on the LucasArts logo - hit escape to proceed - Actors not visible, and an error with walkboxes makes it impossible to walk to anything - Inventory scrolling not implemented, making it impossible to carry more than 4 objects at once  - Missing/Incorrect SCUMM opcodes cause occasional crashes'
     since_version: 0.1.0
     stable_platforms: dos
     unstable_platforms: 'atarist,mac,fmtowns,amiga'
 -
-    id: indy3
+    id: 'scumm:indy3'
     support: broken
     notes: '- Inventory scrolling not implemented, making it impossible to carry more than 4 objects at once  - Missing/Incorrect SCUMM opcodes cause occasional crashes'
     since_version: 0.2.0
     stable_platforms: dos
     unstable_platforms: 'atarist,mac,fmtowns,amiga'
 -
-    id: indy3
+    id: 'scumm:indy3'
     support: broken
     notes: '- Some major crashes may occur in the catacombs - Indiana may be able to walk in odd places, in some rooms  - No music or sound effects in VGA version - EGA version not supported'
     since_version: 0.3.0
     stable_platforms: dos
     unstable_platforms: 'atarist,mac,fmtowns,amiga'
 -
-    id: indy3
+    id: 'scumm:indy3'
     support: good
     notes: '- Indiana may be able to walk in odd places, in some rooms  - No sound effects in VGA version - No music or sound effects in EGA version'
     since_version: 0.4.0
     stable_platforms: dos
     unstable_platforms: 'atarist,mac,fmtowns,amiga'
 -
-    id: indy3
+    id: 'scumm:indy3'
     support: good
     notes: '- FM-TOWNS Kanji version not supported - FM-TOWNS Sounds with partial loops, loop the whole sample instead of just that portion - Indiana may be able to walk in odd places, in some rooms  - No music with Amiga version - No sound effect looping with Amiga version - No sound effects in VGA version'
     since_version: 0.5.0
     stable_platforms: 'amiga,dos,fmtowns'
     unstable_platforms: 'atarist,mac'
 -
-    id: indy3
+    id: 'scumm:indy3'
     support: good
     notes: '- There is no support for the Macintosh interface - FM-TOWNS Kanji version not supported - Indiana may be able to walk in odd places, in some rooms  - Atari ST and Mac versions require pcjr or pcspk music driver'
     since_version: 0.6.0
     stable_platforms: 'amiga,atarist,dos,fmtowns,mac'
     unstable_platforms: ''
 -
-    id: indy3
+    id: 'scumm:indy3'
     support: good
     notes: '- There is no support for the Macintosh interface - FM-TOWNS Kanji version requires the FM-TOWNS Font ROM - Indiana may be able to walk in odd places, in some rooms  - Atari ST and Mac versions require pcjr or pcspk music driver'
     since_version: 0.7.0
     stable_platforms: 'amiga,atarist,dos,fmtowns,mac'
     unstable_platforms: ''
 -
-    id: indy3
+    id: 'scumm:indy3'
     support: good
     notes: '- There is no support for the Macintosh interface - FM-TOWNS Kanji version requires the FM-TOWNS Font ROM'
     since_version: 0.8.0
     stable_platforms: 'amiga,atarist,dos,fmtowns,mac'
     unstable_platforms: ''
 -
-    id: jungle
+    id: 'scumm:jungle'
     support: bugged
     notes: '- Settings aren''t saved - Various bugs & issues'
     since_version: 0.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: jungle
+    id: 'scumm:jungle'
     support: good
     notes: '- Minor graphical glitches'
     since_version: 0.8.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: jungle
+    id: 'scumm:jungle'
     support: good
     notes: ''
     since_version: 0.9.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: jungle
+    id: 'scumm:jungle'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: loom
+    id: 'scumm:loom'
     support: broken
     notes: '- Intro will crash ScummVM at the end, so hit escape to bypass it - Game has graphic issues - May crash due to unimplemented opcodes'
     since_version: 0.1.0
     stable_platforms: dos
     unstable_platforms: 'pce,mac,fmtowns'
 -
-    id: loom
+    id: 'scumm:loom'
     support: bugged
     notes: '- CD music and voices are not always in perfect sync with cutscenes'
     since_version: 0.2.0
     stable_platforms: dos
     unstable_platforms: 'pce,mac,fmtowns'
 -
-    id: loom
+    id: 'scumm:loom'
     support: bugged
     notes: '- EGA version not supported'
     since_version: 0.3.0
     stable_platforms: dos
     unstable_platforms: 'pce,mac,fmtowns'
 -
-    id: loom
+    id: 'scumm:loom'
     support: bugged
     notes: '- No music or sound effects in EGA version'
     since_version: 0.4.0
     stable_platforms: dos
     unstable_platforms: 'pce,mac,fmtowns'
 -
-    id: loom
+    id: 'scumm:loom'
     support: good
     notes: '- No music with Amiga version - No sound effect looping with Amiga version'
     since_version: 0.5.0
     stable_platforms: 'amiga,dos'
     unstable_platforms: 'pce,mac,fmtowns'
 -
-    id: loom
+    id: 'scumm:loom'
     support: excellent
     notes: '- The Roland update from LucasArts is required for MIDI support - No music or sound effects in the Macintosh version - Mac version crashes after copy protection screen - There is no support for the Macintosh interface - Fades are seemingly different  - Text palette sometimes incorrect - Distaff occasionally pink - Kanji version isn''t supported - Use boot parameter to choose difficulty:    - 0 practice (default)   - 1 standard   - 2 expert'
     since_version: 0.6.0
     stable_platforms: 'amiga,atarist,dos,fmtowns,mac'
     unstable_platforms: pce
 -
-    id: loom
+    id: 'scumm:loom'
     support: excellent
     notes: '- The Roland update from LucasArts is required for MIDI support - No music or sound effects in the Macintosh version - There is no support for the Macintosh interface - Fades are seemingly different  - Text palette sometimes incorrect - Distaff occasionally pink - Kanji version isn''t supported - Use boot parameter to choose difficulty:    - 0 practice (default)   - 1 standard   - 2 expert'
     since_version: 0.6.1
     stable_platforms: 'amiga,atarist,dos,fmtowns'
     unstable_platforms: 'pce,mac'
 -
-    id: loom
+    id: 'scumm:loom'
     support: excellent
     notes: '- The Roland update from LucasArts is required for MIDI support in the EGA version - No music or sound effects in the Macintosh version - There is no support for the Macintosh interface - FM-TOWNS Kanji version requires the FM-TOWNS Font ROM - Fades are seemingly different in the FM-TOWNS version - Text palette sometimes incorrect in the FM-TOWNS version - Distaff occasionally pink in the FM-TOWNS version - Use boot parameter to choose difficulty in the FM-TOWNS version:    - 0 practice (default)   - 1 standard   - 2 expert'
     since_version: 0.7.0
     stable_platforms: 'amiga,atarist,dos,fmtowns'
     unstable_platforms: 'pce,mac'
 -
-    id: loom
+    id: 'scumm:loom'
     support: excellent
     notes: '- The Roland update from LucasArts is required for MIDI support in the EGA version - No music or sound effects in the Macintosh version - There is no support for the Macintosh interface - FM-TOWNS Kanji version requires the FM-TOWNS Font ROM - PC-Engine Kanji version requires the system card ROM - Fades are seemingly different in the FM-TOWNS version - Text palette sometimes incorrect in the FM-TOWNS version - Distaff occasionally pink in the FM-TOWNS version - Use boot parameter to choose difficulty in the FM-TOWNS version:    - 0 practice (default)   - 1 standard   - 2 expert'
     since_version: 1.1.0
     stable_platforms: 'amiga,atarist,dos,fmtowns'
     unstable_platforms: 'pce,mac'
 -
-    id: loom
+    id: 'scumm:loom'
     support: excellent
     notes: '- The Roland update from LucasArts is required for MIDI support in the EGA version - No music or sound effects in the Macintosh version - There is no support for the Macintosh interface - FM-TOWNS Kanji version requires the FM-TOWNS Font ROM - PC-Engine Kanji version requires the system card ROM'
     since_version: 1.5.0
     stable_platforms: 'amiga,atarist,dos,fmtowns,pce'
     unstable_platforms: mac
 -
-    id: loom
+    id: 'scumm:loom'
     support: excellent
     notes: '- The Roland update from LucasArts is required for MIDI support in the EGA version - There is no support for the Macintosh interface - FM-TOWNS Kanji version requires the FM-TOWNS Font ROM - PC-Engine Kanji version requires the system card ROM'
     since_version: 1.6.0
     stable_platforms: 'amiga,atarist,dos,fmtowns,pce'
     unstable_platforms: mac
 -
-    id: lost
+    id: 'scumm:lost'
     support: broken
     notes: '- Only plays introduction'
     since_version: 0.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: lost
+    id: 'scumm:lost'
     support: bugged
     notes: '- Minor graphical glitches'
     since_version: 0.8.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: lost
+    id: 'scumm:lost'
     support: good
     notes: ''
     since_version: 1.5.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: lost
+    id: 'scumm:lost'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: maniac
+    id: 'scumm:maniac'
     support: broken
     notes: '- Enhanced version displays the initial character selection screen. Neither input nor text are implemented currently, so kids cannot be selected - Internal functionality (walkboxes, text, input) are missing  - SCUMM v2 opcodes not completely implemented yet'
     since_version: 0.4.0
     stable_platforms: dos
     unstable_platforms: 'apple2,c64,nes,mac,atarist,amiga'
 -
-    id: maniac
+    id: 'scumm:maniac'
     support: bugged
     notes: '- No music or sound effects - Enhanced version runs, although in-game there are still many things wrong'
     since_version: 0.4.1
     stable_platforms: dos
     unstable_platforms: 'apple2,c64,nes,mac,atarist,amiga'
 -
-    id: maniac
+    id: 'scumm:maniac'
     support: bugged
     notes: '- Enhanced PC version is completable - Classic PC version actor costumes are broken, resulting in random crashes - No music or sound effects with Amiga and Classic PC versions'
     since_version: 0.5.0
     stable_platforms: 'amiga,dos'
     unstable_platforms: 'apple2,c64,nes,mac,atarist'
 -
-    id: maniac
+    id: 'scumm:maniac'
     support: good
     notes: '- Minor graphical glitches with actors in classic verison'
     since_version: 0.6.0
     stable_platforms: 'amiga,atarist,dos,mac'
     unstable_platforms: 'apple2,c64,nes'
 -
-    id: maniac
+    id: 'scumm:maniac'
     support: good
     notes: ''
     since_version: 0.7.0
     stable_platforms: 'amiga,atarist,dos,mac'
     unstable_platforms: 'apple2,c64,nes'
 -
-    id: maniac
+    id: 'scumm:maniac'
     support: good
     notes: '- Minor graphical glitches in NES version'
     since_version: 0.8.0
     stable_platforms: 'amiga,atarist,dos,nes,mac'
     unstable_platforms: 'apple2,c64'
 -
-    id: maniac
+    id: 'scumm:maniac'
     support: good
     notes: '- Minor graphical glitches in NES version'
     since_version: 1.8.0
     stable_platforms: 'amiga,apple2,atarist,c64,dos,nes'
     unstable_platforms: ''
 -
-    id: maniac
+    id: 'scumm:maniac'
     support: good
     notes: ''
     since_version: 2.2.0
     stable_platforms: 'amiga,apple2,atarist,c64,dos,nes'
     unstable_platforms: ''
 -
-    id: maniac
+    id: 'scumm:maniac'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'amiga,apple2,atarist,c64,dos,nes'
     unstable_platforms: ''
 -
-    id: maze
+    id: 'scumm:maze'
     support: bugged
     notes: '- Settings aren''t saved - Various bugs & issues'
     since_version: 0.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: maze
+    id: 'scumm:maze'
     support: good
     notes: ''
     since_version: 0.8.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: maze
+    id: 'scumm:maze'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: monkey
+    id: 'scumm:monkey'
     support: broken
     notes: '- VGA Floppy version not supported'
     since_version: 0.1.0
     stable_platforms: dos
     unstable_platforms: 'segacd,fmtowns,mac,atarist,amiga'
 -
-    id: monkey
+    id: 'scumm:monkey'
     support: bugged
     notes: '- EGA version not supported'
     since_version: 0.2.0
     stable_platforms: dos
     unstable_platforms: 'segacd,fmtowns,mac,atarist,amiga'
 -
-    id: monkey
+    id: 'scumm:monkey'
     support: bugged
     notes: '- No sound effects - No music looping in VGA version - EGA version is not implemented   - Copy protection screen will show, but game crashes shortly afterwards.   - Graphics decoders and SCUMM opcodes not implimented yet'
     since_version: 0.3.0
     stable_platforms: dos
     unstable_platforms: 'segacd,fmtowns,mac,atarist,amiga'
 -
-    id: monkey
+    id: 'scumm:monkey'
     support: good
     notes: '- No sound effects'
     since_version: 0.4.0
     stable_platforms: dos
     unstable_platforms: 'segacd,fmtowns,mac,atarist,amiga'
 -
-    id: monkey
+    id: 'scumm:monkey'
     support: good
     notes: '- No music or sound effects in the Amiga version - No sound effects'
     since_version: 0.5.0
     stable_platforms: 'amiga,dos'
     unstable_platforms: 'segacd,fmtowns,mac,atarist'
 -
-    id: monkey
+    id: 'scumm:monkey'
     support: excellent
     notes: '- The Roland update from LucasArts is required for MIDI support in the EGA version - Dialogue choices in the SegaCD version can be selected with 6 (up) 7 (down) or mousewheel, with mouse button or number to select - No music or sound effects in the Amiga version - No sound effects in the SegaCD version'
     since_version: 0.6.0
     stable_platforms: 'amiga,atarist,dos,fmtowns,mac,segacd'
     unstable_platforms: ''
 -
-    id: monkey
+    id: 'scumm:monkey'
     support: excellent
     notes: '- The Roland update from LucasArts is required for MIDI support in the EGA version - Dialogue choices in the SegaCD version can be selected with 6 (up) 7 (down) or mousewheel, with mouse button or number to select - No music or sound effects in the Amiga version'
     since_version: 0.7.0
     stable_platforms: 'amiga,atarist,dos,fmtowns,mac,segacd'
     unstable_platforms: ''
 -
-    id: monkey
+    id: 'scumm:monkey'
     support: excellent
     notes: '- The Roland update from LucasArts is required for MIDI support in the EGA version - Dialogue choices in the SegaCD version can be selected with mousewheel or keyboard arrow keys - No music or sound effects in the Amiga version'
     since_version: 0.10.0
     stable_platforms: 'amiga,atarist,dos,fmtowns,mac,segacd'
     unstable_platforms: ''
 -
-    id: monkey
+    id: 'scumm:monkey'
     support: excellent
     notes: '- The Roland update from LucasArts is required for MIDI support in the EGA version - Dialogue choices in the SegaCD version can be selected with mousewheel or keyboard arrow keys'
     since_version: 1.0.0
     stable_platforms: 'amiga,atarist,dos,fmtowns,mac,segacd'
     unstable_platforms: ''
 -
-    id: monkey2
+    id: 'scumm:monkey2'
     support: excellent
     notes: ''
     since_version: 0.1.0
     stable_platforms: dos
     unstable_platforms: 'fmtowns,mac,amiga'
 -
-    id: monkey2
+    id: 'scumm:monkey2'
     support: excellent
     notes: '- Loading of original instrument samples for Amiga version not implemented, so music differs from original interpreter. - No sound effects with Amiga version - Various graphical glitches with Amiga version'
     since_version: 0.5.0
     stable_platforms: 'amiga,dos'
     unstable_platforms: 'fmtowns,mac'
 -
-    id: monkey2
+    id: 'scumm:monkey2'
     support: excellent
     notes: '- Demo version often crashes due to missing resources, since it was never meant to be playable - No support for playing back the recorded file of gameplay in demo version - FM-TOWNS Kanji version requires the FM-TOWNS Font ROM - Loading of original instrument samples for Amiga version not implemented, so music differs from original interpreter. - Various graphical glitches with Amiga version'
     since_version: 0.6.0
     stable_platforms: 'amiga,dos,fmtowns,mac'
     unstable_platforms: ''
 -
-    id: monkey2
+    id: 'scumm:monkey2'
     support: excellent
     notes: '- Demo version often crashes due to missing resources, since it was never meant to be playable - No support for playing back the recorded file of gameplay in demo version - FM-TOWNS Kanji version requires the FM-TOWNS Font ROM - Loading of original instrument samples for Amiga version not implemented, so music differs from original interpreter.'
     since_version: 0.10.0
     stable_platforms: 'amiga,dos,fmtowns,mac'
     unstable_platforms: ''
 -
-    id: monkey2
+    id: 'scumm:monkey2'
     support: excellent
     notes: '- Demo version often crashes due to missing resources, since it was never meant to be playable - No support for playing back the recorded file of gameplay in demo version - FM-TOWNS Kanji version requires the FM-TOWNS Font ROM'
     since_version: 2.1.0
     stable_platforms: 'amiga,dos,fmtowns,mac'
     unstable_platforms: ''
 -
-    id: mustard
+    id: 'scumm:mustard'
     support: broken
     notes: '- Only shows introduction'
     since_version: 0.7.0
     stable_platforms: win
     unstable_platforms: mac
 -
-    id: mustard
+    id: 'scumm:mustard'
     support: good
     notes: '- Minor graphical glitches with clouds'
     since_version: 0.8.0
     stable_platforms: win
     unstable_platforms: mac
 -
-    id: mustard
+    id: 'scumm:mustard'
     support: good
     notes: ''
     since_version: 0.10.0
     stable_platforms: win
     unstable_platforms: mac
 -
-    id: mustard
+    id: 'scumm:mustard'
     support: good
     notes: ''
     since_version: 1.5.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: mustard
+    id: 'scumm:mustard'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: pajama
+    id: 'scumm:pajama'
     support: good
     notes: '- No songs'
     since_version: 0.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: pajama
+    id: 'scumm:pajama'
     support: good
     notes: '- Gaps and glitches in the background music in Kitchen and Mine areas'
     since_version: 0.9.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: pajama
+    id: 'scumm:pajama'
     support: good
     notes: ''
     since_version: 1.2.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: pajama2
+    id: 'scumm:pajama2'
     support: good
     notes: '- Actor limbs sometimes aren''t visible'
     since_version: 0.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: pajama2
+    id: 'scumm:pajama2'
     support: good
     notes: ''
     since_version: 0.8.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: pajama2
+    id: 'scumm:pajama2'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'ios,mac,win'
     unstable_platforms: ''
 -
-    id: pajama3
+    id: 'scumm:pajama3'
     support: broken
     notes: '- PlayStation 1 version doesn''t use SCUMM - Minor graphical glitches - Sprites aren''t displayed during Ski Ride'
     since_version: 0.8.0
     stable_platforms: 'mac,win'
     unstable_platforms: psx
 -
-    id: pajama3
+    id: 'scumm:pajama3'
     support: good
     notes: '- PlayStation 1 version doesn''t use SCUMM - Minor graphical glitches with dancing can in stomach'
     since_version: 0.8.2
     stable_platforms: 'mac,win'
     unstable_platforms: psx
 -
-    id: pajama3
+    id: 'scumm:pajama3'
     support: good
     notes: '- PlayStation 1 version doesn''t use SCUMM'
     since_version: 0.10.0
     stable_platforms: 'mac,win'
     unstable_platforms: psx
 -
-    id: pass
+    id: 'scumm:pass'
     support: bugged
     notes: '- No subtitles in indy3 demo - No sound effects'
     since_version: 0.4.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: pass
+    id: 'scumm:pass'
     support: excellent
     notes: ''
     since_version: 0.6.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: pjgames
+    id: 'scumm:pjgames'
     support: bugged
     notes: '- Jumping Beans freezes, after introduction'
     since_version: 1.1.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: pjgames
+    id: 'scumm:pjgames'
     support: good
     notes: ''
     since_version: 1.8.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: pjgames
+    id: 'scumm:pjgames'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: puttcircus
+    id: 'scumm:puttcircus'
     support: broken
     notes: '- No inventory controls - Various bugs & issues'
     since_version: 0.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: puttcircus
+    id: 'scumm:puttcircus'
     support: good
     notes: '- Magnifying glass doesn''t work'
     since_version: 0.8.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: puttcircus
+    id: 'scumm:puttcircus'
     support: good
     notes: ''
     since_version: 0.8.2
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: puttmoon
+    id: 'scumm:puttmoon'
     support: broken
     notes: '- Fails an AKOS related assertion shortly after starting  - talkie data not synced/properly implemented - cursor doesn''t turn to arrow on the right hand side of the screen in the first room in the demo'
     since_version: 0.4.0
     stable_platforms: dos
     unstable_platforms: mac
 -
-    id: puttmoon
+    id: 'scumm:puttmoon'
     support: broken
     notes: '- Fails an AKOS related assertion shortly after starting  - Creature behind garage door dissappears'
     since_version: 0.6.0
     stable_platforms: dos
     unstable_platforms: mac
 -
-    id: puttmoon
+    id: 'scumm:puttmoon'
     support: excellent
     notes: ''
     since_version: 0.7.0
     stable_platforms: '3do,win,dos'
     unstable_platforms: mac
 -
-    id: puttmoon
+    id: 'scumm:puttmoon'
     support: excellent
     notes: ''
     since_version: 0.8.2
     stable_platforms: '3do,mac,win,dos'
     unstable_platforms: ''
 -
-    id: puttputt
+    id: 'scumm:puttputt'
     support: broken
     notes: '- Fails to start after looking for seemingly non existent object - talkie data not synced/properly implemented'
     since_version: 0.4.0
     stable_platforms: '3do,dos,win'
     unstable_platforms: mac
 -
-    id: puttputt
+    id: 'scumm:puttputt'
     support: good
     notes: '- Minor graphical glitches when cars come out of their garages on streets - Some sound effects missing'
     since_version: 0.6.0
     stable_platforms: '3do,dos,win'
     unstable_platforms: mac
 -
-    id: puttputt
+    id: 'scumm:puttputt'
     support: good
     notes: '- Minor graphical glitches when cars come out of their garages on streets'
     since_version: 0.6.1
     stable_platforms: '3do,dos,win'
     unstable_platforms: mac
 -
-    id: puttputt
+    id: 'scumm:puttputt'
     support: good
     notes: '- Cursors aren''t scaled correctly in Windows version'
     since_version: 0.7.0
     stable_platforms: '3do,dos,win'
     unstable_platforms: mac
 -
-    id: puttputt
+    id: 'scumm:puttputt'
     support: excellent
     notes: ''
     since_version: 0.8.0
     stable_platforms: '3do,dos,win'
     unstable_platforms: mac
 -
-    id: puttputt
+    id: 'scumm:puttputt'
     support: excellent
     notes: ''
     since_version: 0.8.2
     stable_platforms: '3do,dos,mac,win'
     unstable_platforms: ''
 -
-    id: puttrace
+    id: 'scumm:puttrace'
     support: broken
     notes: '- No inventory controls - Various bugs & issues'
     since_version: 0.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: puttrace
+    id: 'scumm:puttrace'
     support: good
     notes: '- Animation isn''t synced during songs'
     since_version: 0.8.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: puttrace
+    id: 'scumm:puttrace'
     support: good
     notes: ''
     since_version: 0.8.2
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: puttrace
+    id: 'scumm:puttrace'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: putttime
+    id: 'scumm:putttime'
     support: good
     notes: '- Minor graphical glitches when talking in HE80 version - Inventory background and items are often not redrawn - No songs'
     since_version: 0.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: putttime
+    id: 'scumm:putttime'
     support: good
     notes: '- Minor graphical glitches when talking in HE80 version'
     since_version: 0.8.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: putttime
+    id: 'scumm:putttime'
     support: good
     notes: ''
     since_version: 0.10.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: putttime
+    id: 'scumm:putttime'
     support: excellent
     notes: ''
     since_version: DEV
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: puttzoo
+    id: 'scumm:puttzoo'
     support: good
     notes: '- Minor graphical glitches when meeting Kenya in HE72 version - Inventory background and items are often not redrawn'
     since_version: 0.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: puttzoo
+    id: 'scumm:puttzoo'
     support: good
     notes: '- Minor graphical glitches when meeting Kenya in HE72 version'
     since_version: 0.8.0
     stable_platforms: 'ios,mac,win'
     unstable_platforms: ''
 -
-    id: puttzoo
+    id: 'scumm:puttzoo'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'ios,mac,win'
     unstable_platforms: ''
 -
-    id: readtime
+    id: 'scumm:readtime'
     support: good
     notes: ''
     since_version: 1.1.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: samnmax
+    id: 'scumm:samnmax'
     support: broken
     notes: '- Inventory is not resorted after visiting the carnival lost & found - MIDI music requires SAMNMAX to be defined'
     since_version: 0.1.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: samnmax
+    id: 'scumm:samnmax'
     support: excellent
     notes: '- Some mini games may not work'
     since_version: 0.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: samnmax
+    id: 'scumm:samnmax'
     support: excellent
     notes: '- Highway subgame doesn''t behave correctly'
     since_version: 0.3.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: samnmax
+    id: 'scumm:samnmax'
     support: excellent
     notes: ''
     since_version: 0.8.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: socks
+    id: 'scumm:socks'
     support: bugged
     notes: '- Settings aren''t saved - Various bugs & issues'
     since_version: 0.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: socks
+    id: 'scumm:socks'
     support: good
     notes: ''
     since_version: 0.8.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: socks
+    id: 'scumm:socks'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: spyfox
+    id: 'scumm:spyfox'
     support: broken
     notes: '- No inventory controls - Various bugs & issues'
     since_version: 0.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: spyfox
+    id: 'scumm:spyfox'
     support: good
     notes: '- Minor selection issue with buttons on paintings'
     since_version: 0.8.0
     stable_platforms: 'ios,mac,win'
     unstable_platforms: ''
 -
-    id: spyfox
+    id: 'scumm:spyfox'
     support: good
     notes: ''
     since_version: 0.9.0
     stable_platforms: 'ios,mac,win'
     unstable_platforms: ''
 -
-    id: spyfox
+    id: 'scumm:spyfox'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'ios,mac,win'
     unstable_platforms: ''
 -
-    id: spyfox2
+    id: 'scumm:spyfox2'
     support: broken
     notes: '- No inventory controls - Various bugs & issues'
     since_version: 0.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: spyfox2
+    id: 'scumm:spyfox2'
     support: good
     notes: ''
     since_version: 0.8.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: spyfox2
+    id: 'scumm:spyfox2'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: spyozon
+    id: 'scumm:spyozon'
     support: broken
     notes: '- No inventory controls - Various bugs & issues'
     since_version: 0.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: spyozon
+    id: 'scumm:spyozon'
     support: broken
     notes: '- Need to guess the correct colors of Poodles''s fingernails - Various palette glitches - Asserts when looking at pearl'
     since_version: 0.8.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: spyozon
+    id: 'scumm:spyozon'
     support: good
     notes: '- Need to guess the correct colors of Poodles''s fingernails - Various palette glitches'
     since_version: 0.8.2
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: spyozon
+    id: 'scumm:spyozon'
     support: good
     notes: ''
     since_version: 1.1.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: tentacle
+    id: 'scumm:tentacle'
     support: excellent
     notes: '- Maniac Mansion isn''t playable on Ed''s computer. To play the included copy, use ''Add Game'' from the main ScummVM launcher and select the MANIAC directory inside the DOTT game directory'
     since_version: 0.1.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: thinker1
+    id: 'scumm:thinker1'
     support: broken
     notes: '- Demo version only - Objects in mini games aren''t drawn'
     since_version: 0.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: thinker1
+    id: 'scumm:thinker1'
     support: good
     notes: '- Need to use ESC when car is stuck in the smart star challenge'
     since_version: 0.8.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: thinker1
+    id: 'scumm:thinker1'
     support: good
     notes: ''
     since_version: 0.10.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: thinker1
+    id: 'scumm:thinker1'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: thinkerk
+    id: 'scumm:thinkerk'
     support: bugged
     notes: '- Settings aren''t saved - Various bugs & issues'
     since_version: 0.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: thinkerk
+    id: 'scumm:thinkerk'
     support: good
     notes: ''
     since_version: 0.8.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: thinkerk
+    id: 'scumm:thinkerk'
     support: good
     notes: '- Minor graphical glitches'
     since_version: 0.8.1
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: thinkerk
+    id: 'scumm:thinkerk'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: water
+    id: 'scumm:water'
     support: bugged
     notes: '- Settings aren''t saved - Various bugs & issues'
     since_version: 0.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: water
+    id: 'scumm:water'
     support: good
     notes: '- Minor Graphical glitches'
     since_version: 0.8.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: water
+    id: 'scumm:water'
     support: good
     notes: ''
     since_version: 0.8.2
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: water
+    id: 'scumm:water'
     support: excellent
     notes: ''
     since_version: 2.6.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: zak
+    id: 'scumm:zak'
     support: broken
     notes: '- The intro freezes on the LucasArts logo - hit escape to proceed - Actors not visible, and an error with walkboxes makes it impossible to walk to anything'
     since_version: 0.1.0
     stable_platforms: 'dos,fmtowns'
     unstable_platforms: 'atarist,c64,amiga'
 -
-    id: zak
+    id: 'scumm:zak'
     support: bugged
     notes: '- DOS EGA is not supported - No music or sound effects'
     since_version: 0.2.0
     stable_platforms: 'dos,fmtowns'
     unstable_platforms: 'atarist,c64,amiga'
 -
-    id: zak
+    id: 'scumm:zak'
     support: broken
     notes: '- DOS EGA   - The introduction sequence runs, and the game can be started by escaping past it. However neither text nor input are implemented.   - Internal functionality (walkboxes, text, input) are missing    - SCUMM v2 opcodes not completely implemented yet - FM-TOWNS   - No sound effect looping'
     since_version: 0.4.0
     stable_platforms: 'dos,fmtowns'
     unstable_platforms: 'atarist,c64,amiga'
 -
-    id: zak
+    id: 'scumm:zak'
     support: bugged
     notes: '- Classic PC version does not start, due to script problems  - Classic PC version actor costumes are broken, resulting in random crashes  - No music or sound effects in DOS version - FM-TOWNS Kanji version not supported - FM-TOWNS No sound effect looping'
     since_version: 0.4.1
     stable_platforms: 'dos,fmtowns'
     unstable_platforms: 'atarist,c64,amiga'
 -
-    id: zak
+    id: 'scumm:zak'
     support: bugged
     notes: '- FM-TOWNS Kanji version not supported - FM-TOWNS Sounds with partial loops, loop the whole sample instead of just that portion - Classic PC version does not start, due to script problems  - Classic PC version actor costumes are broken, resulting in random crashes  - No music or sound effects with Amiga'
     since_version: 0.5.0
     stable_platforms: 'amiga,dos,fmtowns'
     unstable_platforms: 'atarist,c64'
 -
-    id: zak
+    id: 'scumm:zak'
     support: good
     notes: '- FM-TOWNS Kanji version not supported - Minor graphical glitches with actors in classic verison - No music or sound effects in the Commodore 64 version - Several sound effects buggy or missing in Amiga version'
     since_version: 0.6.0
     stable_platforms: 'amiga,atarist,c64,dos,fmtowns'
     unstable_platforms: ''
 -
-    id: zak
+    id: 'scumm:zak'
     support: good
     notes: '- FM-TOWNS Kanji version requires the FM-TOWNS Font ROM - No music or sound effects in the Commodore 64 version - Several sound effects buggy or missing in Amiga version'
     since_version: 0.7.0
     stable_platforms: 'amiga,atarist,c64,dos,fmtowns'
     unstable_platforms: ''
 -
-    id: zak
+    id: 'scumm:zak'
     support: good
     notes: '- FM-TOWNS Kanji version requires the FM-TOWNS Font ROM - No music or sound effects in the Commodore 64 version'
     since_version: 0.12.0
     stable_platforms: 'amiga,atarist,c64,dos,fmtowns'
     unstable_platforms: ''
 -
-    id: zak
+    id: 'scumm:zak'
     support: good
     notes: '- FM-TOWNS Kanji version requires the FM-TOWNS Font ROM'
     since_version: 1.1.0
     stable_platforms: 'amiga,atarist,c64,dos,fmtowns'
     unstable_platforms: ''
 -
-    id: rosetattoo
+    id: 'sherlock:rosetattoo'
     support: untested
     notes: ''
     since_version: 1.8.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: rosetattoo
+    id: 'sherlock:rosetattoo'
     support: good
     notes: ''
     since_version: 2.1.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: scalpel
+    id: 'sherlock:scalpel'
     support: untested
     notes: ''
     since_version: 1.8.0
     stable_platforms: dos
     unstable_platforms: 3do
 -
-    id: scalpel
+    id: 'sherlock:scalpel'
     support: good
     notes: ''
     since_version: 2.1.0
     stable_platforms: dos
     unstable_platforms: 3do
 -
-    id: sky
+    id: 'sky:sky'
     support: broken
     notes: '- Only the introduction works'
     since_version: 0.4.0
     stable_platforms: dos
     unstable_platforms: amiga
 -
-    id: sky
+    id: 'sky:sky'
     support: bugged
     notes: '- Requires the sky.cpt resource file to be placed in the game directory - Random crashes have been reported  - Floppy demos aren''t supported - The following bugs are present in the original game and can''t be fixed:   - The voice files for some sentences are missing.   - This is especially noticeable in the court and Mrs. Piermont sequence.   - The fonts for the LINC terminal are partially incorrect and the text sometimes passes the screen borders   - Special characters for french and italian subtitles are incorrect sometimes'
     since_version: 0.5.0
     stable_platforms: dos
     unstable_platforms: amiga
 -
-    id: sky
+    id: 'sky:sky'
     support: excellent
     notes: '- Requires the sky.cpt resource file to be placed in the game directory - Floppy demos aren''t supported - The following bugs are present in the original game and can''t be fixed:   - The voice files for some sentences are missing.   - This is especially noticeable in the court and Mrs. Piermont sequence.   - The fonts for the LINC terminal are partially incorrect and the text sometimes passes the screen borders   - Special characters for french and italian subtitles are incorrect sometimes'
     since_version: 0.6.0
     stable_platforms: dos
     unstable_platforms: amiga
 -
-    id: sky
+    id: 'sky:sky'
     support: excellent
     notes: '- Floppy demos aren''t supported - The following bugs are present in the original game and can''t be fixed:   - The voice files for some sentences are missing.   - This is especially noticeable in the court and Mrs. Piermont sequence.   - The fonts for the LINC terminal are partially incorrect and the text sometimes passes the screen borders   - Special characters for french and italian subtitles are incorrect sometimes'
     since_version: 1.6.0
     stable_platforms: dos
     unstable_platforms: amiga
 -
-    id: tlj
+    id: 'stark:tlj'
     support: good
     notes: ''
     since_version: 2.5.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: msn1
+    id: 'supernova:msn1'
     support: good
     notes: ''
     since_version: 2.1.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: msn2
+    id: 'supernova:msn2'
     support: good
     notes: ''
     since_version: 2.1.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: sword1
+    id: 'sword1:sword1'
     support: good
     notes: ''
     since_version: 0.6.0
     stable_platforms: 'dos,win'
     unstable_platforms: 'psx,mac'
 -
-    id: sword1
+    id: 'sword1:sword1'
     support: excellent
     notes: ''
     since_version: 0.10.0
     stable_platforms: 'dos,win,mac'
     unstable_platforms: psx
 -
-    id: sword1
+    id: 'sword1:sword1'
     support: excellent
     notes: ''
     since_version: 1.0.0
     stable_platforms: 'dos,psx,win,mac'
     unstable_platforms: ''
 -
-    id: sword2
+    id: 'sword2:sword2'
     support: good
     notes: ''
     since_version: 0.6.0
     stable_platforms: win
     unstable_platforms: psx
 -
-    id: sword2
+    id: 'sword2:sword2'
     support: excellent
     notes: ''
     since_version: 1.0.0
     stable_platforms: 'psx,win'
     unstable_platforms: ''
 -
-    id: sword25
+    id: 'sword25:sword25'
     support: untested
     notes: ''
     since_version: 1.8.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: sword25
+    id: 'sword25:sword25'
     support: excellent
     notes: ''
     since_version: 2.1.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: teenagent
+    id: 'teenagent:teenagent'
     support: good
     notes: '- Requires the teenagent.dat resource file to be placed in the game directory - Occasional graphical glitches'
     since_version: 1.1.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: teenagent
+    id: 'teenagent:teenagent'
     support: good
     notes: '- Occasional graphical glitches'
     since_version: 1.6.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: dw
+    id: 'tinsel:dw'
     support: excellent
     notes: '- PSX version is missing music support'
     since_version: 1.0.0
     stable_platforms: 'dos,psx'
     unstable_platforms: mac
 -
-    id: dw
+    id: 'tinsel:dw'
     support: excellent
     notes: '- PSX version is missing music support'
     since_version: 1.6.0
     stable_platforms: 'dos,mac,psx'
     unstable_platforms: ''
 -
-    id: dw2
+    id: 'tinsel:dw2'
     support: excellent
     notes: ''
     since_version: 1.0.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: titanic
+    id: 'titanic:titanic'
     support: good
     notes: ''
     since_version: 2.0.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: toltecs
+    id: 'toltecs:toltecs'
     support: good
     notes: ''
     since_version: 1.6.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: tony
+    id: 'tony:tony'
     support: excellent
     notes: ''
     since_version: 1.6.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: toon
+    id: 'toon:toon'
     support: excellent
     notes: '- Requires the toon.dat resource file to be placed in the game directory - Occasional graphical glitches'
     since_version: 1.3.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: toon
+    id: 'toon:toon'
     support: excellent
     notes: ''
     since_version: 1.5.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: toon
+    id: 'toon:toon'
     support: good
     notes: ''
     since_version: 2.6.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: touche
+    id: 'touche:touche'
     support: good
     notes: '- Occasional graphical glitches'
     since_version: 0.10.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: nl
+    id: 'trecision:nl'
     support: excellent
     notes: '- Amiga videos are not yet supported'
     since_version: 2.5.0
     stable_platforms: win
     unstable_platforms: amiga
 -
-    id: blueforce
+    id: 'tsage:blueforce'
     support: good
     notes: ''
     since_version: 1.5.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: blueforce
+    id: 'tsage:blueforce'
     support: good
     notes: '- English and Spanish versions supported'
     since_version: 2.5.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: ringworld
+    id: 'tsage:ringworld'
     support: good
     notes: ''
     since_version: 1.4.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: ringworld
+    id: 'tsage:ringworld'
     support: good
     notes: '- English and Spanish versions supported'
     since_version: 2.5.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: ringworld2
+    id: 'tsage:ringworld2'
     support: untested
     notes: ''
     since_version: 1.7.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: ringworld2
+    id: 'tsage:ringworld2'
     support: good
     notes: ''
     since_version: 2.1.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: tucker
+    id: 'tucker:tucker'
     support: excellent
     notes: ''
     since_version: 0.13.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: lba
+    id: 'twine:lba'
     support: good
     notes: ''
     since_version: 2.5.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: remorse
+    id: 'ultima:remorse'
     support: good
     notes: ''
     since_version: 2.5.0
     stable_platforms: dos
     unstable_platforms: psx
 -
-    id: ultima4
+    id: 'ultima:ultima4'
     support: good
     notes: '- FM-Towns may be working, but we''ll need someone with a copy to provide us a detection entry and test it out. - Provides an optional VGA enhanced mode'
     since_version: 2.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: ultima6
+    id: 'ultima:ultima6'
     support: good
     notes: '- German translation patch is also partially supported, with some interface elements not translated. - Provides an optional enhanced mode that has a full screen map and container widgets.'
     since_version: 2.2.0
     stable_platforms: dos
     unstable_platforms: pc98
 -
-    id: ultima8
+    id: 'ultima:ultima8'
     support: good
     notes: ''
     since_version: 2.2.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: voyeur
+    id: 'voyeur:voyeur'
     support: good
     notes: ''
     since_version: 1.7.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: 5ld
+    id: 'wintermute:5ld'
     support: good
     notes: ''
     since_version: 1.7.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: 5ma
+    id: 'wintermute:5ma'
     support: good
     notes: ''
     since_version: 1.7.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: bickadoodle
+    id: 'wintermute:bickadoodle'
     support: good
     notes: ''
     since_version: 1.7.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: chivalry
+    id: 'wintermute:chivalry'
     support: good
     notes: '- Requires additional fonts.'
     since_version: 1.7.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: deadcity
+    id: 'wintermute:deadcity'
     support: good
     notes: ''
     since_version: 1.7.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: dirtysplit
+    id: 'wintermute:dirtysplit'
     support: good
     notes: ''
     since_version: 1.7.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: escapemansion
+    id: 'wintermute:escapemansion'
     support: good
     notes: ''
     since_version: 1.7.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: helga
+    id: 'wintermute:helga'
     support: good
     notes: ''
     since_version: 1.7.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: ritter
+    id: 'wintermute:ritter'
     support: good
     notes: ''
     since_version: 1.7.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: rosemary
+    id: 'wintermute:rosemary'
     support: good
     notes: ''
     since_version: 1.7.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: twc
+    id: 'wintermute:twc'
     support: good
     notes: ''
     since_version: 1.7.0
     stable_platforms: 'win,mac'
     unstable_platforms: ''
 -
-    id: cloudsofxeen
+    id: 'xeen:cloudsofxeen'
     support: good
     notes: ''
     since_version: 2.1.0
     stable_platforms: dos
     unstable_platforms: dos
 -
-    id: darksideofxeen
+    id: 'xeen:darksideofxeen'
     support: good
     notes: ''
     since_version: 2.1.0
     stable_platforms: dos
     unstable_platforms: dos
 -
-    id: swordsofxeen
+    id: 'xeen:swordsofxeen'
     support: good
     notes: ''
     since_version: 2.1.0
     stable_platforms: dos
     unstable_platforms: ''
 -
-    id: worldofxeen
+    id: 'xeen:worldofxeen'
     support: good
     notes: ''
     since_version: 2.1.0
     stable_platforms: dos
     unstable_platforms: dos
 -
-    id: zgi
+    id: 'zvision:zgi'
     support: good
     notes: '- The hires MPEG2 videos of the DVD version aren''t supported yet. The lowres videos are used instead'
     since_version: 1.8.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: zgi
+    id: 'zvision:zgi'
     support: good
     notes: ''
     since_version: 2.1.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: znemesis
+    id: 'zvision:znemesis'
     support: good
     notes: ''
     since_version: 1.8.0
     stable_platforms: 'dos,win'
     unstable_platforms: ''
 -
-    id: chopsuey
+    id: 'director:chopsuey'
     support: excellent
     notes: ''
     since_version: 2.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: easternmind
+    id: 'director:easternmind'
     support: good
     notes: ''
     since_version: 2.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: fukuokagoround
+    id: 'director:fukuokagoround'
     support: bugged
     notes: 'Certain videos don''t load'
     since_version: 2.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: ganbareinuchan
+    id: 'director:ganbareinuchan'
     support: excellent
     notes: ''
     since_version: 2.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: ganbareinuchan2
+    id: 'director:ganbareinuchan2'
     support: excellent
     notes: ''
     since_version: 2.7.0
     stable_platforms: mac
     unstable_platforms: ''
 -
-    id: henachoco01
+    id: 'director:henachoco01'
     support: good
     notes: ''
     since_version: 2.7.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: henachoco02
+    id: 'director:henachoco02'
     support: good
     notes: ''
     since_version: 2.7.0
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: henachoco03
+    id: 'director:henachoco03'
     support: good
     notes: ''
     since_version: 2.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: henachoco04
+    id: 'director:henachoco04'
     support: good
     notes: ''
     since_version: 2.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: henachoco05
+    id: 'director:henachoco05'
     support: bugged
     notes: ''
     since_version: 2.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: japanart07
+    id: 'director:japanart07'
     support: bugged
     notes: 'Scrolling text box feature isn''t supported yet'
     since_version: 2.7.0
     stable_platforms: mac
     unstable_platforms: ''
 -
-    id: majestic
+    id: 'director:majestic'
     support: good
     notes: '- German release uses Director 5 and is not yet supported'
     since_version: 2.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: nemurenu
+    id: 'director:nemurenu'
     support: excellent
     notes: 'Intro doesn''t play in Mac version (uses accelerator)'
     since_version: 2.7.0
     stable_platforms: 'mac,pippin'
     unstable_platforms: ''
 -
-    id: overringunder
+    id: 'director:overringunder'
     support: good
     notes: ''
     since_version: 2.7.0
     stable_platforms: mac
     unstable_platforms: ''
 -
-    id: pepperon
+    id: 'director:pepperon'
     support: good
     notes: ''
     since_version: 2.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: the7colors
+    id: 'director:the7colors'
     support: good
     notes: ''
     since_version: 2.7.0
     stable_platforms: mac
     unstable_platforms: ''
 -
-    id: timegal
+    id: 'director:timegal'
     support: good
     notes: ''
     since_version: 2.7.0
     stable_platforms: 'mac,win'
     unstable_platforms: ''
 -
-    id: syberia
+    id: 'tetraedge:syberia'
     support: good
     notes: ''
     since_version: DEV
     stable_platforms: mac
     unstable_platforms: 'win,ps2,xbox,winmobile,nds,android,ps3,xbox360,ios,switch'
 -
-    id: syberia2
+    id: 'tetraedge:syberia2'
     support: good
     notes: ''
     since_version: DEV
     stable_platforms: mac
     unstable_platforms: 'win,ps2,xbox,winmobile,android,ps3,xbox360,ios,switch'
 -
-    id: nancy1
+    id: 'nancy:nancy1'
     support: good
     notes: 'Original menus are not yet supported'
     since_version: DEV
     stable_platforms: win
     unstable_platforms: ''
 -
-    id: vampirediaries
+    id: 'nancy:vampirediaries'
     support: good
     notes: 'Original menus are not yet supported'
     since_version: DEV

--- a/data/en/director_demos.yaml
+++ b/data/en/director_demos.yaml
@@ -1,97 +1,97 @@
 # This is a generated file, please do not edit manually
 -
-    id: bigsound
+    id: 'director:bigsound'
     platform: mac
     lang: en
     title: 'BigSound VW Player'
     version: '0'
     url: /frs/demos/director/d0/en/bigsound-mac.zip
 -
-    id: freehand
+    id: 'director:freehand'
     platform: mac
     lang: en
     title: 'Aldus FreeHand 2.0'
     version: '0'
     url: /frs/demos/director/d0/en/freehand-demo-mac.zip
 -
-    id: geoquery
+    id: 'director:geoquery'
     platform: mac
     lang: en
     title: 'Odesta GeoQuery'
     version: '0'
     url: /frs/demos/director/d0/en/geoquery-demo-mac.zip
 -
-    id: ideacomm
+    id: 'director:ideacomm'
     platform: mac
     lang: en
     title: 'IDEAcomm Mac'
     version: '0'
     url: /frs/demos/director/d0/en/ideacomm-demo-mac.zip
 -
-    id: illustrator88
+    id: 'director:illustrator88'
     platform: mac
     lang: en
     title: 'Adobe Illustrator 88'
     version: '0'
     url: /frs/demos/director/d0/en/illustrator88-demo-mac.zip
 -
-    id: macportable
+    id: 'director:macportable'
     platform: mac
     lang: en
     title: 'Your Apple Tour of the Macintosh Portable'
     version: '0'
     url: /frs/demos/director/d0/en/macportable-mac.zip
 -
-    id: musicpublisher
+    id: 'director:musicpublisher'
     platform: mac
     lang: en
     title: 'Graphic Notes Music Publisher'
     version: '0'
     url: /frs/demos/director/d0/en/musicpublisher-demo-mac.zip
 -
-    id: osmo
+    id: 'director:osmo'
     platform: mac
     lang: en
     title: 'Cosmic Osmo and the Worlds Beyond the Mackerel'
     version: '0'
     url: /frs/demos/director/d0/en/osmo-demo-mac.zip
 -
-    id: pspice
+    id: 'director:pspice'
     platform: mac
     lang: en
     title: 'MicroSim PSpice'
     version: '0'
     url: /frs/demos/director/d0/en/pspice-demo-mac.zip
 -
-    id: shatter
+    id: 'director:shatter'
     platform: mac
     lang: en
     title: 'Shatter by Mike Saenz'
     version: '0'
     url: /frs/demos/director/d0/en/shatter-demo-mac.zip
 -
-    id: osmo
+    id: 'director:osmo'
     platform: mac
     lang: en
     title: 'Cosmic Osmo and the Worlds Beyond the Mackerel'
     version: '1'
     url: /frs/demos/director/d1/en/osmo-demo-cd-mac.zip
 -
-    id: rosettastone
+    id: 'director:rosettastone'
     platform: mac
     lang: ja
     title: 'The Rosetta Stone'
     version: '1'
     url: /frs/demos/director/d1/ja/rosettastone-demo-mac-ja.zip
 -
-    id: backgrounds
+    id: 'director:backgrounds'
     platform: mac
     lang: en
     title: 'Backgrounds for Multimedia Series'
     version: '2'
     url: /frs/demos/director/d2/en/backgrounds-demo-mac.zip
 -
-    id: director
+    id: 'director:director'
     platform: mac
     lang: en
     title: 'The Apartment D2'
@@ -105,4088 +105,4088 @@
     version: '2'
     url: /frs/demos/director/d2/en/system7smash-mac.zip
 -
-    id: warlock
+    id: 'director:warlock'
     platform: mac
     lang: en
     title: 'Spaceship Warlock'
     version: '2'
     url: /frs/demos/director/d2/en/warlock-demo-mac-100.zip
 -
-    id: warlock
+    id: 'director:warlock'
     platform: mac
     lang: en
     title: 'Spaceship Warlock'
     version: '2'
     url: /frs/demos/director/d2/en/warlock-demo-mac-111.zip
 -
-    id: aamn
+    id: 'director:aamn'
     platform: mac
     lang: en
     title: 'Anatomy & Anaesthesia of the Mandibular Nerve'
     version: '3'
     url: /frs/demos/director/d3/en/aamn-demo-mac.zip
 -
-    id: adam
+    id: 'director:adam'
     platform: mac
     lang: ja
     title: A.D.A.M.
     version: '3'
     url: /frs/demos/director/d3/ja/adam-demo-mac-ja.zip
 -
-    id: adobedimensions
+    id: 'director:adobedimensions'
     platform: mac
     lang: ja
     title: 'Professional Tips for Adobe Dimensions'
     version: '3'
     url: /frs/demos/director/d3/ja/adobedimensions-demo-mac-ja.zip
 -
-    id: alankay
+    id: 'director:alankay'
     platform: mac
     lang: ja
     title: 'Alan Kay CD-ROM Pack'
     version: '3'
     url: /frs/demos/director/d3/ja/alankay-demo-mac-ja.zip
 -
-    id: amandastories
+    id: 'director:amandastories'
     platform: mac
     lang: en
     title: AmandaStories
     version: '3'
     url: /frs/demos/director/d3/en/amandastories-demo-mac.zip
 -
-    id: animaltown
+    id: 'director:animaltown'
     platform: mac
     lang: ja
     title: わくわくアニマルタウン
     version: '3'
     url: /frs/demos/director/d3/ja/animaltown-demo-mac-ja.zip
 -
-    id: asylum300
+    id: 'director:asylum300'
     platform: mac
     lang: ja
     title: 'Asylum 300'
     version: '3'
     url: /frs/demos/director/d3/ja/asylum300-demo-mac-ja.zip
 -
-    id: bakkunooni
+    id: 'director:bakkunooni'
     platform: mac
     lang: ja
     title: 'VOLT-AGE バックの鬼 -侘-'
     version: '3'
     url: /frs/demos/director/d3/ja/bakkunooni-demo-mac-ja.zip
 -
-    id: belcher
+    id: 'director:belcher'
     platform: mac
     lang: en
     title: 'The Belcher'
     version: '3'
     url: /frs/demos/director/d3/en/belcher-mac.zip
 -
-    id: bigtimemovie
+    id: 'director:bigtimemovie'
     platform: mac
     lang: ja
     title: 'Big Time Movie Studios'
     version: '3'
     url: /frs/demos/director/d3/ja/bigtimemovie-demo-mac-ja.zip
 -
-    id: bioflix
+    id: 'director:bioflix'
     platform: mac
     lang: en
     title: BioFlix
     version: '3'
     url: /frs/demos/director/d3/en/bioflix-demo-mac.zip
 -
-    id: blam
+    id: 'director:blam'
     platform: mac
     lang: en
     title: BLAM!
     version: '3'
     url: /frs/demos/director/d3/blam-demo-mac.zip
 -
-    id: bob
+    id: 'director:bob'
     platform: mac
     lang: en
     title: Bob
     version: '3'
     url: /frs/demos/director/d3/en/bob-mac.zip
 -
-    id: bodypark
+    id: 'director:bodypark'
     platform: win
     lang: en
     title: 'Body Park'
     version: '3'
     url: /frs/demos/director/d3/en/bodypark-demo-win.zip
 -
-    id: bookshelf94
+    id: 'director:bookshelf94'
     platform: win
     lang: en
     title: 'Microsoft Bookshelf 1994'
     version: '3'
     url: /frs/demos/director/d3/en/bookshelf94-demo-win.zip
 -
-    id: bpmc
+    id: 'director:bpmc'
     platform: win
     lang: en
     title: 'Byron Preiss Multimedia Catalog'
     version: '3'
     url: /frs/demos/director/d3/en/bpmc-demo-win.zip
 -
-    id: businessmanager
+    id: 'director:businessmanager'
     platform: mac
     lang: ja
     title: '琢磨 BusinessManager'
     version: '3'
     url: /frs/demos/director/d3/ja/businessmanager-demo-mac-ja-351.zip
 -
-    id: businessmanager
+    id: 'director:businessmanager'
     platform: mac
     lang: ja
     title: '琢磨 BusinessManager'
     version: '3'
     url: /frs/demos/director/d3/ja/businessmanager-demo-mac-ja.zip
 -
-    id: calling
+    id: 'director:calling'
     platform: mac
     lang: ja
     title: Calling
     version: '3'
     url: /frs/demos/director/d3/ja/calling-demo-mac-ja.zip
 -
-    id: cellofania
+    id: 'director:cellofania'
     platform: mac
     lang: ja
     title: セロファニア
     version: '3'
     url: /frs/demos/director/d3/ja/cellofania-demo-mac-ja.zip
 -
-    id: chaos
+    id: 'director:chaos'
     platform: mac
     lang: ja
     title: 'The C.H.A.O.S. Continuum'
     version: '3'
     url: /frs/demos/director/d3/ja/chaos-demo-mac-ja.zip
 -
-    id: childishgambino
+    id: 'director:childishgambino'
     platform: mac
     lang: en
     title: 'Capturing Donald Glover''s Motion'
     version: '3'
     url: /frs/demos/director/d3/en/childishgambino-mac.zip
 -
-    id: chisanaensoka
+    id: 'director:chisanaensoka'
     platform: mac
     lang: ja
     title: 小さな演奏家
     version: '3'
     url: /frs/demos/director/d3/ja/chisanaensoka-demo-mac-ja.zip
 -
-    id: chuckletime
+    id: 'director:chuckletime'
     platform: mac
     lang: ja
     title: チャックルタイム
     version: '3'
     url: /frs/demos/director/d3/ja/chuckletime-demo-mac-ja.zip
 -
-    id: cinemania94
+    id: 'director:cinemania94'
     platform: win
     lang: en
     title: 'Microsoft Cinemania 94'
     version: '3'
     url: /frs/demos/director/d3/en/cinemania94-demo-win.zip
 -
-    id: cinemania95
+    id: 'director:cinemania95'
     platform: win
     lang: en
     title: 'Microsoft Cinemania 95'
     version: '3'
     url: /frs/demos/director/d3/en/cinemania95-demo-win.zip
 -
-    id: cklasse
+    id: 'director:cklasse'
     platform: win
     lang: de
     title: 'Mercedes-Benz C-Class Information Booth'
     version: '3'
     url: /frs/demos/director/d3/de/cklasse-win-de.zip
 -
-    id: cpu
+    id: 'director:cpu'
     platform: mac
     lang: en
     title: 'Connectix PowerBook Utilities'
     version: '3'
     url: /frs/demos/director/d3/en/cpu-demo-mac.zip
 -
-    id: creativeeye
+    id: 'director:creativeeye'
     platform: mac
     lang: ja
     title: 'Creative EYE'
     version: '3'
     url: /frs/demos/director/d3/ja/creativeeye-demo-mac-ja-9402.zip
 -
-    id: creativeeye
+    id: 'director:creativeeye'
     platform: mac
     lang: ja
     title: 'Creative EYE'
     version: '3'
     url: /frs/demos/director/d3/ja/creativeeye-demo-mac-ja-9406.zip
 -
-    id: cutie10
+    id: 'director:cutie10'
     platform: mac
     lang: ja
     title: キューティ１０
     version: '3'
     url: /frs/demos/director/d3/ja/cutie10-demo-mac-ja.zip
 -
-    id: dinosafari
+    id: 'director:dinosafari'
     platform: mac
     lang: ja
     title: 'Dinosaur Safari'
     version: '3'
     url: /frs/demos/director/d3/ja/dinosafari-demo-mac-ja.zip
 -
-    id: director
+    id: 'director:director'
     platform: mac
     lang: en
     title: 'The Apartment D3'
     version: '3'
     url: /frs/demos/director/theapartment3.zip
 -
-    id: dirmacromind
+    id: 'director:dirmacromind'
     platform: mac
     lang: en
     title: 'MacroMind Director'
     version: '3'
     url: /frs/demos/director/d3/en/dirmacromind-demo-mac.zip
 -
-    id: donnamatrix
+    id: 'director:donnamatrix'
     platform: mac
     lang: en
     title: 'Donna Matrix'
     version: '3'
     url: /frs/demos/director/d3/en/donnamatrix-demo-mac.zip
 -
-    id: edmark
+    id: 'director:edmark'
     platform: mac
     lang: ja
     title: 'Edmark Demo'
     version: '3'
     url: /frs/demos/director/d3/ja/edmark-mac-ja.zip
 -
-    id: emigre
+    id: 'director:emigre'
     platform: mac
     lang: en
     title: 'Emigre Signs of Type: Big Cheese'
     version: '3'
     url: /frs/demos/director/d3/en/emigre-demo-mac.zip
 -
-    id: encarta95
+    id: 'director:encarta95'
     platform: win
     lang: en
     title: 'Microsoft Encarta ''95'
     version: '3'
     url: /frs/demos/director/d3/en/encarta95-demo-win.zip
 -
-    id: erikotamuraoz
+    id: 'director:erikotamuraoz'
     platform: mac
     lang: ja
     title: 'Eriko Tamura: Oz'
     version: '3'
     url: /frs/demos/director/d3/ja/erikotamuraoz-demo-mac-ja.zip
 -
-    id: exoticjapan
+    id: 'director:exoticjapan'
     platform: mac
     lang: en
     title: 'Exotic Japan: A Guide to Japanese Culture and Language'
     version: '3'
     url: /frs/demos/director/d3/en/exoticjapan-demo-mac.zip
 -
-    id: explorapedia
+    id: 'director:explorapedia'
     platform: win
     lang: en
     title: 'Microsoft Explorapedia'
     version: '3'
     url: /frs/demos/director/d3/en/explorapedia-demo-win.zip
 -
-    id: flw
+    id: 'director:flw'
     platform: win
     lang: en
     title: 'The Ultimate Frank Lloyd Wright: America''s Architect'
     version: '3'
     url: /frs/demos/director/d3/en/flw-demo-win.zip
 -
-    id: fototune
+    id: 'director:fototune'
     platform: mac
     lang: ja
     title: 'FotoTune Multimedia Show'
     version: '3'
     url: /frs/demos/director/d3/ja/fototune-mac-ja.zip
 -
-    id: gadget
+    id: 'director:gadget'
     platform: mac
     lang: en
     title: 'Gadget: Invention, Travel & Adventure'
     version: '3'
     url: /frs/demos/director/d3/en/gadget-demo-mac.zip
 -
-    id: gadget
+    id: 'director:gadget'
     platform: win
     lang: en
     title: 'Gadget: Invention, Travel & Adventure'
     version: '3'
     url: /frs/demos/director/d3/en/gadget-demo-win.zip
 -
-    id: garyukeiba
+    id: 'director:garyukeiba'
     platform: mac
     lang: ja
     title: 我流競馬
     version: '3'
     url: /frs/demos/director/d3/ja/garyukeiba-demo-mac-ja.zip
 -
-    id: goalrush1
+    id: 'director:goalrush1'
     platform: mac
     lang: ja
     title: 'Goal Rush!! (Demo 1)'
     version: '3'
     url: /frs/demos/director/d3/ja/goalrush1-demo-mac-ja-1.zip
 -
-    id: goalrush1
+    id: 'director:goalrush1'
     platform: mac
     lang: ja
     title: 'Goal Rush!! (Demo 2)'
     version: '3'
     url: /frs/demos/director/d3/ja/goalrush1-demo-mac-ja-2.zip
 -
-    id: goalrush2
+    id: 'director:goalrush2'
     platform: mac
     lang: ja
     title: 'Goal Rush!! 2 ～戦術分析編～'
     version: '3'
     url: /frs/demos/director/d3/ja/goalrush2-demo-mac-ja.zip
 -
-    id: granmarmalade
+    id: 'director:granmarmalade'
     platform: mac
     lang: ja
     title: グラン・マーマレード・マジカル・ビレッジ
     version: '3'
     url: /frs/demos/director/d3/ja/granmarmalade-demo-mac-ja.zip
 -
-    id: hellcab
+    id: 'director:hellcab'
     platform: mac
     lang: ja
     title: 'Hell Cab'
     version: '3'
     url: /frs/demos/director/d3/ja/hellcab-demo-mac-ja.zip
 -
-    id: henachoco
+    id: 'director:henachoco'
     platform: mac
     lang: ja
     title: へなちょこダービー
     version: '3'
     url: /frs/demos/director/d3/ja/henachoco-demo-mac-ja.zip
 -
-    id: hhouse
+    id: 'director:hhouse'
     platform: win
     lang: en
     title: 'Gahan Wilson''s The Ultimate Haunted House'
     version: '3'
     url: /frs/demos/director/d3/en/hhouse-demo-win.zip
 -
-    id: hikaruhana
+    id: 'director:hikaruhana'
     platform: mac
     lang: ja
     title: 光る花
     version: '3'
     url: /frs/demos/director/d3/ja/hikaruhana-demo-mac-ja.zip
 -
-    id: hoaddams2
+    id: 'director:hoaddams2'
     platform: mac
     lang: en
     title: 'Hollywood Online: Addams Family Values'
     version: '3'
     url: /frs/demos/director/d3/en/hoaddams2-mac.zip
 -
-    id: hoangus
+    id: 'director:hoangus'
     platform: mac
     lang: en
     title: 'Hollywood Online: Angus'
     version: '3'
     url: /frs/demos/director/d3/en/hoangus-mac.zip
 -
-    id: hoangus
+    id: 'director:hoangus'
     platform: win
     lang: en
     title: 'Hollywood Online: Angus'
     version: '3'
     url: /frs/demos/director/d3/en/hoangus-win.zip
 -
-    id: hodolores
+    id: 'director:hodolores'
     platform: mac
     lang: en
     title: 'Hollywood Online: Dolores Claiborne'
     version: '3'
     url: /frs/demos/director/d3/en/hodolores-mac.zip
 -
-    id: hodolores
+    id: 'director:hodolores'
     platform: win
     lang: en
     title: 'Hollywood Online: Dolores Claiborne'
     version: '3'
     url: /frs/demos/director/d3/en/hodolores-win.zip
 -
-    id: horobroy
+    id: 'director:horobroy'
     platform: mac
     lang: en
     title: 'Hollywood Online: Rob Roy: Legend of the Mist'
     version: '3'
     url: /frs/demos/director/d3/en/horobroy-mac.zip
 -
-    id: horobroy
+    id: 'director:horobroy'
     platform: win
     lang: en
     title: 'Hollywood Online: Rob Roy: Legend of the Mist'
     version: '3'
     url: /frs/demos/director/d3/en/horobroy-win.zip
 -
-    id: hostargate
+    id: 'director:hostargate'
     platform: mac
     lang: en
     title: 'Hollywood Online: Stargate'
     version: '3'
     url: /frs/demos/director/d3/en/hostargate-mac.zip
 -
-    id: hothenet
+    id: 'director:hothenet'
     platform: mac
     lang: en
     title: 'Hollywood Online: The Net'
     version: '3'
     url: /frs/demos/director/d3/en/hothenet-mac.zip
 -
-    id: hothenet
+    id: 'director:hothenet'
     platform: win
     lang: en
     title: 'Hollywood Online: The Net'
     version: '3'
     url: /frs/demos/director/d3/en/hothenet-win.zip
 -
-    id: hypercardlessons
+    id: 'director:hypercardlessons'
     platform: mac
     lang: ja
     title: 'HyperCard Lessons'
     version: '3'
     url: /frs/demos/director/d3/ja/hypercardlessons-demo-mac-ja.zip
 -
-    id: hypermaterial
+    id: 'director:hypermaterial'
     platform: mac
     lang: ja
     title: 'Hyper Material'
     version: '3'
     url: /frs/demos/director/d3/ja/hypermaterial-demo-mac-ja.zip
 -
-    id: imaginopolis
+    id: 'director:imaginopolis'
     platform: win
     lang: en
     title: 'Microsoft Imaginopolis'
     version: '3'
     url: /frs/demos/director/d3/en/imaginopolis-win.zip
 -
-    id: imgimpact
+    id: 'director:imgimpact'
     platform: mac
     lang: ja
     title: 'Images with Impact!'
     version: '3'
     url: /frs/demos/director/d3/ja/imgimpact-demo-mac-ja.zip
 -
-    id: intelligentnote
+    id: 'director:intelligentnote'
     platform: mac
     lang: ja
     title: インテリジェントノート
     version: '3'
     url: /frs/demos/director/d3/ja/intelligentnote-demo-mac-ja.zip
 -
-    id: inugumi
+    id: 'director:inugumi'
     platform: mac
     lang: ja
     title: 犬組
     version: '3'
     url: /frs/demos/director/d3/ja/inugumi-demo-mac-ja.zip
 -
-    id: ipc
+    id: 'director:ipc'
     platform: mac
     lang: en
     title: 'About InterActive Publishing'
     version: '3'
     url: /frs/demos/director/d3/en/ipc-mac.zip
 -
-    id: ipc
+    id: 'director:ipc'
     platform: win
     lang: en
     title: 'About InterActive Publishing'
     version: '3'
     url: /frs/demos/director/d3/en/ipc-win.zip
 -
-    id: iptr
+    id: 'director:iptr'
     platform: mac
     lang: en
     title: 'I Photograph to Remember'
     version: '3'
     url: /frs/demos/director/d3/en/iptr-demo-mac.zip
 -
-    id: ironhelix
+    id: 'director:ironhelix'
     platform: mac
     lang: en
     title: 'Iron Helix (1992)'
     version: '3'
     url: /frs/demos/director/d3/en/ironhelix-demo-mac-1992.zip
 -
-    id: ironhelix
+    id: 'director:ironhelix'
     platform: mac
     lang: en
     title: 'Iron Helix (1994)'
     version: '3'
     url: /frs/demos/director/d3/en/ironhelix-demo-mac-1994.zip
 -
-    id: ironhelix
+    id: 'director:ironhelix'
     platform: mac
     lang: ja
     title: 'Iron Helix'
     version: '3'
     url: /frs/demos/director/d3/ja/ironhelix-demo-mac-ja.zip
 -
-    id: jman
+    id: 'director:jman'
     platform: mac
     lang: en
     title: 'The Journeyman Project (v1.2)'
     version: '3'
     url: /frs/demos/director/d3/en/jman-demo-mac-12.zip
 -
-    id: jointnet
+    id: 'director:jointnet'
     platform: mac
     lang: ja
     title: JOINT-net
     version: '3'
     url: /frs/demos/director/d3/ja/jointnet-demo-mac-ja.zip
 -
-    id: katsumadojo
+    id: 'director:katsumadojo'
     platform: mac
     lang: ja
     title: 信光の勝馬道場
     version: '3'
     url: /frs/demos/director/d3/ja/katsumadojo-demo-mac-ja.zip
 -
-    id: kazuyakun
+    id: 'director:kazuyakun'
     platform: mac
     lang: ja
     title: 数ヤ君
     version: '3'
     url: /frs/demos/director/d3/ja/kazuyakun-demo-mac-ja.zip
 -
-    id: keiri
+    id: 'director:keiri'
     platform: mac
     lang: ja
     title: 経理入門
     version: '3'
     url: /frs/demos/director/d3/ja/keiri-mac-ja.zip
 -
-    id: kishido
+    id: 'director:kishido'
     platform: mac
     lang: ja
     title: 棋士道
     version: '3'
     url: /frs/demos/director/d3/ja/kishido-demo-mac-ja.zip
 -
-    id: koyosha
+    id: 'director:koyosha'
     platform: mac
     lang: ja
     title: 'Koyosha CD-INSPIREシリーズ'
     version: '3'
     url: /frs/demos/director/d3/ja/koyosha-demo-mac-ja.zip
 -
-    id: kpt
+    id: 'director:kpt'
     platform: mac
     lang: ja
     title: 'Kai''s Power Tools for Photoshop'
     version: '3'
     url: /frs/demos/director/d3/ja/kpt-demo-mac-ja.zip
 -
-    id: kyoto
+    id: 'director:kyoto'
     platform: mac
     lang: en
     title: 'Cosmology of Kyoto'
     version: '3'
     url: /frs/demos/director/d3/en/kyoto-demo-mac.zip
 -
-    id: kyoto
+    id: 'director:kyoto'
     platform: mac
     lang: ja
     title: 'Cosmology of Kyoto'
     version: '3'
     url: /frs/demos/director/d3/ja/kyoto-demo-mac-ja.zip
 -
-    id: learningsystem
+    id: 'director:learningsystem'
     platform: mac
     lang: en
     title: 'The Learning System'
     version: '3'
     url: /frs/demos/director/d3/en/learningsystem-mac.zip
 -
-    id: learningsystem
+    id: 'director:learningsystem'
     platform: win
     lang: en
     title: 'The Learning System'
     version: '3'
     url: /frs/demos/director/d3/en/learningsystem-win.zip
 -
-    id: leopardspots
+    id: 'director:leopardspots'
     platform: win
     lang: en
     title: 'How the Leopard Got His Spots'
     version: '3'
     url: /frs/demos/director/d3/en/leopardspots-demo-win.zip
 -
-    id: lotus123
+    id: 'director:lotus123'
     platform: mac
     lang: ja
     title: 'Lotus 1-2-3'
     version: '3'
     url: /frs/demos/director/d3/ja/lotus123-demo-mac-ja.zip
 -
-    id: macbasic
+    id: 'director:macbasic'
     platform: mac
     lang: ja
     title: 'MacBASIC: Learning BASIC on HyperCard'
     version: '3'
     url: /frs/demos/director/d3/ja/macbasic-demo-mac-ja-c.zip
 -
-    id: macbasic
+    id: 'director:macbasic'
     platform: mac
     lang: ja
     title: 'MacBASIC: Learning BASIC on HyperCard'
     version: '3'
     url: /frs/demos/director/d3/ja/macbasic-demo-mac-ja-m.zip
 -
-    id: maczaurus
+    id: 'director:maczaurus'
     platform: mac
     lang: ja
     title: 'Sharp Mac-Zaurus'
     version: '3'
     url: /frs/demos/director/d3/ja/maczaurus-demo-mac-ja.zip
 -
-    id: marinefantasy
+    id: 'director:marinefantasy'
     platform: mac
     lang: ja
     title: '大方洋二の海中写真館 Marine Fantasy'
     version: '3'
     url: /frs/demos/director/d3/ja/marinefantasy-demo-mac-ja.zip
 -
-    id: mazebrew
+    id: 'director:mazebrew'
     platform: mac
     lang: ja
     title: MazeBrew
     version: '3'
     url: /frs/demos/director/d3/ja/mazebrew-demo-mac-ja.zip
 -
-    id: meetingmaker
+    id: 'director:meetingmaker'
     platform: mac
     lang: en
     title: 'Meeting Maker'
     version: '3'
     url: /frs/demos/director/d3/en/meetingmaker-demo-mac.zip
 -
-    id: mipeterwolf
+    id: 'director:mipeterwolf'
     platform: mac
     lang: ja
     title: '～Music Island Vol.1～ "ピーターと狼" (Demo 1)'
     version: '3'
     url: /frs/demos/director/d3/ja/mipeterwolf-demo-mac-ja-1.zip
 -
-    id: mipeterwolf
+    id: 'director:mipeterwolf'
     platform: mac
     lang: ja
     title: '～Music Island Vol.1～ "ピーターと狼" (Demo 2)'
     version: '3'
     url: /frs/demos/director/d3/ja/mipeterwolf-demo-mac-ja-2.zip
 -
-    id: mmmozart
+    id: 'director:mmmozart'
     platform: mac
     lang: en
     title: 'Multimedia Mozart: The Dissonant Quartet'
     version: '3'
     url: /frs/demos/director/d3/en/mmmozart-demo-mac.zip
 -
-    id: mmschubert
+    id: 'director:mmschubert'
     platform: mac
     lang: en
     title: 'Multimedia Schubert: The "Trout" Quintet"'
     version: '3'
     url: /frs/demos/director/d3/en/mmschubert-demo-mac.zip
 -
-    id: moderntimes
+    id: 'director:moderntimes'
     platform: mac
     lang: ja
     title: 'Charles Chaplin in Modern Times (Demo 1)'
     version: '3'
     url: /frs/demos/director/d3/ja/moderntimes-demo-mac-ja-1.zip
 -
-    id: moderntimes
+    id: 'director:moderntimes'
     platform: mac
     lang: ja
     title: 'Charles Chaplin in Modern Times (Demo 2)'
     version: '3'
     url: /frs/demos/director/d3/ja/moderntimes-demo-mac-ja-2.zip
 -
-    id: msarcade
+    id: 'director:msarcade'
     platform: win
     lang: en
     title: 'Microsoft Arcade'
     version: '3'
     url: /frs/demos/director/d3/en/msarcade-demo-win.zip
 -
-    id: msartgallery
+    id: 'director:msartgallery'
     platform: win
     lang: en
     title: 'Microsoft Art Gallery'
     version: '3'
     url: /frs/demos/director/d3/en/msartgallery-demo-win.zip
 -
-    id: msbaseball
+    id: 'director:msbaseball'
     platform: win
     lang: en
     title: 'Microsoft Complete Baseball'
     version: '3'
     url: /frs/demos/director/d3/en/msbaseball-demo-win.zip
 -
-    id: msbasketball
+    id: 'director:msbasketball'
     platform: win
     lang: en
     title: 'Microsoft Complete Basketball'
     version: '3'
     url: /frs/demos/director/d3/en/msbasketball-demo-win.zip
 -
-    id: msbhumanbody
+    id: 'director:msbhumanbody'
     platform: win
     lang: en
     title: 'Scholastic''s The Magic School Bus Explores the Human Body'
     version: '3'
     url: /frs/demos/director/d3/en/msbhumanbody-demo-win.zip
 -
-    id: msbsolarsystem
+    id: 'director:msbsolarsystem'
     platform: win
     lang: en
     title: 'Scholastic''s The Magic School Bus Explores the Solar System'
     version: '3'
     url: /frs/demos/director/d3/en/msbsolarsystem-demo-win.zip
 -
-    id: mscomposers
+    id: 'director:mscomposers'
     platform: win
     lang: en
     title: 'Microsoft Illustrated Interactive Composer Series'
     version: '3'
     url: /frs/demos/director/d3/en/mscomposers-demo-win.zip
 -
-    id: msdinosaurs
+    id: 'director:msdinosaurs'
     platform: win
     lang: en
     title: 'Microsoft Dinosaurs'
     version: '3'
     url: /frs/demos/director/d3/en/msdinosaurs-demo-win.zip
 -
-    id: msflight
+    id: 'director:msflight'
     platform: win
     lang: en
     title: 'Microsoft Flight Simulator'
     version: '3'
     url: /frs/demos/director/d3/en/msflight-demo-win.zip
 -
-    id: msfonts
+    id: 'director:msfonts'
     platform: win
     lang: en
     title: 'Microsoft TrueType Font Pack'
     version: '3'
     url: /frs/demos/director/d3/en/msfonts-demo-win.zip
 -
-    id: msgfromapple
+    id: 'director:msgfromapple'
     platform: mac
     lang: ja
     title: 'Message from Apple'
     version: '3'
     url: /frs/demos/director/d3/ja/msgfromapple-mac-ja.zip
 -
-    id: msgolf
+    id: 'director:msgolf'
     platform: win
     lang: en
     title: 'Microsoft Golf'
     version: '3'
     url: /frs/demos/director/d3/en/msgolf-demo-win.zip
 -
-    id: msmoney
+    id: 'director:msmoney'
     platform: win
     lang: en
     title: 'Microsoft Money'
     version: '3'
     url: /frs/demos/director/d3/en/msmoney-demo-win.zip
 -
-    id: msmouse
+    id: 'director:msmouse'
     platform: win
     lang: en
     title: 'The Microsoft Mouse'
     version: '3'
     url: /frs/demos/director/d3/en/msmouse-demo-win.zip
 -
-    id: msmouseh
+    id: 'director:msmouseh'
     platform: win
     lang: en
     title: 'Microsoft Home Mouse'
     version: '3'
     url: /frs/demos/director/d3/en/msmouseh-demo-win.zip
 -
-    id: msmusint
+    id: 'director:msmusint'
     platform: win
     lang: en
     title: 'Microsoft Musical Instruments'
     version: '3'
     url: /frs/demos/director/d3/en/msmusint-demo-win.zip
 -
-    id: msnatkey
+    id: 'director:msnatkey'
     platform: win
     lang: en
     title: 'Microsoft Natural Keyboard'
     version: '3'
     url: /frs/demos/director/d3/en/msnatkey-demo-win.zip
 -
-    id: mspublish
+    id: 'director:mspublish'
     platform: win
     lang: en
     title: 'Microsoft Publisher'
     version: '3'
     url: /frs/demos/director/d3/en/mspublish-demo-win.zip
 -
-    id: mspublishd
+    id: 'director:mspublishd'
     platform: win
     lang: en
     title: 'Microsoft Publisher Design Packs'
     version: '3'
     url: /frs/demos/director/d3/en/mspublishd-demo-win.zip
 -
-    id: mssndbits
+    id: 'director:mssndbits'
     platform: win
     lang: en
     title: 'Microsoft SoundBits'
     version: '3'
     url: /frs/demos/director/d3/en/mssndbits-demo-win.zip
 -
-    id: murdersam
+    id: 'director:murdersam'
     platform: mac
     lang: ja
     title: 'Who Killed Sam Rupert?'
     version: '3'
     url: /frs/demos/director/d3/ja/murdersam-demo-mac-ja.zip
 -
-    id: muzukashiihon
+    id: 'director:muzukashiihon'
     platform: mac
     lang: ja
     title: 難しい本を読むと眠くなる
     version: '3'
     url: /frs/demos/director/d3/ja/muzukashiihon-demo-mac-ja-alt.zip
 -
-    id: muzukashiihon
+    id: 'director:muzukashiihon'
     platform: mac
     lang: ja
     title: 難しい本を読むと眠くなる
     version: '3'
     url: /frs/demos/director/d3/ja/muzukashiihon-demo-mac-ja.zip
 -
-    id: necrobius
+    id: 'director:necrobius'
     platform: mac
     lang: en
     title: Necrobius
     version: '3'
     url: /frs/demos/director/d3/en/necrobius-demo-mac.zip
 -
-    id: necromancer
+    id: 'director:necromancer'
     platform: mac
     lang: en
     title: Necromancer
     version: '3'
     url: /frs/demos/director/d3/en/necromancer-demo-mac.zip
 -
-    id: negishihomes
+    id: 'director:negishihomes'
     platform: mac
     lang: ja
     title: 'Negishi Homes 建築見積ｿﾌﾄ'
     version: '3'
     url: /frs/demos/director/d3/ja/negishihomes-demo-mac-ja.zip
 -
-    id: newton
+    id: 'director:newton'
     platform: mac
     lang: en
     title: 'World of Newton'
     version: '3'
     url: /frs/demos/director/d3/en/newton-demo-mac.zip
 -
-    id: nonta
+    id: 'director:nonta'
     platform: mac
     lang: ja
     title: のんたくんとゆかいななかまたち
     version: '3'
     url: /frs/demos/director/d3/ja/nonta-demo-mac-ja.zip
 -
-    id: novacity
+    id: 'director:novacity'
     platform: mac
     lang: ja
     title: 'Nova City'
     version: '3'
     url: /frs/demos/director/d3/ja/novacity-demo-mac-ja.zip
 -
-    id: nsxpress
+    id: 'director:nsxpress'
     platform: mac
     lang: ja
     title: 'Honda NSX Press CD-ROM'
     version: '3'
     url: /frs/demos/director/d3/ja/nsxpress-demo-mac-ja.zip
 -
-    id: oceansbelow
+    id: 'director:oceansbelow'
     platform: mac
     lang: ja
     title: 'Oceans Below'
     version: '3'
     url: /frs/demos/director/d3/ja/oceansbelow-demo-mac-ja.zip
 -
-    id: olnet
+    id: 'director:olnet'
     platform: mac
     lang: ja
     title: 'Open Library'
     version: '3'
     url: /frs/demos/director/d3/ja/olnet-demo-mac-ja-lite.zip
 -
-    id: olnet
+    id: 'director:olnet'
     platform: mac
     lang: ja
     title: 'Open Library'
     version: '3'
     url: /frs/demos/director/d3/ja/olnet-demo-mac-ja-net.zip
 -
-    id: peaceland
+    id: 'director:peaceland'
     platform: mac
     lang: ja
     title: PeaceLand
     version: '3'
     url: /frs/demos/director/d3/ja/peaceland-demo-mac-ja.zip
 -
-    id: picturecard
+    id: 'director:picturecard'
     platform: mac
     lang: ja
     title: 絵カード訓練システム
     version: '3'
     url: /frs/demos/director/d3/ja/picturecard-demo-mac-ja.zip
 -
-    id: pixar
+    id: 'director:pixar'
     platform: mac
     lang: en
     title: 'Pixar Projector'
     version: '3'
     url: /frs/demos/director/d3/en/pixar-demo-mac.zip
 -
-    id: playroom
+    id: 'director:playroom'
     platform: mac
     lang: en
     title: 'The Playroom'
     version: '3'
     url: /frs/demos/director/d3/en/playroom-demo-mac.zip
 -
-    id: presenpack
+    id: 'director:presenpack'
     platform: mac
     lang: ja
     title: 'Director PresenPack'
     version: '3'
     url: /frs/demos/director/d3/ja/presenpack-mac-ja.zip
 -
-    id: pressit
+    id: 'director:pressit'
     platform: mac
     lang: ja
     title: PRESSiT
     version: '3'
     url: /frs/demos/director/d3/ja/pressit-demo-mac-ja.zip
 -
-    id: provektor2
+    id: 'director:provektor2'
     platform: mac
     lang: en
     title: 'Provektor II: Design & Image Library'
     version: '3'
     url: /frs/demos/director/d3/en/provektor2-demo-mac-cheese.zip
 -
-    id: provektor2
+    id: 'director:provektor2'
     platform: mac
     lang: en
     title: 'Provektor II: Design & Image Library'
     version: '3'
     url: /frs/demos/director/d3/en/provektor2-demo-mac.zip
 -
-    id: provektor3
+    id: 'director:provektor3'
     platform: mac
     lang: en
     title: 'Provektor III: Design & Image Library'
     version: '3'
     url: /frs/demos/director/d3/en/provektor3-demo-mac.zip
 -
-    id: provektormed
+    id: 'director:provektormed'
     platform: mac
     lang: en
     title: 'Provektor Media'
     version: '3'
     url: /frs/demos/director/d3/en/provektormed-demo-mac.zip
 -
-    id: pyramidint
+    id: 'director:pyramidint'
     platform: mac
     lang: ja
     title: 'Pyramid Interactive'
     version: '3'
     url: /frs/demos/director/d3/ja/pyramidint-demo-mac-ja.zip
 -
-    id: raydream
+    id: 'director:raydream'
     platform: mac
     lang: en
     title: 'Ray Dream Designer'
     version: '3'
     url: /frs/demos/director/d3/en/raydream-demo-mac.zip
 -
-    id: raydream
+    id: 'director:raydream'
     platform: mac
     lang: ja
     title: 'Ray Dream Designer'
     version: '3'
     url: /frs/demos/director/d3/ja/raydream-demo-mac-ja.zip
 -
-    id: redshift
+    id: 'director:redshift'
     platform: mac
     lang: en
     title: 'RedShift: Multimedia Astronomy (1993)'
     version: '3'
     url: /frs/demos/director/d3/en/redshift-demo-mac-1993.zip
 -
-    id: rodney
+    id: 'director:rodney'
     platform: mac
     lang: en
     title: 'Rodney''s Funscreen'
     version: '3'
     url: /frs/demos/director/d3/en/rodney-demo-mac.zip
 -
-    id: schoolworld
+    id: 'director:schoolworld'
     platform: mac
     lang: ja
     title: 'A-L: Artificial Life: School World'
     version: '3'
     url: /frs/demos/director/d3/ja/schoolworld-demo-mac-ja.zip
 -
-    id: screamingmetal
+    id: 'director:screamingmetal'
     platform: mac
     lang: en
     title: 'Screaming Metal'
     version: '3'
     url: /frs/demos/director/d3/en/screamingmetal-demo-mac-1992.zip
 -
-    id: screamingmetal
+    id: 'director:screamingmetal'
     platform: mac
     lang: en
     title: 'Screaming Metal'
     version: '3'
     url: /frs/demos/director/d3/en/screamingmetal-demo-mac-1993.zip
 -
-    id: scripting
+    id: 'director:scripting'
     platform: mac
     lang: ja
     title: 'Macromedia Director Lingo Scripting Technology'
     version: '3'
     url: /frs/demos/director/d3/ja/scripting-demo-mac-ja-1.zip
 -
-    id: scripting
+    id: 'director:scripting'
     platform: mac
     lang: ja
     title: 'Macromedia Director Lingo Scripting Technology'
     version: '3'
     url: /frs/demos/director/d3/ja/scripting-demo-mac-ja-2.zip
 -
-    id: sculpt4d
+    id: 'director:sculpt4d'
     platform: mac
     lang: en
     title: 'Sculpt 4D'
     version: '3'
     url: /frs/demos/director/d3/en/sculpt4d-demo-mac-2.zip
 -
-    id: sculpt4d
+    id: 'director:sculpt4d'
     platform: mac
     lang: en
     title: 'Sculpt 4D'
     version: '3'
     url: /frs/demos/director/d3/en/sculpt4d-demo-mac-3.zip
 -
-    id: sculpt4d
+    id: 'director:sculpt4d'
     platform: mac
     lang: en
     title: 'Sculpt 4D'
     version: '3'
     url: /frs/demos/director/d3/en/sculpt4d-demo-mac-5.zip
 -
-    id: sculpt4d
+    id: 'director:sculpt4d'
     platform: mac
     lang: en
     title: 'Sculpt 4D'
     version: '3'
     url: /frs/demos/director/d3/en/sculpt4d-demo-mac-usage.zip
 -
-    id: sculpt4d
+    id: 'director:sculpt4d'
     platform: mac
     lang: ja
     title: 'Sculpt 4D'
     version: '3'
     url: /frs/demos/director/d3/ja/sculpt4d-demo-mac-ja-1.zip
 -
-    id: sfk
+    id: 'director:sfk'
     platform: mac
     lang: en
     title: 'Science for Kids Product Demos'
     version: '3'
     url: /frs/demos/director/d3/en/sfk-mac.zip
 -
-    id: sk8board
+    id: 'director:sk8board'
     platform: win
     lang: en
     title: 'RIDE: An Interactive Skateboarding Experience'
     version: '3'
     url: /frs/demos/director/d3/en/sk8board-demo-win.zip
 -
-    id: snh
+    id: 'director:snh'
     platform: mac
     lang: en
     title: 'A Silly Noisy House'
     version: '3'
     url: /frs/demos/director/d3/en/snh-demo-mac.zip
 -
-    id: strata
+    id: 'director:strata'
     platform: mac
     lang: ja
     title: 'Strata Studio Pro'
     version: '3'
     url: /frs/demos/director/d3/ja/strata-demo-mac-ja.zip
 -
-    id: stravinsky
+    id: 'director:stravinsky'
     platform: mac
     lang: en
     title: 'Igor Stravinsky: The Rite of Spring'
     version: '3'
     url: /frs/demos/director/d3/en/stravinsky-demo-mac.zip
 -
-    id: tokon5
+    id: 'director:tokon5'
     platform: mac
     lang: ja
     title: '闘魂V: 長州 力'
     version: '3'
     url: /frs/demos/director/d3/ja/tokon5-demo-mac-ja.zip
 -
-    id: toonet11
+    id: 'director:toonet11'
     platform: mac
     lang: ja
     title: TooNet11
     version: '3'
     url: /frs/demos/director/d3/ja/toonet11-demo-mac-ja.zip
 -
-    id: totaldistortion
+    id: 'director:totaldistortion'
     platform: mac
     lang: en
     title: 'Total Distortion'
     version: '3'
     url: /frs/demos/director/d3/en/totaldistortion-demo-mac.zip
 -
-    id: totaldistortion
+    id: 'director:totaldistortion'
     platform: mac
     lang: ja
     title: 'Total Distortion'
     version: '3'
     url: /frs/demos/director/d3/ja/totaldistortion-demo-mac-ja.zip
 -
-    id: transland
+    id: 'director:transland'
     platform: mac
     lang: ja
     title: トランスランド
     version: '3'
     url: /frs/demos/director/d3/ja/transland-demo-mac-ja.zip
 -
-    id: trekfinalunity
+    id: 'director:trekfinalunity'
     platform: win
     lang: en
     title: 'Star Trek: The Next Generation - "A Final Unity"'
     version: '3'
     url: /frs/demos/director/d3/en/trekfinalunity-demo-win.zip
 -
-    id: tree
+    id: 'director:tree'
     platform: mac
     lang: ja
     title: 'Onyx Tree Pro'
     version: '3'
     url: /frs/demos/director/d3/ja/tree-demo-mac-ja.zip
 -
-    id: ttw
+    id: 'director:ttw'
     platform: mac
     lang: ja
     title: 'Through the Window: In Search for the Lost Bag'
     version: '3'
     url: /frs/demos/director/d3/ja/ttw-demo-mac-ja.zip
 -
-    id: ukiuki1
+    id: 'director:ukiuki1'
     platform: mac
     lang: ja
     title: 'ウキウキ釣り天国 ～幻の天狗池～'
     version: '3'
     url: /frs/demos/director/d3/ja/ukiuki1-demo-mac-ja.zip
 -
-    id: ukiukistamp
+    id: 'director:ukiukistamp'
     platform: mac
     lang: ja
     title: うきうきスタンプ
     version: '3'
     url: /frs/demos/director/d3/ja/ukiukistamp-demo-mac-ja.zip
 -
-    id: ukyo1
+    id: 'director:ukyo1'
     platform: mac
     lang: ja
     title: うきょー1
     version: '3'
     url: /frs/demos/director/d3/ja/ukyo1-demo-mac-ja.zip
 -
-    id: ultrobot
+    id: 'director:ultrobot'
     platform: win
     lang: en
     title: 'Isaac Asimov''s The Ultimate Robot'
     version: '3'
     url: /frs/demos/director/d3/en/ultrobot-demo-win.zip
 -
-    id: vcbe
+    id: 'director:vcbe'
     platform: mac
     lang: ja
     title: 'Virtual Cocktail Bar Executive (Demo 1)'
     version: '3'
     url: /frs/demos/director/d3/ja/vcbe-demo-mac-ja-1.zip
 -
-    id: vcbe
+    id: 'director:vcbe'
     platform: mac
     lang: ja
     title: 'Virtual Cocktail Bar Executive (Demo 2)'
     version: '3'
     url: /frs/demos/director/d3/ja/vcbe-demo-mac-ja-2.zip
 -
-    id: verttice
+    id: 'director:verttice'
     platform: mac
     lang: en
     title: 'DreamLight Verttice (v1.0)'
     version: '3'
     url: /frs/demos/director/d3/en/verttice-mac-10.zip
 -
-    id: verttice
+    id: 'director:verttice'
     platform: mac
     lang: en
     title: 'DreamLight Verttice (v1.1 PPC)'
     version: '3'
     url: /frs/demos/director/d3/en/verttice-mac-11-ppc.zip
 -
-    id: verttice
+    id: 'director:verttice'
     platform: mac
     lang: en
     title: 'DreamLight Verttice (v1.1 68K)'
     version: '3'
     url: /frs/demos/director/d3/en/verttice-mac-11.zip
 -
-    id: vvcyber
+    id: 'director:vvcyber'
     platform: mac
     lang: en
     title: 'Victor Vector & Yondo: The Cyberplasm Formula'
     version: '3'
     url: /frs/demos/director/d3/en/vvcyber-demo-mac.zip
 -
-    id: vvcyber
+    id: 'director:vvcyber'
     platform: win
     lang: en
     title: 'Victor Vector & Yondo: The Cyberplasm Formula'
     version: '3'
     url: /frs/demos/director/d3/en/vvcyber-demo-win.zip
 -
-    id: vvs
+    id: 'director:vvs'
     platform: mac
     lang: ja
     title: 'Virtual Variety Show'
     version: '3'
     url: /frs/demos/director/d3/ja/vvs-demo-mac-ja.zip
 -
-    id: warlock
+    id: 'director:warlock'
     platform: mac
     lang: en
     title: 'Spaceship Warlock (1994)'
     version: '3'
     url: /frs/demos/director/d3/en/warlock-demo-mac-1994.zip
 -
-    id: warlock
+    id: 'director:warlock'
     platform: win
     lang: en
     title: 'Spaceship Warlock'
     version: '3'
     url: /frs/demos/director/d3/en/warlock-demo-win.zip
 -
-    id: wep
+    id: 'director:wep'
     platform: win
     lang: en
     title: 'The Best of Microsoft Entertainment Pack'
     version: '3'
     url: /frs/demos/director/d3/en/wep-win.zip
 -
-    id: wonderompm
+    id: 'director:wonderompm'
     platform: mac
     lang: ja
     title: アルダスページメーカー4.5J速習用CD-ROM
     version: '3'
     url: /frs/demos/director/d3/ja/wonderompm-demo-mac-ja.zip
 -
-    id: wrath
+    id: 'director:wrath'
     platform: win
     lang: en
     title: 'Wrath of the Gods'
     version: '3'
     url: /frs/demos/director/d3/en/wrath-demo-win.zip
 -
-    id: wriggle
+    id: 'director:wriggle'
     platform: mac
     lang: en
     title: Wriggle
     version: '3'
     url: /frs/demos/director/d3/en/wriggle-demo-mac.zip
 -
-    id: xanthus
+    id: 'director:xanthus'
     platform: mac
     lang: en
     title: Xanthus
     version: '3'
     url: /frs/demos/director/d3/en/xanthus-demo-mac.zip
 -
-    id: y2lpeanuts
+    id: 'director:y2lpeanuts'
     platform: win
     lang: en
     title: 'Yearn2Learn: Peanuts'
     version: '3'
     url: /frs/demos/director/d3/en/y2lpeanuts-demo-win.zip
 -
-    id: y2lsnoopy
+    id: 'director:y2lsnoopy'
     platform: win
     lang: en
     title: 'Yearn2Learn: Snoopy'
     version: '3'
     url: /frs/demos/director/d3/en/y2lsnoopy-demo-win.zip
 -
-    id: y2lsnoopy
+    id: 'director:y2lsnoopy'
     platform: mac
     lang: ja
     title: 'Yearn2Learn: Snoopy'
     version: '3'
     url: /frs/demos/director/d3/ja/y2lsnoopy-demo-mac-ja.zip
 -
-    id: zaibatsu
+    id: 'director:zaibatsu'
     platform: mac
     lang: ja
     title: 財閥銀行
     version: '3'
     url: /frs/demos/director/d3/ja/zaibatsu-demo-mac-ja.zip
 -
-    id: 3datlas97
+    id: 'director:3datlas97'
     platform: win
     lang: en
     title: '3D Atlas 97'
     version: '4'
     url: /frs/demos/director/d4/en/3datlas97-demo-win.zip
 -
-    id: angelgate
+    id: 'director:angelgate'
     platform: mac
     lang: ja
     title: 'Angel Gate'
     version: '4'
     url: /frs/demos/director/d4/ja/angelgate-demo-mac-ja.zip
 -
-    id: angelgate
+    id: 'director:angelgate'
     platform: win
     lang: ja
     title: 'Angel Gate'
     version: '4'
     url: /frs/demos/director/d4/ja/angelgate-demo-win-ja.zip
 -
-    id: angelolatrie
+    id: 'director:angelolatrie'
     platform: mac
     lang: ja
     title: 'Jean Cocteau: Angélolatrie & Phénixologie'
     version: '4'
     url: /frs/demos/director/d4/ja/angelolatrie-demo-mac-ja.zip
 -
-    id: angelolatrie
+    id: 'director:angelolatrie'
     platform: win
     lang: ja
     title: 'Jean Cocteau: Angélolatrie & Phénixologie'
     version: '4'
     url: /frs/demos/director/d4/ja/angelolatrie-demo-win-ja.zip
 -
-    id: antsafire
+    id: 'director:antsafire'
     platform: mac
     lang: en
     title: 'Ants Afire!'
     version: '4'
     url: /frs/demos/director/d4/en/antsafire-mac.zip
 -
-    id: aol
+    id: 'director:aol'
     platform: mac
     lang: en
     title: 'America Online'
     version: '4'
     url: /frs/demos/director/d4/en/aol-demo-mac.zip
 -
-    id: aol
+    id: 'director:aol'
     platform: win
     lang: en
     title: 'America Online'
     version: '4'
     url: /frs/demos/director/d4/en/aol-demo-win.zip
 -
-    id: applestore
+    id: 'director:applestore'
     platform: mac
     lang: en
     title: 'Apple Company Store'
     version: '4'
     url: /frs/demos/director/d4/en/applestore-mac.zip
 -
-    id: aquazone
+    id: 'director:aquazone'
     platform: mac
     lang: ja
     title: Aquazone
     version: '4'
     url: /frs/demos/director/d4/ja/aquazone-demo-mac-ja.zip
 -
-    id: aquazone
+    id: 'director:aquazone'
     platform: win
     lang: ja
     title: Aquazone
     version: '4'
     url: /frs/demos/director/d4/ja/aquazone-demo-win-ja.zip
 -
-    id: arcofdoom
+    id: 'director:arcofdoom'
     platform: mac
     lang: en
     title: 'Arc of Doom'
     version: '4'
     url: /frs/demos/director/d4/en/arcofdoom-demo-mac.zip
 -
-    id: ataripack
+    id: 'director:ataripack'
     platform: win
     lang: en
     title: 'Activision''s Atari 2600 Action Pack'
     version: '4'
     url: /frs/demos/director/d4/en/ataripack-demo-win.zip
 -
-    id: bearfamily
+    id: 'director:bearfamily'
     platform: mac
     lang: ja
     title: 'A Bear Family Adventure'
     version: '4'
     url: /frs/demos/director/d4/ja/bearfamily-demo-mac-ja.zip
 -
-    id: bebox
+    id: 'director:bebox'
     platform: mac
     lang: ja
     title: BeBox
     version: '4'
     url: /frs/demos/director/d4/ja/bebox-demo-mac-ja.zip
 -
-    id: betterd
+    id: 'director:betterd'
     platform: mac
     lang: ja
     title: 'The Better Dead Ratification'
     version: '4'
     url: /frs/demos/director/d4/ja/betterd-demo-mac-ja.zip
 -
-    id: bht
+    id: 'director:bht'
     platform: win
     lang: en
     title: 'A Brief History of Time: An Interactive Adventure'
     version: '4'
     url: /frs/demos/director/d4/en/bht-demo-win.zip
 -
-    id: blaster
+    id: 'director:blaster'
     platform: win
     lang: en
     title: 'Blaster Series Demo'
     version: '4'
     url: /frs/demos/director/d4/en/blaster-win.zip
 -
-    id: blockbuster2
+    id: 'director:blockbuster2'
     platform: win
     lang: en
     title: 'Blockbuster Guide to Movies & Videos, 2nd Edition'
     version: '4'
     url: /frs/demos/director/d4/en/blockbuster2-demo-win.zip
 -
-    id: bugbook
+    id: 'director:bugbook'
     platform: win
     lang: en
     title: 'The Multimedia Bug Book'
     version: '4'
     url: /frs/demos/director/d4/en/bugbook-demo-win.zip
 -
-    id: c64pack
+    id: 'director:c64pack'
     platform: win
     lang: en
     title: 'Buena Vista International 1997 Promotional Interactive CD-ROM'
     version: '4'
     url: /frs/demos/director/d4/en/c64pack-demo-win.zip
 -
-    id: catseyeview
+    id: 'director:catseyeview'
     platform: mac
     lang: en
     title: 'Cat''s Eye View'
     version: '4'
     url: /frs/demos/director/d4/en/catseyeview-demo-mac.zip
 -
-    id: chinacrisis
+    id: 'director:chinacrisis'
     platform: mac
     lang: ja
     title: 'China Crisis'
     version: '4'
     url: /frs/demos/director/d4/ja/chinacrisis-demo-mac-ja.zip
 -
-    id: chuckaduck
+    id: 'director:chuckaduck'
     platform: mac
     lang: en
     title: 'Chop Suey'
     version: '4'
     url: /frs/demos/director/d4/en/chuckaduck-mac.zip
 -
-    id: chuniverse
+    id: 'director:chuniverse'
     platform: win
     lang: en
     title: 'The Challenge of the Universe'
     version: '4'
     url: /frs/demos/director/d4/en/chuniverse-demo-win.zip
 -
-    id: cinemac
+    id: 'director:cinemac'
     platform: mac
     lang: en
     title: 'CineMac Screen Saver Factory'
     version: '4'
     url: /frs/demos/director/d4/en/cinemac-demo-mac.zip
 -
-    id: circus
+    id: 'director:circus'
     platform: mac
     lang: en
     title: Circus!
     version: '4'
     url: /frs/demos/director/d4/en/circus-demo-mac.zip
 -
-    id: circus
+    id: 'director:circus'
     platform: win
     lang: en
     title: Circus!
     version: '4'
     url: /frs/demos/director/d4/en/circus-demo-win.zip
 -
-    id: cmc
+    id: 'director:cmc'
     platform: win
     lang: en
     title: 'Creative Multimedia Catalog'
     version: '4'
     url: /frs/demos/director/d4/en/cmc-win.zip
 -
-    id: cnl
+    id: 'director:cnl'
     platform: mac
     lang: ja
     title: 'City Net Line'
     version: '4'
     url: /frs/demos/director/d4/ja/cnl-demo-mac-ja.zip
 -
-    id: connections
+    id: 'director:connections'
     platform: win
     lang: en
     title: Connections
     version: '4'
     url: /frs/demos/director/d4/en/connections-demo-win.zip
 -
-    id: ctrain
+    id: 'director:ctrain'
     platform: win
     lang: en
     title: 'Doing it in C++'
     version: '4'
     url: /frs/demos/director/d4/en/ctrain-demo-win.zip
 -
-    id: d
+    id: 'director:d'
     platform: win
     lang: en
     title: D
     version: '4'
     url: /frs/demos/director/d4/en/d-demo-win.zip
 -
-    id: dailymail100
+    id: 'director:dailymail100'
     platform: win
     lang: en
     title: 'Daily Mail Centenary: 100 Amazing Years'
     version: '4'
     url: /frs/demos/director/d4/en/dailymail100-win.zip
 -
-    id: davidsonpp
+    id: 'director:davidsonpp'
     platform: win
     lang: en
     title: 'Davidson Product Previews'
     version: '4'
     url: /frs/demos/director/d4/en/davidsonpp-win.zip
 -
-    id: dazzeloids
+    id: 'director:dazzeloids'
     platform: mac
     lang: en
     title: Dazzeloids
     version: '4'
     url: /frs/demos/director/d4/en/dazzeloids-demo-mac.zip
 -
-    id: derratsorcerum
+    id: 'director:derratsorcerum'
     platform: mac
     lang: en
     title: 'Derrat Sorcerum'
     version: '4'
     url: /frs/demos/director/d4/en/derratsorcerum-demo-mac.zip
 -
-    id: director
+    id: 'director:director'
     platform: mac
     lang: en
     title: 'The Apartment D4'
     version: '4'
     url: /frs/demos/director/theapartment4.zip
 -
-    id: dirmacromedia
+    id: 'director:dirmacromedia'
     platform: mac
     lang: ja
     title: 'Dinosaur Safari'
     version: '4'
     url: /frs/demos/director/d4/ja/dirmacromedia-demo-mac-ja.zip
 -
-    id: dkmm2
+    id: 'director:dkmm2'
     platform: mac
     lang: en
     title: 'Dorling Kindersley Multimedia Sampler Disc 2'
     version: '4'
     url: /frs/demos/director/d4/en/dkmm2-mac.zip
 -
-    id: dkmm2
+    id: 'director:dkmm2'
     platform: win
     lang: en
     title: 'Dorling Kindersley Multimedia Sampler Disc 2'
     version: '4'
     url: /frs/demos/director/d4/en/dkmm2-win.zip
 -
-    id: dreidel
+    id: 'director:dreidel'
     platform: mac
     lang: en
     title: 'DreidelLand: An Electronic Hanukah Treat'
     version: '4'
     url: /frs/demos/director/d4/en/dreidel-mac.zip
 -
-    id: earthwormjim
+    id: 'director:earthwormjim'
     platform: win
     lang: en
     title: 'Earthworm Jim'
     version: '4'
     url: /frs/demos/director/d4/en/earthwormjim-demo-win.zip
 -
-    id: elmopreschool
+    id: 'director:elmopreschool'
     platform: win
     lang: en
     title: 'Elmo''s Preschool'
     version: '4'
     url: /frs/demos/director/d4/en/elmopreschool-demo-win.zip
 -
-    id: elroypave
+    id: 'director:elroypave'
     platform: mac
     lang: en
     title: 'Elroy Hits the Pavement'
     version: '4'
     url: /frs/demos/director/d4/en/elroypave-demo-mac.zip
 -
-    id: elroypave
+    id: 'director:elroypave'
     platform: win
     lang: en
     title: 'Elroy Hits the Pavement'
     version: '4'
     url: /frs/demos/director/d4/en/elroypave-demo-win.zip
 -
-    id: emme
+    id: 'director:emme'
     platform: mac
     lang: en
     title: 'E.M.M.E. Interactive: The Keys to Knowledge'
     version: '4'
     url: /frs/demos/director/d4/en/emme-mac.zip
 -
-    id: emme
+    id: 'director:emme'
     platform: win
     lang: en
     title: 'E.M.M.E. Interactive: The Keys to Knowledge'
     version: '4'
     url: /frs/demos/director/d4/en/emme-win.zip
 -
-    id: famalbum
+    id: 'director:famalbum'
     platform: win
     lang: en
     title: 'Family Album Creator'
     version: '4'
     url: /frs/demos/director/d4/en/famalbum-demo-win.zip
 -
-    id: famdoc4
+    id: 'director:famdoc4'
     platform: win
     lang: en
     title: 'The Family Doctor, 4th Edition'
     version: '4'
     url: /frs/demos/director/d4/en/famdoc4-demo-win.zip
 -
-    id: fantazion
+    id: 'director:fantazion'
     platform: mac
     lang: ja
     title: 'World Engine Fantazion'
     version: '4'
     url: /frs/demos/director/d4/ja/fantazion-demo-mac-ja.zip
 -
-    id: fppirates
+    id: 'director:fppirates'
     platform: mac
     lang: en
     title: 'Great Adventures by Fisher-Price: Pirates'
     version: '4'
     url: /frs/demos/director/d4/en/fppirates-demo-mac.zip
 -
-    id: fppuddlebooks
+    id: 'director:fppuddlebooks'
     platform: mac
     lang: en
     title: 'Fisher-Price Read & Play: Puddle Books Demos'
     version: '4'
     url: /frs/demos/director/d4/en/fppuddlebooks-mac.zip
 -
-    id: fppuddlebooks
+    id: 'director:fppuddlebooks'
     platform: win
     lang: en
     title: 'Fisher-Price Read & Play: Puddle Books Demos'
     version: '4'
     url: /frs/demos/director/d4/en/fppuddlebooks-win.zip
 -
-    id: frankenstein
+    id: 'director:frankenstein'
     platform: mac
     lang: en
     title: 'Frankenstein: Through the Eyes of the Monster'
     version: '4'
     url: /frs/demos/director/d4/en/frankenstein-demo-mac.zip
 -
-    id: frankenstein
+    id: 'director:frankenstein'
     platform: win
     lang: en
     title: 'Frankenstein: Through the Eyes of the Monster'
     version: '4'
     url: /frs/demos/director/d4/en/frankenstein-demo-win.zip
 -
-    id: fsky
+    id: 'director:fsky'
     platform: mac
     lang: en
     title: 'A Field Trip to the Sky'
     version: '4'
     url: /frs/demos/director/d4/en/fsky-demo-mac.zip
 -
-    id: futarinoryori
+    id: 'director:futarinoryori'
     platform: mac
     lang: ja
     title: ふたりの料理物語
     version: '4'
     url: /frs/demos/director/d4/ja/futarinoryori-demo-mac-ja.zip
 -
-    id: greetingstudio
+    id: 'director:greetingstudio'
     platform: mac
     lang: ja
     title: 'Greeting STUDIO'
     version: '4'
     url: /frs/demos/director/d4/ja/greetingstudio-demo-mac-ja.zip
 -
-    id: greetingstudio
+    id: 'director:greetingstudio'
     platform: win
     lang: ja
     title: 'Greeting STUDIO'
     version: '4'
     url: /frs/demos/director/d4/ja/greetingstudio-demo-win-ja.zip
 -
-    id: gundam0079
+    id: 'director:gundam0079'
     platform: mac
     lang: en
     title: 'Gundam 0079: The War for Earth'
     version: '4'
     url: /frs/demos/director/d4/en/gundam0079-demo-mac.zip
 -
-    id: gusbuds
+    id: 'director:gusbuds'
     platform: mac
     lang: en
     title: 'Gus and the CyberBuds Learning Adventure Series'
     version: '4'
     url: /frs/demos/director/d4/en/gusbuds-mac.zip
 -
-    id: gusbuds
+    id: 'director:gusbuds'
     platform: win
     lang: en
     title: 'Gus and the CyberBuds Learning Adventure Series'
     version: '4'
     url: /frs/demos/director/d4/en/gusbuds-win.zip
 -
-    id: guscarn
+    id: 'director:guscarn'
     platform: mac
     lang: en
     title: 'Gus Goes to the Kooky Carnival'
     version: '4'
     url: /frs/demos/director/d4/en/guscarn-demo-mac.zip
 -
-    id: gusolis
+    id: 'director:gusolis'
     platform: mac
     lang: en
     title: 'Gus Goes to Cyberopolis'
     version: '4'
     url: /frs/demos/director/d4/en/gusolis-demo-mac.zip
 -
-    id: gustown
+    id: 'director:gustown'
     platform: mac
     lang: en
     title: 'Gus Goes to Cybertown'
     version: '4'
     url: /frs/demos/director/d4/en/gustown-demo-mac.zip
 -
-    id: headbone
+    id: 'director:headbone'
     platform: mac
     lang: en
     title: 'Headbone CD-ROM Sampler'
     version: '4'
     url: /frs/demos/director/d4/en/headbone-mac-1.zip
 -
-    id: headbone
+    id: 'director:headbone'
     platform: win
     lang: en
     title: 'Headbone CD-ROM Sampler'
     version: '4'
     url: /frs/demos/director/d4/en/headbone-win-1.zip
 -
-    id: himejijo
+    id: 'director:himejijo'
     platform: mac
     lang: ja
     title: A.MAZING姫路城
     version: '4'
     url: /frs/demos/director/d4/ja/himejijo-demo-mac-ja.zip
 -
-    id: hyperblade
+    id: 'director:hyperblade'
     platform: win
     lang: en
     title: HyperBlade
     version: '4'
     url: /frs/demos/director/d4/en/hyperblade-demo-win.zip
 -
-    id: imagineers
+    id: 'director:imagineers'
     platform: mac
     lang: en
     title: 'The Imagineers'
     version: '4'
     url: /frs/demos/director/d4/en/imagineers-demo-mac.zip
 -
-    id: incoming
+    id: 'director:incoming'
     platform: win
     lang: en
     title: iNCOMING
     version: '4'
     url: /frs/demos/director/d4/en/incoming-win.zip
 -
-    id: infinitycity
+    id: 'director:infinitycity'
     platform: mac
     lang: en
     title: 'Infinity City'
     version: '4'
     url: /frs/demos/director/d4/en/infinitycity-demo-mac.zip
 -
-    id: infinitycity
+    id: 'director:infinitycity'
     platform: win
     lang: en
     title: 'Infinity City'
     version: '4'
     url: /frs/demos/director/d4/en/infinitycity-demo-win.zip
 -
-    id: inposition
+    id: 'director:inposition'
     platform: mac
     lang: ja
     title: INposition
     version: '4'
     url: /frs/demos/director/d4/ja/inposition-demo-mac-ja.zip
 -
-    id: iona
+    id: 'director:iona'
     platform: mac
     lang: en
     title: 'Iona Software Demo CD (1996)'
     version: '4'
     url: /frs/demos/director/d4/en/iona-demo-mac-96.zip
 -
-    id: iona
+    id: 'director:iona'
     platform: win
     lang: en
     title: 'Iona Software Demo CD (1996)'
     version: '4'
     url: /frs/demos/director/d4/en/iona-demo-win-96.zip
 -
-    id: jewels
+    id: 'director:jewels'
     platform: win
     lang: en
     title: 'Jewels of the Oracle'
     version: '4'
     url: /frs/demos/director/d4/en/jewels-demo-win.zip
 -
-    id: jman
+    id: 'director:jman'
     platform: mac
     lang: en
     title: 'The Journeyman Project'
     version: '4'
     url: /frs/demos/director/d4/en/jman-demo-mac-img.zip
 -
-    id: jman2
+    id: 'director:jman2'
     platform: mac
     lang: en
     title: 'The Journeyman Project 2: Buried in Time (1994)'
     version: '4'
     url: /frs/demos/director/d4/en/jman2-demo-mac-062294.zip
 -
-    id: jman2
+    id: 'director:jman2'
     platform: mac
     lang: en
     title: 'The Journeyman Project 2: Buried in Time (Final)'
     version: '4'
     url: /frs/demos/director/d4/en/jman2-demo-mac-final.zip
 -
-    id: jman2
+    id: 'director:jman2'
     platform: mac
     lang: en
     title: 'The Journeyman Project 2: Buried in Time (Gallery)'
     version: '4'
     url: /frs/demos/director/d4/en/jman2-demo-mac-gallery.zip
 -
-    id: jman2
+    id: 'director:jman2'
     platform: mac
     lang: en
     title: 'The Journeyman Project 2: Buried in Time (Overview)'
     version: '4'
     url: /frs/demos/director/d4/en/jman2-demo-mac-overview.zip
 -
-    id: jman2
+    id: 'director:jman2'
     platform: mac
     lang: ja
     title: 'The Journeyman Project 2: Buried in Time'
     version: '4'
     url: /frs/demos/director/d4/ja/jman2-demo-mac-ja.zip
 -
-    id: jman2
+    id: 'director:jman2'
     platform: win
     lang: ja
     title: 'The Journeyman Project 2: Buried in Time'
     version: '4'
     url: /frs/demos/director/d4/ja/jman2-demo-win-ja.zip
 -
-    id: karuta
+    id: 'director:karuta'
     platform: mac
     lang: ja
     title: かるたでおじゃる
     version: '4'
     url: /frs/demos/director/d4/ja/karuta-demo-mac-ja.zip
 -
-    id: karuta
+    id: 'director:karuta'
     platform: win
     lang: ja
     title: かるたでおじゃる
     version: '4'
     url: /frs/demos/director/d4/ja/karuta-demo-win-ja.zip
 -
-    id: kenji
+    id: 'director:kenji'
     platform: mac
     lang: ja
     title: Kenji
     version: '4'
     url: /frs/demos/director/d4/ja/kenji-demo-mac-ja.zip
 -
-    id: kfk
+    id: 'director:kfk'
     platform: win
     lang: en
     title: 'Kung Fu Kim'
     version: '4'
     url: /frs/demos/director/d4/en/kfk-win.zip
 -
-    id: kidsbox
+    id: 'director:kidsbox'
     platform: mac
     lang: ja
     title: 'Kids Box'
     version: '4'
     url: /frs/demos/director/d4/ja/kidsbox-demo-mac-ja.zip
 -
-    id: kidtools
+    id: 'director:kidtools'
     platform: win
     lang: en
     title: 'Kid Tools Series Demo'
     version: '4'
     url: /frs/demos/director/d4/en/kidtools-win.zip
 -
-    id: laughingbird
+    id: 'director:laughingbird'
     platform: mac
     lang: en
     title: 'The Laughing Bird Restaurant'
     version: '4'
     url: /frs/demos/director/d4/en/laughingbird-mac.zip
 -
-    id: letters
+    id: 'director:letters'
     platform: win
     lang: en
     title: Letters
     version: '4'
     url: /frs/demos/director/d4/en/letters-demo-win.zip
 -
-    id: lion
+    id: 'director:lion'
     platform: mac
     lang: en
     title: Lion
     version: '4'
     url: /frs/demos/director/d4/en/lion-demo-mac.zip
 -
-    id: macos8
+    id: 'director:macos8'
     platform: mac
     lang: en
     title: 'Mac OS 8'
     version: '4'
     url: /frs/demos/director/d4/en/macos8-demo-mac.zip
 -
-    id: madpup
+    id: 'director:madpup'
     platform: win
     lang: en
     title: 'Madeline and the Magnificent Puppet Show: A Learning Journey'
     version: '4'
     url: /frs/demos/director/d4/en/madpup-demo-win-1.zip
 -
-    id: madpup
+    id: 'director:madpup'
     platform: win
     lang: en
     title: 'Madeline and the Magnificent Puppet Show: A Learning Journey'
     version: '4'
     url: /frs/demos/director/d4/en/madpup-demo-win-2.zip
 -
-    id: madtg
+    id: 'director:madtg'
     platform: win
     lang: en
     title: 'Madeline Thinking Games'
     version: '4'
     url: /frs/demos/director/d4/en/madtg-demo-win-1996.zip
 -
-    id: manhole
+    id: 'director:manhole'
     platform: mac
     lang: ja
     title: 'The Manhole (Masterpiece Edition)'
     version: '4'
     url: /frs/demos/director/d4/ja/manhole-demo-mac-ja-me.zip
 -
-    id: mastermansion
+    id: 'director:mastermansion'
     platform: win
     lang: en
     title: 'Masterpiece Mansion'
     version: '4'
     url: /frs/demos/director/d4/en/mastermansion-demo-win.zip
 -
-    id: mathblasterjr
+    id: 'director:mathblasterjr'
     platform: mac
     lang: en
     title: 'Math Blaster Jr.'
     version: '4'
     url: /frs/demos/director/d4/en/mathblasterjr-demo-mac.zip
 -
-    id: mathtest
+    id: 'director:mathtest'
     platform: mac
     lang: en
     title: 'Math Test'
     version: '4'
     url: /frs/demos/director/d4/en/mathtest-mac.zip
 -
-    id: mcmillennium
+    id: 'director:mcmillennium'
     platform: win
     lang: en
     title: 'Mission Code: Millennium'
     version: '4'
     url: /frs/demos/director/d4/en/mcmillennium-demo-win.zip
 -
-    id: mechwarrior2
+    id: 'director:mechwarrior2'
     platform: win
     lang: en
     title: 'MechWarrior 2'
     version: '4'
     url: /frs/demos/director/d4/en/mechwarrior2-demo-win.zip
 -
-    id: mediabook
+    id: 'director:mediabook'
     platform: mac
     lang: en
     title: 'The MediaBook CD for Director (Sampler)'
     version: '4'
     url: /frs/demos/director/d4/en/mediabook-demo-mac-sampler.zip
 -
-    id: mediabook
+    id: 'director:mediabook'
     platform: mac
     lang: en
     title: 'The MediaBook CD for Director (Toolbox)'
     version: '4'
     url: /frs/demos/director/d4/en/mediabook-demo-mac-toolbox.zip
 -
-    id: mominoki
+    id: 'director:mominoki'
     platform: mac
     lang: ja
     title: 'もみの木の下で ～ The Day of St.Claus'
     version: '4'
     url: /frs/demos/director/d4/ja/mominoki-demo-mac-ja.zip
 -
-    id: msoffice
+    id: 'director:msoffice'
     platform: mac
     lang: en
     title: 'Microsoft Office'
     version: '4'
     url: /frs/demos/director/d4/en/msoffice-demo-mac.zip
 -
-    id: msoffice
+    id: 'director:msoffice'
     platform: win
     lang: en
     title: 'Microsoft Office'
     version: '4'
     url: /frs/demos/director/d4/en/msoffice-demo-win.zip
 -
-    id: mukashibanashi
+    id: 'director:mukashibanashi'
     platform: mac
     lang: ja
     title: 日本昔話
     version: '4'
     url: /frs/demos/director/d4/ja/mukashibanashi-demo-mac-ja.zip
 -
-    id: muppets
+    id: 'director:muppets'
     platform: win
     lang: en
     title: 'Muppet Treasure Island'
     version: '4'
     url: /frs/demos/director/d4/en/muppets-demo-win.zip
 -
-    id: mysteriousegypt
+    id: 'director:mysteriousegypt'
     platform: win
     lang: fi
     title: 'Mysterious Egypt'
     version: '4'
     url: /frs/demos/director/d4/fi/mysteriousegypt-demo-win-fi.zip
 -
-    id: necrobius
+    id: 'director:necrobius'
     platform: win
     lang: en
     title: Necrobius
     version: '4'
     url: /frs/demos/director/d4/en/necrobius-demo-win.zip
 -
-    id: nendo
+    id: 'director:nendo'
     platform: mac
     lang: ja
     title: 'Digital Nendo'
     version: '4'
     url: /frs/demos/director/d4/ja/nendo-demo-mac-ja.zip
 -
-    id: newslinks
+    id: 'director:newslinks'
     platform: win
     lang: en
     title: 'ABC NewsLinks'
     version: '4'
     url: /frs/demos/director/d4/en/newslinks-demo-win.zip
 -
-    id: nihonchiri
+    id: 'director:nihonchiri'
     platform: mac
     lang: ja
     title: Visual日本地理
     version: '4'
     url: /frs/demos/director/d4/ja/nihonchiri-demo-mac-ja.zip
 -
-    id: nine
+    id: 'director:nine'
     platform: win
     lang: en
     title: '9: The Last Resort'
     version: '4'
     url: /frs/demos/director/d4/en/nine-demo-win.zip
 -
-    id: niningashi
+    id: 'director:niningashi'
     platform: mac
     lang: ja
     title: ににんがし
     version: '4'
     url: /frs/demos/director/d4/ja/niningashi-demo-mac-ja.zip
 -
-    id: niningashi
+    id: 'director:niningashi'
     platform: win
     lang: ja
     title: ににんがし
     version: '4'
     url: /frs/demos/director/d4/ja/niningashi-demo-win-ja.zip
 -
-    id: nixon
+    id: 'director:nixon'
     platform: win
     lang: en
     title: 'Nixon: Watergate'
     version: '4'
     url: /frs/demos/director/d4/en/nixon-demo-win.zip
 -
-    id: noahsark
+    id: 'director:noahsark'
     platform: mac
     lang: ja
     title: 'Noah''s Ark'
     version: '4'
     url: /frs/demos/director/d4/ja/noahsark-demo-mac-ja.zip
 -
-    id: noahsark
+    id: 'director:noahsark'
     platform: win
     lang: ja
     title: 'Noah''s Ark'
     version: '4'
     url: /frs/demos/director/d4/ja/noahsark-demo-win-ja.zip
 -
-    id: noir
+    id: 'director:noir'
     platform: win
     lang: en
     title: 'Noir: A Shadowy Thriller'
     version: '4'
     url: /frs/demos/director/d4/en/noir-demo-win.zip
 -
-    id: nomis
+    id: 'director:nomis'
     platform: mac
     lang: en
     title: Nomis
     version: '4'
     url: /frs/demos/director/d4/en/nomis-mac.zip
 -
-    id: orgotto
+    id: 'director:orgotto'
     platform: mac
     lang: ja
     title: Orgotto
     version: '4'
     url: /frs/demos/director/d4/ja/orgotto-demo-mac.zip
 -
-    id: orgotto
+    id: 'director:orgotto'
     platform: win
     lang: ja
     title: Orgotto
     version: '4'
     url: /frs/demos/director/d4/ja/orgotto-demo-win.zip
 -
-    id: origin
+    id: 'director:origin'
     platform: win
     lang: en
     title: 'Origin Systems Product Catalog (v11)'
     version: '4'
     url: /frs/demos/director/d4/en/origin-win-v11.zip
 -
-    id: origin
+    id: 'director:origin'
     platform: win
     lang: en
     title: 'Origin Systems Product Catalog (v6)'
     version: '4'
     url: /frs/demos/director/d4/en/origin-win-v6.zip
 -
-    id: origin
+    id: 'director:origin'
     platform: win
     lang: en
     title: 'Origin Systems Product Catalog (v7)'
     version: '4'
     url: /frs/demos/director/d4/en/origin-win-v7.zip
 -
-    id: origin
+    id: 'director:origin'
     platform: win
     lang: en
     title: 'Origin Systems Product Catalog (v8)'
     version: '4'
     url: /frs/demos/director/d4/en/origin-win-v8.zip
 -
-    id: osaka1
+    id: 'director:osaka1'
     platform: mac
     lang: ja
     title: '必修大阪弁集中講座I 2010年、標準語は大阪弁になる'
     version: '4'
     url: /frs/demos/director/d4/ja/osaka1-demo-mac-ja.zip
 -
-    id: osaka1
+    id: 'director:osaka1'
     platform: win
     lang: ja
     title: '必修大阪弁集中講座I 2010年、標準語は大阪弁になる'
     version: '4'
     url: /frs/demos/director/d4/ja/osaka1-demo-win-ja.zip
 -
-    id: pagemaker
+    id: 'director:pagemaker'
     platform: mac
     lang: en
     title: 'Aldus PageMaker'
     version: '4'
     url: /frs/demos/director/d4/en/pagemaker-demo-mac.zip
 -
-    id: paris
+    id: 'director:paris'
     platform: mac
     lang: fr
     title: 'Paris: History and Splendour'
     version: '4'
     url: /frs/demos/director/d4/fr/paris-demo-mac-fr.zip
 -
-    id: paris
+    id: 'director:paris'
     platform: win
     lang: fr
     title: 'Paris: History and Splendour'
     version: '4'
     url: /frs/demos/director/d4/fr/paris-demo-win-fr.zip
 -
-    id: parliament
+    id: 'director:parliament'
     platform: win
     lang: en
     title: 'People & Parliament: A Stranger''s Guide to Westminster'
     version: '4'
     url: /frs/demos/director/d4/en/parliament-win.zip
 -
-    id: pbbear
+    id: 'director:pbbear'
     platform: win
     lang: en
     title: 'P. B. Bear''s Birthday Party'
     version: '4'
     url: /frs/demos/director/d4/en/pbbear-demo-win.zip
 -
-    id: petepilotti1
+    id: 'director:petepilotti1'
     platform: mac
     lang: fi
     title: 'Pete Pilotti & Pontiac: Seikkailu Lapponiassa'
     version: '4'
     url: /frs/demos/director/d4/fi/petepilotti1-demo-mac-fi.zip
 -
-    id: petepilotti1
+    id: 'director:petepilotti1'
     platform: win
     lang: fi
     title: 'Pete Pilotti & Pontiac: Seikkailu Lapponiassa'
     version: '4'
     url: /frs/demos/director/d4/fi/petepilotti1-demo-win-fi.zip
 -
-    id: phantplanet
+    id: 'director:phantplanet'
     platform: mac
     lang: ja
     title: 'アミューズメント プラネット ファンタスマゴリア'
     version: '4'
     url: /frs/demos/director/d4/ja/phantplanet-demo-mac-ja.zip
 -
-    id: phantplanet
+    id: 'director:phantplanet'
     platform: win
     lang: ja
     title: 'アミューズメント プラネット ファンタスマゴリア'
     version: '4'
     url: /frs/demos/director/d4/ja/phantplanet-demo-win-ja.zip
 -
-    id: photos4us
+    id: 'director:photos4us'
     platform: mac
     lang: en
     title: Photos4us
     version: '4'
     url: /frs/demos/director/d4/en/photos4us-demo-mac.zip
 -
-    id: pitfall
+    id: 'director:pitfall'
     platform: win
     lang: en
     title: 'Pitfall: The Mayan Adventure'
     version: '4'
     url: /frs/demos/director/d4/en/pitfall-demo-win.zip
 -
-    id: playskool
+    id: 'director:playskool'
     platform: mac
     lang: en
     title: 'Playskool Software Experience'
     version: '4'
     url: /frs/demos/director/d4/en/playskool-mac.zip
 -
-    id: playskool
+    id: 'director:playskool'
     platform: win
     lang: en
     title: 'Playskool Software Experience'
     version: '4'
     url: /frs/demos/director/d4/en/playskool-win.zip
 -
-    id: popup
+    id: 'director:popup'
     platform: mac
     lang: ja
     title: 'Pop Up Computer'
     version: '4'
     url: /frs/demos/director/d4/ja/popup-demo-mac-ja.zip
 -
-    id: popupmaker
+    id: 'director:popupmaker'
     platform: mac
     lang: ja
     title: 'Pop Up Maker'
     version: '4'
     url: /frs/demos/director/d4/ja/popupmaker-demo-mac-ja.zip
 -
-    id: prangers1
+    id: 'director:prangers1'
     platform: mac
     lang: en
     title: 'PowerRangers Part 1'
     version: '4'
     url: /frs/demos/director/d4/en/prangers1-mac.zip
 -
-    id: prangers2
+    id: 'director:prangers2'
     platform: mac
     lang: en
     title: 'PowerRangers Part 2'
     version: '4'
     url: /frs/demos/director/d4/en/prangers2-mac.zip
 -
-    id: princeint
+    id: 'director:princeint'
     platform: mac
     lang: en
     title: 'Prince Interactive'
     version: '4'
     url: /frs/demos/director/d4/en/princeint-demo-mac.zip
 -
-    id: princeint
+    id: 'director:princeint'
     platform: win
     lang: en
     title: 'Prince Interactive'
     version: '4'
     url: /frs/demos/director/d4/en/princeint-demo-win.zip
 -
-    id: psych
+    id: 'director:psych'
     platform: mac
     lang: en
     title: 'Psych: An Interactive Stress Buster!'
     version: '4'
     url: /frs/demos/director/d4/en/psych-mac-105.zip
 -
-    id: psych
+    id: 'director:psych'
     platform: mac
     lang: en
     title: 'Psych: An Interactive Stress Buster!'
     version: '4'
     url: /frs/demos/director/d4/en/psych-mac-201.zip
 -
-    id: pyrethrum1
+    id: 'director:pyrethrum1'
     platform: mac
     lang: ja
     title: 除虫菊Vol.1
     version: '4'
     url: /frs/demos/director/d4/ja/pyrethrum1-demo-mac-ja.zip
 -
-    id: pyrethrum1
+    id: 'director:pyrethrum1'
     platform: win
     lang: ja
     title: 除虫菊Vol.1
     version: '4'
     url: /frs/demos/director/d4/ja/pyrethrum1-demo-win-ja.zip
 -
-    id: quantumgate2
+    id: 'director:quantumgate2'
     platform: mac
     lang: ja
     title: 'The Vortex: Quantum Gate II'
     version: '4'
     url: /frs/demos/director/d4/ja/quantumgate2-demo-mac-ja.zip
 -
-    id: quantumgate2
+    id: 'director:quantumgate2'
     platform: win
     lang: ja
     title: 'The Vortex: Quantum Gate II'
     version: '4'
     url: /frs/demos/director/d4/ja/quantumgate2-demo-win-ja.zip
 -
-    id: racingdays
+    id: 'director:racingdays'
     platform: mac
     lang: ja
     title: 'Racing Days'
     version: '4'
     url: /frs/demos/director/d4/ja/racingdays-demo-mac-ja.zip
 -
-    id: readblasterjr
+    id: 'director:readblasterjr'
     platform: mac
     lang: en
     title: 'Reading Blaster Jr.'
     version: '4'
     url: /frs/demos/director/d4/en/readblasterjr-demo-mac.zip
 -
-    id: redshift
+    id: 'director:redshift'
     platform: mac
     lang: en
     title: 'RedShift: Multimedia Astronomy'
     version: '4'
     url: /frs/demos/director/d4/en/redshift-demo-mac-1994.zip
 -
-    id: rheingold
+    id: 'director:rheingold'
     platform: mac
     lang: ja
     title: ラインの黄金
     version: '4'
     url: /frs/demos/director/d4/ja/rheingold-demo-mac-ja.zip
 -
-    id: santafe1
+    id: 'director:santafe1'
     platform: win
     lang: en
     title: 'Santa Fe Mysteries: The Elk Moon Murder'
     version: '4'
     url: /frs/demos/director/d4/en/santafe1-demo-win.zip
 -
-    id: searchlearn
+    id: 'director:searchlearn'
     platform: win
     lang: en
     title: 'Search & Learn Adventures'
     version: '4'
     url: /frs/demos/director/d4/en/searchlearn-demo-win.zip
 -
-    id: sensei
+    id: 'director:sensei'
     platform: mac
     lang: en
     title: Sensei
     version: '4'
     url: /frs/demos/director/d4/en/sensei-mac.zip
 -
-    id: shadeviewer
+    id: 'director:shadeviewer'
     platform: mac
     lang: ja
     title: 'Shade Viewer'
     version: '4'
     url: /frs/demos/director/d4/ja/shadeviewer-demo-mac-ja.zip
 -
-    id: shanghai
+    id: 'director:shanghai'
     platform: win
     lang: en
     title: 'Shanghai: Great Moments'
     version: '4'
     url: /frs/demos/director/d4/en/shanghai-demo-win.zip
 -
-    id: shinshofukei
+    id: 'director:shinshofukei'
     platform: win
     lang: ja
     title: 心象風景
     version: '4'
     url: /frs/demos/director/d4/ja/shinshofukei-demo-win-ja.zip
 -
-    id: shramerica
+    id: 'director:shramerica'
     platform: win
     lang: en
     title: 'Schoolhouse Rock!: America Rock'
     version: '4'
     url: /frs/demos/director/d4/en/shramerica-demo-win.zip
 -
-    id: shrgrammar
+    id: 'director:shrgrammar'
     platform: win
     lang: en
     title: 'Schoolhouse Rock!: Grammar Rock'
     version: '4'
     url: /frs/demos/director/d4/en/shrgrammar-demo-win.zip
 -
-    id: shrmath
+    id: 'director:shrmath'
     platform: win
     lang: en
     title: 'Schoolhouse Rock!: Math Rock'
     version: '4'
     url: /frs/demos/director/d4/en/shrmath-demo-win.zip
 -
-    id: skyborg
+    id: 'director:skyborg'
     platform: win
     lang: en
     title: 'SkyBorg: Into the Vortex'
     version: '4'
     url: /frs/demos/director/d4/en/skyborg-demo-win.zip
 -
-    id: smashsounds1
+    id: 'director:smashsounds1'
     platform: win
     lang: en
     title: 'Smash Sounds Volume 1'
     version: '4'
     url: /frs/demos/director/d4/en/smashsounds1-demo-win.zip
 -
-    id: sozaijiten
+    id: 'director:sozaijiten'
     platform: mac
     lang: ja
     title: 素材辞典
     version: '4'
     url: /frs/demos/director/d4/ja/sozaijiten-demo-mac-ja.zip
 -
-    id: spycraft
+    id: 'director:spycraft'
     platform: win
     lang: en
     title: 'Spycraft: The Great Game'
     version: '4'
     url: /frs/demos/director/d4/en/spycraft-demo-win.zip
 -
-    id: sscocacola
+    id: 'director:sscocacola'
     platform: mac
     lang: en
     title: 'Coca-Cola Screen Saver'
     version: '4'
     url: /frs/demos/director/d4/en/sscocacola-mac.zip
 -
-    id: ssdietcoke
+    id: 'director:ssdietcoke'
     platform: mac
     lang: en
     title: 'Diet Coke Screen Saver'
     version: '4'
     url: /frs/demos/director/d4/en/ssdietcoke-mac.zip
 -
-    id: sslivepicture
+    id: 'director:sslivepicture'
     platform: mac
     lang: en
     title: 'Live Picture Screen Saver'
     version: '4'
     url: /frs/demos/director/d4/en/sslivepicture-mac.zip
 -
-    id: tetsuman
+    id: 'director:tetsuman'
     platform: mac
     lang: ja
     title: 'ハイ! 鉄マン です'
     version: '4'
     url: /frs/demos/director/d4/ja/tetsuman-demo-mac-ja.zip
 -
-    id: tetsuman
+    id: 'director:tetsuman'
     platform: win
     lang: ja
     title: 'ハイ! 鉄マン です'
     version: '4'
     url: /frs/demos/director/d4/ja/tetsuman-demo-win-ja.zip
 -
-    id: tetsumangaiden
+    id: 'director:tetsumangaiden'
     platform: mac
     lang: ja
     title: '鉄マン外伝 ゲーム大王の野望'
     version: '4'
     url: /frs/demos/director/d4/ja/tetsumangaiden-demo-mac-ja.zip
 -
-    id: tetsumangaiden
+    id: 'director:tetsumangaiden'
     platform: win
     lang: ja
     title: '鉄マン外伝 ゲーム大王の野望'
     version: '4'
     url: /frs/demos/director/d4/ja/tetsumangaiden-demo-win-ja.zip
 -
-    id: toeic
+    id: 'director:toeic'
     platform: mac
     lang: ja
     title: PowerTOEIC
     version: '4'
     url: /frs/demos/director/d4/ja/toeic-demo-mac-ja.zip
 -
-    id: tommy
+    id: 'director:tommy'
     platform: win
     lang: en
     title: 'Pete Townshend Presents Tommy: The Interactive Adventure'
     version: '4'
     url: /frs/demos/director/d4/en/tommy-demo-win.zip
 -
-    id: tonetrakker
+    id: 'director:tonetrakker'
     platform: win
     lang: en
     title: 'Tone Trakker'
     version: '4'
     url: /frs/demos/director/d4/en/tonetrakker-demo-win.zip
 -
-    id: toyota95
+    id: 'director:toyota95'
     platform: mac
     lang: en
     title: '1995 Toyota Interactive'
     version: '4'
     url: /frs/demos/director/d4/en/toyota95-mac.zip
 -
-    id: trektech
+    id: 'director:trektech'
     platform: mac
     lang: en
     title: 'Star Trek: The Next Generation Interactive Technical Manual'
     version: '4'
     url: /frs/demos/director/d4/en/trektech-demo-mac.zip
 -
-    id: ubt
+    id: 'director:ubt'
     platform: win
     lang: en
     title: 'Under the Big Top'
     version: '4'
     url: /frs/demos/director/d4/en/ubt-win.zip
 -
-    id: ukiuki1
+    id: 'director:ukiuki1'
     platform: mac
     lang: ja
     title: 'ウキウキ釣り天国 ～幻の天狗池～'
     version: '4'
     url: /frs/demos/director/d4/ja/ukiuki1-demo-cd-mac-ja.zip
 -
-    id: ukiuki1
+    id: 'director:ukiuki1'
     platform: win
     lang: ja
     title: 'ウキウキ釣り天国 ～幻の天狗池～'
     version: '4'
     url: /frs/demos/director/d4/ja/ukiuki1-demo-win-ja.zip
 -
-    id: ukiuki2
+    id: 'director:ukiuki2'
     platform: mac
     lang: ja
     title: 'ウキウキ釣り天国2 ～波止の五目釣り～'
     version: '4'
     url: /frs/demos/director/d4/ja/ukiuki2-demo-mac-ja.zip
 -
-    id: ukiuki2
+    id: 'director:ukiuki2'
     platform: win
     lang: ja
     title: 'ウキウキ釣り天国2 ～波止の五目釣り～'
     version: '4'
     url: /frs/demos/director/d4/ja/ukiuki2-demo-win-ja.zip
 -
-    id: vcop
+    id: 'director:vcop'
     platform: mac
     lang: en
     title: 'Virtual Cop'
     version: '4'
     url: /frs/demos/director/d4/en/vcop-demo-mac.zip
 -
-    id: verttice
+    id: 'director:verttice'
     platform: mac
     lang: en
     title: 'DreamLight Verttice'
     version: '4'
     url: /frs/demos/director/d4/en/verttice-mac-20.zip
 -
-    id: victorianpark
+    id: 'director:victorianpark'
     platform: mac
     lang: ja
     title: 'Victorian Park'
     version: '4'
     url: /frs/demos/director/d4/ja/victorianpark-demo-mac-ja.zip
 -
-    id: vote
+    id: 'director:vote'
     platform: win
     lang: en
     title: 'Vote America: Your Field Guide to Electing a President'
     version: '4'
     url: /frs/demos/director/d4/en/vote-demo-win.zip
 -
-    id: vtarot
+    id: 'director:vtarot'
     platform: win
     lang: en
     title: 'Virtual Tarot'
     version: '4'
     url: /frs/demos/director/d4/en/vtarot-demo-win.zip
 -
-    id: vusic
+    id: 'director:vusic'
     platform: mac
     lang: en
     title: 'Vusic: The Screen Raver'
     version: '4'
     url: /frs/demos/director/d4/en/vusic-demo-mac.zip
 -
-    id: vusic
+    id: 'director:vusic'
     platform: win
     lang: en
     title: 'Vusic: The Screen Raver'
     version: '4'
     url: /frs/demos/director/d4/en/vusic-demo-win.zip
 -
-    id: wariwari
+    id: 'director:wariwari'
     platform: mac
     lang: ja
     title: わりわりワールド
     version: '4'
     url: /frs/demos/director/d4/ja/wariwari-demo-mac-ja.zip
 -
-    id: wariwari
+    id: 'director:wariwari'
     platform: win
     lang: ja
     title: わりわりワールド
     version: '4'
     url: /frs/demos/director/d4/ja/wariwari-demo-win-ja.zip
 -
-    id: warplanes
+    id: 'director:warplanes'
     platform: mac
     lang: en
     title: 'Warplanes: Modern Fighting Aircraft'
     version: '4'
     url: /frs/demos/director/d4/en/warplanes-demo-mac.zip
 -
-    id: wonderomcw
+    id: 'director:wonderomcw'
     platform: mac
     lang: ja
     title: 'WONDEROM クラリスワークス'
     version: '4'
     url: /frs/demos/director/d4/ja/wonderomcw-demo-mac-ja.zip
 -
-    id: worldatlas
+    id: 'director:worldatlas'
     platform: win
     lang: en
     title: 'World Reference Atlas'
     version: '4'
     url: /frs/demos/director/d4/en/worldatlas-demo-win.zip
 -
-    id: wwanimals
+    id: 'director:wwanimals'
     platform: win
     lang: en
     title: 'Wide World of Animals'
     version: '4'
     url: /frs/demos/director/d4/en/wwanimals-demo-win.zip
 -
-    id: ybr2
+    id: 'director:ybr2'
     platform: win
     lang: ja
     title: イエロー・ブリック・ロードII
     version: '4'
     url: /frs/demos/director/d4/ja/ybr2-demo-win-ja.zip
 -
-    id: yoidon
+    id: 'director:yoidon'
     platform: mac
     lang: ja
     title: よ〜いドン!
     version: '4'
     url: /frs/demos/director/d4/ja/yoidon-demo-mac-ja.zip
 -
-    id: yoidon
+    id: 'director:yoidon'
     platform: win
     lang: ja
     title: よ〜いドン!
     version: '4'
     url: /frs/demos/director/d4/ja/yoidon-demo-win-ja.zip
 -
-    id: znemesis
+    id: 'director:znemesis'
     platform: win
     lang: en
     title: 'Zork Nemesis: The Forbidden Lands'
     version: '4'
     url: /frs/demos/director/d4/en/znemesis-demo-win.zip
 -
-    id: almabril98
+    id: 'director:almabril98'
     platform: win
     lang: pt-br
     title: 'Almanaque Abril 1998'
     version: '5'
     url: /frs/demos/director/d5/pt-br/almabril98-demo-win-br.zip
 -
-    id: arad
+    id: 'director:arad'
     platform: win
     lang: en
     title: 'Animaniacs River Adventure'
     version: '5'
     url: /frs/demos/director/d5/en/arad-win.zip
 -
-    id: arcmedia
+    id: 'director:arcmedia'
     platform: mac
     lang: en
     title: 'Arc Media Demos'
     version: '5'
     url: /frs/demos/director/d5/en/arcmedia-mac.zip
 -
-    id: arcmedia
+    id: 'director:arcmedia'
     platform: win
     lang: en
     title: 'Arc Media Demos'
     version: '5'
     url: /frs/demos/director/d5/en/arcmedia-win.zip
 -
-    id: bluesbros2000
+    id: 'director:bluesbros2000'
     platform: win
     lang: en
     title: 'Blues Brothers 2000 Full Promotion'
     version: '5'
     url: /frs/demos/director/d5/en/bluesbros2000-win.zip
 -
-    id: bvi1997
+    id: 'director:bvi1997'
     platform: mac
     lang: en
     title: 'Buena Vista International 1997 Promotional Interactive CD-ROM'
     version: '5'
     url: /frs/demos/director/d5/en/bvi1997-mac.zip
 -
-    id: bvi1997
+    id: 'director:bvi1997'
     platform: win
     lang: en
     title: 'Buena Vista International 1997 Promotional Interactive CD-ROM'
     version: '5'
     url: /frs/demos/director/d5/en/bvi1997-win.zip
 -
-    id: christmassmallhouse
+    id: 'director:christmassmallhouse'
     platform: mac
     lang: ja
     title: 'Christmastime at Small House (1998 Demo)'
     version: '5'
     url: /frs/demos/director/d5/ja/christmassmallhouse-demo-mac-ja-1.zip
 -
-    id: christmassmallhouse
+    id: 'director:christmassmallhouse'
     platform: win
     lang: ja
     title: 'Christmastime at Small House (1998 Demo)'
     version: '5'
     url: /frs/demos/director/d5/ja/christmassmallhouse-demo-win-ja-1.zip
 -
-    id: christmassmallhouse
+    id: 'director:christmassmallhouse'
     platform: mac
     lang: ja
     title: 'Christmastime at Small House (2000 Demo)'
     version: '5'
     url: /frs/demos/director/d5/ja/christmassmallhouse-demo-mac-ja-2.zip
 -
-    id: christmassmallhouse
+    id: 'director:christmassmallhouse'
     platform: win
     lang: ja
     title: 'Christmastime at Small House (2000 Demo)'
     version: '5'
     url: /frs/demos/director/d5/ja/christmassmallhouse-demo-win-ja-2.zip
 -
-    id: davidsonps
+    id: 'director:davidsonps'
     platform: win
     lang: en
     title: 'Davidson Product Sampler'
     version: '5'
     url: /frs/demos/director/d5/en/davidsonps-cd-win.zip
 -
-    id: davidsonps
+    id: 'director:davidsonps'
     platform: win
     lang: en
     title: 'Davidson Product Sampler'
     version: '5'
     url: /frs/demos/director/d5/en/davidsonps-win-10.zip
 -
-    id: dimensionq
+    id: 'director:dimensionq'
     platform: mac
     lang: en
     title: 'Iz and Auggie: Escape from Dimension Q'
     version: '5'
     url: /frs/demos/director/d5/en/dimensionq-demo-mac.zip
 -
-    id: dimensionq
+    id: 'director:dimensionq'
     platform: win
     lang: en
     title: 'Iz and Auggie: Escape from Dimension Q'
     version: '5'
     url: /frs/demos/director/d5/en/dimensionq-demo-win.zip
 -
-    id: edmark
+    id: 'director:edmark'
     platform: mac
     lang: en
     title: 'Edmark Demo'
     version: '5'
     url: /frs/demos/director/d5/en/edmark-mac.zip
 -
-    id: edmark
+    id: 'director:edmark'
     platform: win
     lang: en
     title: 'Edmark Demo'
     version: '5'
     url: /frs/demos/director/d5/en/edmark-win.zip
 -
-    id: ernie
+    id: 'director:ernie'
     platform: win
     lang: se
     title: Ernie
     version: '5'
     url: /frs/demos/director/d5/se/ernie-demo-win-se.zip
 -
-    id: giggletour
+    id: 'director:giggletour'
     platform: mac
     lang: en
     title: 'The Gigglebone Gang World Tour'
     version: '5'
     url: /frs/demos/director/d5/en/giggletour-demo-mac.zip
 -
-    id: giggletour
+    id: 'director:giggletour'
     platform: win
     lang: en
     title: 'The Gigglebone Gang World Tour'
     version: '5'
     url: /frs/demos/director/d5/en/giggletour-demo-win.zip
 -
-    id: guignols2
+    id: 'director:guignols2'
     platform: win
     lang: fr
     title: 'Les Guignols de l''Info: Le cauchemar de PPD'
     version: '5'
     url: /frs/demos/director/d5/fr/guignols2-demo-win-fr.zip
 -
-    id: headbone
+    id: 'director:headbone'
     platform: mac
     lang: en
     title: 'Headbone CD-ROM Sampler'
     version: '5'
     url: /frs/demos/director/d5/en/headbone-mac-2.zip
 -
-    id: headbone
+    id: 'director:headbone'
     platform: win
     lang: en
     title: 'Headbone CD-ROM Sampler'
     version: '5'
     url: /frs/demos/director/d5/en/headbone-win-2.zip
 -
-    id: hollywoodhigh
+    id: 'director:hollywoodhigh'
     platform: mac
     lang: en
     title: 'Hollywood High'
     version: '5'
     url: /frs/demos/director/d5/en/hollywoodhigh-demo-mac.zip
 -
-    id: hollywoodhigh
+    id: 'director:hollywoodhigh'
     platform: win
     lang: en
     title: 'Hollywood High'
     version: '5'
     url: /frs/demos/director/d5/en/hollywoodhigh-demo-win.zip
 -
-    id: jslearn
+    id: 'director:jslearn'
     platform: mac
     lang: en
     title: 'JumpStart Learning System'
     version: '5'
     url: /frs/demos/director/d5/en/jslearn-mac-d5.zip
 -
-    id: jslearn
+    id: 'director:jslearn'
     platform: win
     lang: en
     title: 'JumpStart Learning System'
     version: '5'
     url: /frs/demos/director/d5/en/jslearn-win-d5.zip
 -
-    id: kamennoyakata
+    id: 'director:kamennoyakata'
     platform: win
     lang: ja
     title: 仮面の館
     version: '5'
     url: /frs/demos/director/d5/ja/kamennoyakata-demo-win-ja.zip
 -
-    id: madcc12
+    id: 'director:madcc12'
     platform: mac
     lang: en
     title: 'Madeline Classroom Companion: 1st & 2nd Grade'
     version: '5'
     url: /frs/demos/director/d5/en/madcc12-demo-mac.zip
 -
-    id: madcc12
+    id: 'director:madcc12'
     platform: win
     lang: en
     title: 'Madeline Classroom Companion: 1st & 2nd Grade'
     version: '5'
     url: /frs/demos/director/d5/en/madcc12-demo-win-ss.zip
 -
-    id: madcc12
+    id: 'director:madcc12'
     platform: win
     lang: en
     title: 'Madeline Classroom Companion: 1st & 2nd Grade'
     version: '5'
     url: /frs/demos/director/d5/en/madcc12-demo-win.zip
 -
-    id: madccpk
+    id: 'director:madccpk'
     platform: mac
     lang: en
     title: 'Madeline Classroom Companion: Preschool & Kindergarten'
     version: '5'
     url: /frs/demos/director/d5/en/madccpk-demo-mac.zip
 -
-    id: madccpk
+    id: 'director:madccpk'
     platform: win
     lang: en
     title: 'Madeline Classroom Companion: Preschool & Kindergarten'
     version: '5'
     url: /frs/demos/director/d5/en/madccpk-demo-win.zip
 -
-    id: mavisbeacon
+    id: 'director:mavisbeacon'
     platform: mac
     lang: en
     title: 'Mavis Beacon Teaches Typing'
     version: '5'
     url: /frs/demos/director/d5/en/mavisbeacon-demo-mac.zip
 -
-    id: msn
+    id: 'director:msn'
     platform: win
     lang: en
     title: 'The Microsoft Network'
     version: '5'
     url: /frs/demos/director/d5/en/msn-win.zip
 -
-    id: osaka2
+    id: 'director:osaka2'
     platform: mac
     lang: ja
     title: '必修大阪弁集中講座II 2015年、東京人の逆襲'
     version: '5'
     url: /frs/demos/director/d5/ja/osaka2-demo-mac-ja.zip
 -
-    id: osaka2
+    id: 'director:osaka2'
     platform: win
     lang: ja
     title: '必修大阪弁集中講座II 2015年、東京人の逆襲'
     version: '5'
     url: /frs/demos/director/d5/ja/osaka2-demo-win-ja.zip
 -
-    id: picasso
+    id: 'director:picasso'
     platform: win
     lang: en
     title: 'Picasso: the man, his works, the legend'
     version: '5'
     url: /frs/demos/director/d5/en/picasso-demo-win.zip
 -
-    id: ravensburger
+    id: 'director:ravensburger'
     platform: mac
     lang: de
     title: 'Ravensburger Interactive Demo-Sampler'
     version: '5'
     url: /frs/demos/director/d5/de/ravensburger-mac-de.zip
 -
-    id: ravensburger
+    id: 'director:ravensburger'
     platform: mac
     lang: de
     title: 'Ravensburger Interactive Demo-Sampler'
     version: '5'
     url: /frs/demos/director/d5/de/ravensburger-win-de.zip
 -
-    id: rolypolys2
+    id: 'director:rolypolys2'
     platform: mac
     lang: ja
     title: ローリーポーリーズの世界旅行
     version: '5'
     url: /frs/demos/director/d5/ja/rolypolys2-demo-mac-ja.zip
 -
-    id: rolypolys2
+    id: 'director:rolypolys2'
     platform: win
     lang: ja
     title: ローリーポーリーズの世界旅行
     version: '5'
     url: /frs/demos/director/d5/ja/rolypolys2-demo-win-ja.zip
 -
-    id: secretsafari
+    id: 'director:secretsafari'
     platform: mac
     lang: ja
     title: 'Secret Safari'
     version: '5'
     url: /frs/demos/director/d5/ja/secretsafari-demo-mac-ja.zip
 -
-    id: secretsafari
+    id: 'director:secretsafari'
     platform: win
     lang: ja
     title: 'Secret Safari'
     version: '5'
     url: /frs/demos/director/d5/ja/secretsafari-demo-win-ja.zip
 -
-    id: shr1st2nd
+    id: 'director:shr1st2nd'
     platform: mac
     lang: en
     title: 'Schoolhouse Rock!: 1st & 2nd Grade Essentials'
     version: '5'
     url: /frs/demos/director/d5/en/shr1st2nd-demo-mac.zip
 -
-    id: shr1st2nd
+    id: 'director:shr1st2nd'
     platform: win
     lang: en
     title: 'Schoolhouse Rock!: 1st & 2nd Grade Essentials'
     version: '5'
     url: /frs/demos/director/d5/en/shr1st2nd-demo-win.zip
 -
-    id: shr3rd4th
+    id: 'director:shr3rd4th'
     platform: mac
     lang: en
     title: 'Schoolhouse Rock!: 3rd & 4th Grade Essentials'
     version: '5'
     url: /frs/demos/director/d5/en/shr3rd4th-demo-mac.zip
 -
-    id: shr3rd4th
+    id: 'director:shr3rd4th'
     platform: win
     lang: en
     title: 'Schoolhouse Rock!: 3rd & 4th Grade Essentials'
     version: '5'
     url: /frs/demos/director/d5/en/shr3rd4th-demo-win.zip
 -
-    id: shrmess
+    id: 'director:shrmess'
     platform: win
     lang: en
     title: 'Schoolhouse Rock!: 1st-4th Grade Math Essentials'
     version: '5'
     url: /frs/demos/director/d5/en/shrmess-demo-win.zip
 -
-    id: slamdunktyping
+    id: 'director:slamdunktyping'
     platform: mac
     lang: en
     title: 'Slam Dunk Typing'
     version: '5'
     url: /frs/demos/director/d5/en/slamdunktyping-demo-mac.zip
 -
-    id: slamdunktyping
+    id: 'director:slamdunktyping'
     platform: win
     lang: en
     title: 'Slam Dunk Typing'
     version: '5'
     url: /frs/demos/director/d5/en/slamdunktyping-demo-win.zip
 -
-    id: smallhouse
+    id: 'director:smallhouse'
     platform: mac
     lang: ja
     title: 'Small House'
     version: '5'
     url: /frs/demos/director/d5/ja/smallhouse-demo-mac-ja.zip
 -
-    id: smallhouse
+    id: 'director:smallhouse'
     platform: win
     lang: ja
     title: 'Small House'
     version: '5'
     url: /frs/demos/director/d5/ja/smallhouse-demo-win-ja.zip
 -
-    id: takeru
+    id: 'director:takeru'
     platform: win
     lang: en
     title: 'Buichi Terasawa''s Takeru: Letter of the Law'
     version: '5'
     url: /frs/demos/director/d5/en/takeru-demo-win.zip
 -
-    id: troubleshoot101
+    id: 'director:troubleshoot101'
     platform: mac
     lang: en
     title: 'Troubleshooting 101'
     version: '5'
     url: /frs/demos/director/d5/en/troubleshoot101-mac.zip
 -
-    id: ukiuki3
+    id: 'director:ukiuki3'
     platform: win
     lang: ja
     title: 'ウキウキ釣り天国3 ～人魚島のボート釣り～'
     version: '5'
     url: /frs/demos/director/d5/ja/ukiuki3-demo-cd-win-ja.zip
 -
-    id: ukiuki3
+    id: 'director:ukiuki3'
     platform: win
     lang: ja
     title: 'ウキウキ釣り天国3 ～人魚島のボート釣り～'
     version: '5'
     url: /frs/demos/director/d5/ja/ukiuki3-demo-win-ja.zip
 -
-    id: vp2
+    id: 'director:vp2'
     platform: mac
     lang: en
     title: 'Virtual Physics: The Eggs of Time'
     version: '5'
     url: /frs/demos/director/d5/en/vp2-demo-mac.zip
 -
-    id: vp2
+    id: 'director:vp2'
     platform: win
     lang: en
     title: 'Virtual Physics: The Eggs of Time'
     version: '5'
     url: /frs/demos/director/d5/en/vp2-demo-win.zip
 -
-    id: ybr3
+    id: 'director:ybr3'
     platform: mac
     lang: ja
     title: 'Yellow Brick Road ハラペコ月と星あつめ'
     version: '5'
     url: /frs/demos/director/d5/ja/ybr3-demo-mac-ja.zip
 -
-    id: ybr3
+    id: 'director:ybr3'
     platform: win
     lang: ja
     title: 'Yellow Brick Road ハラペコ月と星あつめ'
     version: '5'
     url: /frs/demos/director/d5/ja/ybr3-demo-win-ja.zip
 -
-    id: amgpremiere
+    id: 'director:amgpremiere'
     platform: mac
     lang: en
     title: 'The American Girls Premiere'
     version: '6'
     url: /frs/demos/director/d6/en/amgpremiere-mac-atut.zip
 -
-    id: amgpremiere
+    id: 'director:amgpremiere'
     platform: mac
     lang: en
     title: 'The American Girls Premiere'
     version: '6'
     url: /frs/demos/director/d6/en/amgpremiere-mac-btut.zip
 -
-    id: amgpremiere
+    id: 'director:amgpremiere'
     platform: mac
     lang: en
     title: 'The American Girls Premiere'
     version: '6'
     url: /frs/demos/director/d6/en/amgpremiere-mac-dir.zip
 -
-    id: amgpremiere
+    id: 'director:amgpremiere'
     platform: win
     lang: en
     title: 'The American Girls Premiere'
     version: '6'
     url: /frs/demos/director/d6/en/amgpremiere-win-atut.zip
 -
-    id: amgpremiere
+    id: 'director:amgpremiere'
     platform: win
     lang: en
     title: 'The American Girls Premiere'
     version: '6'
     url: /frs/demos/director/d6/en/amgpremiere-win-btut.zip
 -
-    id: amgpremiere
+    id: 'director:amgpremiere'
     platform: win
     lang: en
     title: 'The American Girls Premiere'
     version: '6'
     url: /frs/demos/director/d6/en/amgpremiere-win-dir.zip
 -
-    id: cfdemo
+    id: 'director:cfdemo'
     platform: win
     lang: en
     title: 'The ClueFinders Demo'
     version: '6'
     url: /frs/demos/director/d6/en/cfdemo-win.zip
 -
-    id: dfireworks
+    id: 'director:dfireworks'
     platform: win
     lang: en
     title: 'The Digital Fireworks Stand'
     version: '6'
     url: /frs/demos/director/d6/en/dfireworks-win-98.zip
 -
-    id: disneyint
+    id: 'director:disneyint'
     platform: mac
     lang: en
     title: 'Disney Interactive presents Learning & Creativity Sampler Volume I'
     version: '6'
     url: /frs/demos/director/d6/en/disneyint-mac.zip
 -
-    id: disneyint
+    id: 'director:disneyint'
     platform: win
     lang: en
     title: 'Disney Interactive presents Learning & Creativity Sampler Volume I'
     version: '6'
     url: /frs/demos/director/d6/en/disneyint-win.zip
 -
-    id: engl
+    id: 'director:engl'
     platform: win
     lang: ru
     title: 'English for Beginners'
     version: '6'
     url: /frs/demos/director/d6/ru/engl-demo-win-ru.zip
 -
-    id: fpcastle2
+    id: 'director:fpcastle2'
     platform: mac
     lang: en
     title: 'Great Adventures by Fisher-Price: Castle (1998)'
     version: '6'
     url: /frs/demos/director/d6/en/fpcastle2-demo-mac.zip
 -
-    id: fpcastle2
+    id: 'director:fpcastle2'
     platform: win
     lang: en
     title: 'Great Adventures by Fisher-Price: Castle (1998)'
     version: '6'
     url: /frs/demos/director/d6/en/fpcastle2-demo-win.zip
 -
-    id: fpcon
+    id: 'director:fpcon'
     platform: mac
     lang: en
     title: 'Fisher-Price Big Action Construction'
     version: '6'
     url: /frs/demos/director/d6/en/fpcon-demo-mac.zip
 -
-    id: fpcon
+    id: 'director:fpcon'
     platform: win
     lang: en
     title: 'Fisher-Price Big Action Construction'
     version: '6'
     url: /frs/demos/director/d6/en/fpcon-demo-win.zip
 -
-    id: fpdollhouse
+    id: 'director:fpdollhouse'
     platform: mac
     lang: en
     title: 'Fisher-Price Time to Play: Grand Dollhouse'
     version: '6'
     url: /frs/demos/director/d6/en/fpdollhouse-demo-mac.zip
 -
-    id: fpdollhouse
+    id: 'director:fpdollhouse'
     platform: win
     lang: en
     title: 'Fisher-Price Time to Play: Grand Dollhouse'
     version: '6'
     url: /frs/demos/director/d6/en/fpdollhouse-demo-win.zip
 -
-    id: fpready1
+    id: 'director:fpready1'
     platform: win
     lang: en
     title: 'Fisher-Price Ready for School: First Grade'
     version: '6'
     url: /frs/demos/director/d6/en/fpready1-demo-win.zip
 -
-    id: fpreadyk
+    id: 'director:fpreadyk'
     platform: mac
     lang: en
     title: 'Fisher-Price Ready for School: Kindergarten'
     version: '6'
     url: /frs/demos/director/d6/en/fpreadyk-demo-mac.zip
 -
-    id: fpreadyk
+    id: 'director:fpreadyk'
     platform: win
     lang: en
     title: 'Fisher-Price Ready for School: Kindergarten'
     version: '6'
     url: /frs/demos/director/d6/en/fpreadyk-demo-win.zip
 -
-    id: fpreadyt
+    id: 'director:fpreadyt'
     platform: mac
     lang: en
     title: 'Fisher-Price Ready for School: Toddler'
     version: '6'
     url: /frs/demos/director/d6/en/fpreadyt-demo-mac.zip
 -
-    id: fpreadyt
+    id: 'director:fpreadyt'
     platform: win
     lang: en
     title: 'Fisher-Price Ready for School: Toddler'
     version: '6'
     url: /frs/demos/director/d6/en/fpreadyt-demo-win.zip
 -
-    id: fpwestern
+    id: 'director:fpwestern'
     platform: mac
     lang: en
     title: 'Great Adventures by Fisher-Price: Wild Western Town'
     version: '6'
     url: /frs/demos/director/d6/en/fpwestern-demo-mac.zip
 -
-    id: fpwestern
+    id: 'director:fpwestern'
     platform: win
     lang: en
     title: 'Great Adventures by Fisher-Price: Wild Western Town'
     version: '6'
     url: /frs/demos/director/d6/en/fpwestern-demo-win.zip
 -
-    id: generations
+    id: 'director:generations'
     platform: win
     lang: en
     title: Generations
     version: '6'
     url: /frs/demos/director/d6/en/generations-demo-win.zip
 -
-    id: jslearn
+    id: 'director:jslearn'
     platform: mac
     lang: en
     title: 'JumpStart Learning System'
     version: '6'
     url: /frs/demos/director/d6/en/jslearn-mac-97.zip
 -
-    id: jslearn
+    id: 'director:jslearn'
     platform: mac
     lang: en
     title: 'JumpStart Learning System'
     version: '6'
     url: /frs/demos/director/d6/en/jslearn-mac-98.zip
 -
-    id: jslearn
+    id: 'director:jslearn'
     platform: mac
     lang: en
     title: 'JumpStart Learning System'
     version: '6'
     url: /frs/demos/director/d6/en/jslearn-mac-99.zip
 -
-    id: jslearn
+    id: 'director:jslearn'
     platform: win
     lang: en
     title: 'JumpStart Learning System'
     version: '6'
     url: /frs/demos/director/d6/en/jslearn-win-97.zip
 -
-    id: jslearn
+    id: 'director:jslearn'
     platform: win
     lang: en
     title: 'JumpStart Learning System'
     version: '6'
     url: /frs/demos/director/d6/en/jslearn-win-98.zip
 -
-    id: jslearn
+    id: 'director:jslearn'
     platform: win
     lang: en
     title: 'JumpStart Learning System'
     version: '6'
     url: /frs/demos/director/d6/en/jslearn-win-99.zip
 -
-    id: kontyngent99
+    id: 'director:kontyngent99'
     platform: win
     lang: pl
     title: 'Katalog Samochodów Kontyngent ''99'
     version: '6'
     url: /frs/demos/director/d6/pl/kontyngent99-win-pl.zip
 -
-    id: landdesigner
+    id: 'director:landdesigner'
     platform: win
     lang: en
     title: 'Sierra Land Designer'
     version: '6'
     url: /frs/demos/director/d6/en/landdesigner-demo-win.zip
 -
-    id: madtg
+    id: 'director:madtg'
     platform: win
     lang: en
     title: 'Madeline Thinking Games'
     version: '6'
     url: /frs/demos/director/d6/en/madtg-demo-win-1998.zip
 -
-    id: mulanpresskit
+    id: 'director:mulanpresskit'
     platform: mac
     lang: en
     title: 'Mulan Multimedia Press Kit'
     version: '6'
     url: /frs/demos/director/d6/en/mulanpresskit-mac.zip
 -
-    id: mulanpresskit
+    id: 'director:mulanpresskit'
     platform: win
     lang: en
     title: 'Mulan Multimedia Press Kit'
     version: '6'
     url: /frs/demos/director/d6/en/mulanpresskit-win.zip
 -
-    id: netmarket
+    id: 'director:netmarket'
     platform: mac
     lang: en
     title: 'CUC netMarket Demo'
     version: '6'
     url: /frs/demos/director/d6/en/netmarket-mac.zip
 -
-    id: netmarket
+    id: 'director:netmarket'
     platform: win
     lang: en
     title: 'CUC netMarket Demo'
     version: '6'
     url: /frs/demos/director/d6/en/netmarket-win.zip
 -
-    id: objetivo
+    id: 'director:objetivo'
     platform: win
     lang: pt-br
     title: 'Astrologia e Geografia Objetivo'
     version: '6'
     url: /frs/demos/director/d6/pt-br/objetivo-win-br.zip
 -
-    id: poohlearn
+    id: 'director:poohlearn'
     platform: mac
     lang: en
     title: 'Disney Learning Winnie the Pooh Demos'
     version: '6'
     url: /frs/demos/director/d6/en/poohlearn-mac.zip
 -
-    id: poohlearn
+    id: 'director:poohlearn'
     platform: win
     lang: en
     title: 'Disney Learning Winnie the Pooh Demos'
     version: '6'
     url: /frs/demos/director/d6/en/poohlearn-win.zip
 -
-    id: poohp
+    id: 'director:poohp'
     platform: mac
     lang: en
     title: 'Winnie the Pooh Preschool'
     version: '6'
     url: /frs/demos/director/d6/en/poohp-demo-mac-d6.zip
 -
-    id: poohp
+    id: 'director:poohp'
     platform: win
     lang: en
     title: 'Winnie the Pooh Preschool'
     version: '6'
     url: /frs/demos/director/d6/en/poohp-demo-win-d6.zip
 -
-    id: ssgbi
+    id: 'director:ssgbi'
     platform: mac
     lang: en
     title: 'German Bold Italic Screen Saver'
     version: '6'
     url: /frs/demos/director/d6/en/ssgbi-mac.zip
 -
-    id: ssleepipes
+    id: 'director:ssleepipes'
     platform: mac
     lang: en
     title: 'The Lee Pipes Desktop Animated Feature'
     version: '6'
     url: /frs/demos/director/d6/en/ssleepipes-mac.zip
 -
-    id: ssleepipes
+    id: 'director:ssleepipes'
     platform: win
     lang: en
     title: 'The Lee Pipes Desktop Animated Feature'
     version: '6'
     url: /frs/demos/director/d6/en/ssleepipes-win.zip
 -
-    id: tchaik
+    id: 'director:tchaik'
     platform: win
     lang: ru
     title: 'Пётр Ильи́ч Чайко́вский: Жизнь и творчество'
     version: '6'
     url: /frs/demos/director/d6/ru/tchaik-demo-win-ru.zip
 -
-    id: thesims
+    id: 'director:thesims'
     platform: win
     lang: en
     title: 'The Sims Electronic Press Kit'
     version: '6'
     url: /frs/demos/director/d6/en/thesims-win.zip
 -
-    id: tutti
+    id: 'director:tutti'
     platform: win
     lang: ru
     title: 'Волшебные истории Тутти'
     version: '6'
     url: /frs/demos/director/d6/ru/tutti-win-ru.zip
 -
-    id: artus1
+    id: 'director:artus1'
     platform: win
     lang: en
     title: 'Artus against the Demon of the Museum'
     version: '7'
     url: /frs/demos/director/d7/en/artus1-demo-win.zip
 -
-    id: basilbaker
+    id: 'director:basilbaker'
     platform: win
     lang: en
     title: 'Venice Under Glass: A Basil Baker Mystery Adventure'
     version: '7'
     url: /frs/demos/director/d7/en/basilbaker-demo-win.zip
 -
-    id: billetrille1
+    id: 'director:billetrille1'
     platform: win
     lang: fi
     title: 'Bille & Trille: Da fantasien slap løs'
     version: '7'
     url: /frs/demos/director/d7/fi/billetrille1-demo-win-fi.zip
 -
-    id: disneylearning
+    id: 'director:disneylearning'
     platform: mac
     lang: en
     title: 'Disney Interactive Learning Sampler'
     version: '7'
     url: /frs/demos/director/d7/en/disneylearning-mac.zip
 -
-    id: disneylearning
+    id: 'director:disneylearning'
     platform: win
     lang: en
     title: 'Disney Interactive Learning Sampler'
     version: '7'
     url: /frs/demos/director/d7/en/disneylearning-win.zip
 -
-    id: dotsafe
+    id: 'director:dotsafe'
     platform: win
     lang: en
     title: Dotsafe
     version: '7'
     url: /frs/demos/director/d7/en/dotsafe-demo-win.zip
 -
-    id: easports2000
+    id: 'director:easports2000'
     platform: win
     lang: en
     title: 'EA Sports_2000 (E3 1999)'
     version: '7'
     url: /frs/demos/director/d7/en/easports2000-win.zip
 -
-    id: isscommerce
+    id: 'director:isscommerce'
     platform: mac
     lang: en
     title: 'International Space Station: Space Commercialization'
     version: '7'
     url: /frs/demos/director/d7/en/isscommerce-mac.zip
 -
-    id: isscommerce
+    id: 'director:isscommerce'
     platform: win
     lang: en
     title: 'International Space Station: Space Commercialization'
     version: '7'
     url: /frs/demos/director/d7/en/isscommerce-win.zip
 -
-    id: jewels
+    id: 'director:jewels'
     platform: win
     lang: en
     title: 'Jewels of the Oracle'
     version: '7'
     url: /frs/demos/director/d7/en/jewels-demo-win.zip
 -
-    id: jsa
+    id: 'director:jsa'
     platform: win
     lang: en
     title: 'JumpStart Advanced: How Does Your Child Learn Best?'
     version: '7'
     url: /frs/demos/director/d7/en/jsa-win.zip
 -
-    id: lbkinder
+    id: 'director:lbkinder'
     platform: win
     lang: en
     title: 'Maurice Sendak''s Little Bear Kindergarten Thinking Adventures'
     version: '7'
     url: /frs/demos/director/d7/en/lbkinder-demo-win.zip
 -
-    id: lbpre
+    id: 'director:lbpre'
     platform: win
     lang: en
     title: 'Maurice Sendak''s Little Bear Preschool Thinking Adventures'
     version: '7'
     url: /frs/demos/director/d7/en/lbpre-demo-win.zip
 -
-    id: leepipes
+    id: 'director:leepipes'
     platform: mac
     lang: en
     title: 'Lee Pipes Press Kit'
     version: '7'
     url: /frs/demos/director/d7/en/leepipes-mac.zip
 -
-    id: leepipes
+    id: 'director:leepipes'
     platform: win
     lang: en
     title: 'Lee Pipes Press Kit'
     version: '7'
     url: /frs/demos/director/d7/en/leepipes-win.zip
 -
-    id: mickeyp
+    id: 'director:mickeyp'
     platform: win
     lang: en
     title: 'Mickey Mouse Preschool'
     version: '7'
     url: /frs/demos/director/d7/en/mickeyp-demo-win-d7.zip
 -
-    id: mickeyt
+    id: 'director:mickeyt'
     platform: mac
     lang: en
     title: 'Mickey Mouse Toddler'
     version: '7'
     url: /frs/demos/director/d7/en/mickeyt-demo-mac-d7.zip
 -
-    id: mickeyt
+    id: 'director:mickeyt'
     platform: win
     lang: en
     title: 'Mickey Mouse Toddler'
     version: '7'
     url: /frs/demos/director/d7/en/mickeyt-demo-win-d7.zip
 -
-    id: planetstrass
+    id: 'director:planetstrass'
     platform: win
     lang: en
     title: Pl@net
     version: '7'
     url: /frs/demos/director/d7/en/planetstrass-demo-win.zip
 -
-    id: verttice
+    id: 'director:verttice'
     platform: mac
     lang: en
     title: 'DreamLight Verttice'
     version: '7'
     url: /frs/demos/director/d7/en/verttice-mac-30.zip
 -
-    id: verttice
+    id: 'director:verttice'
     platform: win
     lang: en
     title: 'DreamLight Verttice'
     version: '7'
     url: /frs/demos/director/d7/en/verttice-win-30.zip
 -
-    id: balto2
+    id: 'director:balto2'
     platform: win
     lang: en
     title: 'Balto II: Wolf Quest (Trailer)'
     version: '8'
     url: /frs/demos/director/d8/en/balto2-trailer.zip
 -
-    id: barbrapunzel
+    id: 'director:barbrapunzel'
     platform: win
     lang: en
     title: 'Barbie as Rapunzel: A Creative Adventure'
     version: '8'
     url: /frs/demos/director/d8/en/barbrapunzel-demo-win.zip
 -
-    id: billetrille2
+    id: 'director:billetrille2'
     platform: mac
     lang: fi
     title: 'Bille & Trille: Helt ude i skoven'
     version: '8'
     url: /frs/demos/director/d8/fi/billetrille2-demo-mac-fi.zip
 -
-    id: lbt8
+    id: 'director:lbt8'
     platform: win
     lang: en
     title: 'The Land Before Time: The Big Freeze'
     version: '8'
     url: /frs/demos/director/d8/en/lbt8-demo-win.zip
 -
-    id: mickeyk
+    id: 'director:mickeyk'
     platform: mac
     lang: en
     title: 'Mickey Mouse Kindergarten'
     version: '8'
     url: /frs/demos/director/d8/en/mickeyk-demo-mac-d8.zip
 -
-    id: mickeyk
+    id: 'director:mickeyk'
     platform: mac
     lang: en
     title: 'Mickey Mouse Kindergarten'
     version: '8'
     url: /frs/demos/director/d8/en/mickeyk-demo-mac-ss.zip
 -
-    id: mickeyk
+    id: 'director:mickeyk'
     platform: win
     lang: en
     title: 'Mickey Mouse Kindergarten'
     version: '8'
     url: /frs/demos/director/d8/en/mickeyk-demo-win-d8.zip
 -
-    id: mickeyk
+    id: 'director:mickeyk'
     platform: win
     lang: en
     title: 'Mickey Mouse Kindergarten'
     version: '8'
     url: /frs/demos/director/d8/en/mickeyk-demo-win-ss.zip
 -
-    id: mickeyp
+    id: 'director:mickeyp'
     platform: mac
     lang: en
     title: 'Mickey Mouse Preschool'
     version: '8'
     url: /frs/demos/director/d8/en/mickeyp-demo-mac-d8.zip
 -
-    id: mickeyp
+    id: 'director:mickeyp'
     platform: mac
     lang: en
     title: 'Mickey Mouse Preschool'
     version: '8'
     url: /frs/demos/director/d8/en/mickeyp-demo-mac-ss.zip
 -
-    id: mickeyp
+    id: 'director:mickeyp'
     platform: win
     lang: en
     title: 'Mickey Mouse Preschool'
     version: '8'
     url: /frs/demos/director/d8/en/mickeyp-demo-win-d8.zip
 -
-    id: mickeyt
+    id: 'director:mickeyt'
     platform: mac
     lang: en
     title: 'Mickey Mouse Toddler'
     version: '8'
     url: /frs/demos/director/d8/en/mickeyt-demo-mac-d8.zip
 -
-    id: mickeyt
+    id: 'director:mickeyt'
     platform: win
     lang: en
     title: 'Mickey Mouse Toddler'
     version: '8'
     url: /frs/demos/director/d8/en/mickeyt-demo-win-d8.zip
 -
-    id: phonicsquest
+    id: 'director:phonicsquest'
     platform: win
     lang: en
     title: 'Disney Phonics Quest'
     version: '8'
     url: /frs/demos/director/d8/en/phonicsquest-demo-win.zip
 -
-    id: poohk
+    id: 'director:poohk'
     platform: mac
     lang: en
     title: 'Winnie the Pooh Kindergarten'
     version: '8'
     url: /frs/demos/director/d8/en/poohk-demo-mac-d8.zip
 -
-    id: poohk
+    id: 'director:poohk'
     platform: mac
     lang: en
     title: 'Winnie the Pooh Kindergarten (Slideshow)'
     version: '8'
     url: /frs/demos/director/d8/en/poohk-demo-mac-ss.zip
 -
-    id: poohk
+    id: 'director:poohk'
     platform: win
     lang: en
     title: 'Winnie the Pooh Kindergarten (Slideshow 2)'
     version: '8'
     url: /frs/demos/director/d8/en/poohk-demo-win-ss-alt.zip
 -
-    id: poohk
+    id: 'director:poohk'
     platform: win
     lang: en
     title: 'Winnie the Pooh Kindergarten (Slideshow 1)'
     version: '8'
     url: /frs/demos/director/d8/en/poohk-demo-win-ss.zip
 -
-    id: poohk
+    id: 'director:poohk'
     platform: win
     lang: en
     title: 'Winnie the Pooh Kindergarten'
     version: '8'
     url: /frs/demos/director/d8/en/poohk-demo-win.zip
 -
-    id: poohp
+    id: 'director:poohp'
     platform: mac
     lang: en
     title: 'Winnie the Pooh Preschool'
     version: '8'
     url: /frs/demos/director/d8/en/poohp-demo-mac-d8.zip
 -
-    id: poohp
+    id: 'director:poohp'
     platform: win
     lang: en
     title: 'Winnie the Pooh Preschool (Slideshow)'
     version: '8'
     url: /frs/demos/director/d8/en/poohp-demo-win-ss-alt.zip
 -
-    id: poohp
+    id: 'director:poohp'
     platform: win
     lang: en
     title: 'Winnie the Pooh Preschool'
     version: '8'
     url: /frs/demos/director/d8/en/poohp-demo-win.zip
 -
-    id: pooht
+    id: 'director:pooht'
     platform: mac
     lang: en
     title: 'Winnie the Pooh Toddler'
     version: '8'
     url: /frs/demos/director/d8/en/pooht-demo-mac-d8.zip
 -
-    id: pooht
+    id: 'director:pooht'
     platform: win
     lang: en
     title: 'Winnie the Pooh Toddler'
     version: '8'
     url: /frs/demos/director/d8/en/pooht-demo-win-d8.zip
 -
-    id: pooht
+    id: 'director:pooht'
     platform: win
     lang: en
     title: 'Winnie the Pooh Toddler (Slideshow)'
     version: '8'
     url: /frs/demos/director/d8/en/pooht-demo-win-ss.zip
 -
-    id: rh
+    id: 'director:rh'
     platform: mac
     lang: en
     title: 'Rescue Heroes Demo'
     version: '8'
     url: /frs/demos/director/d8/en/rh-mac.zip
 -
-    id: rh
+    id: 'director:rh'
     platform: win
     lang: en
     title: 'Rescue Heroes Demo'
     version: '8'
     url: /frs/demos/director/d8/en/rh-win.zip
 -
-    id: rhem1
+    id: 'director:rhem1'
     platform: win
     lang: en
     title: Rhem
     version: '8'
     url: /frs/demos/director/d8/en/rhem1-demo-win.zip
 -
-    id: secretkeys
+    id: 'director:secretkeys'
     platform: mac
     lang: en
     title: 'Search for the Secret Keys with Mickey'
     version: '8'
     url: /frs/demos/director/d8/en/secretkeys-demo-mac.zip
 -
-    id: secretkeys
+    id: 'director:secretkeys'
     platform: win
     lang: en
     title: 'Search for the Secret Keys with Mickey'
     version: '8'
     url: /frs/demos/director/d8/en/secretkeys-demo-win.zip
 -
-    id: ss102dalmations
+    id: 'director:ss102dalmations'
     platform: win
     lang: en
     title: '102 Dalmations Screen Saver'
     version: '8'
     url: /frs/demos/director/d8/en/ss102dalmations-win.zip
 -
-    id: ssholidaymickey
+    id: 'director:ssholidaymickey'
     platform: win
     lang: en
     title: 'Holiday Mickey Screen Saver'
     version: '8'
     url: /frs/demos/director/d8/en/ssholidaymickey-win.zip
 -
-    id: sspeekaboo
+    id: 'director:sspeekaboo'
     platform: win
     lang: en
     title: 'Winnie the Pooh Peek-a-Boo Screen Saver'
     version: '8'
     url: /frs/demos/director/d8/en/sspeekaboo-win.zip
 -
-    id: unlimitedcl
+    id: 'director:unlimitedcl'
     platform: win
     lang: es
     title: 'Unlimited CD-ROMs Educativos'
     version: '8'
     url: /frs/demos/director/d8/es/unlimitedcl-win-es.zip
 -
-    id: unwrap
+    id: 'director:unwrap'
     platform: mac
     lang: en
     title: 'Unwrap the Magic: Holiday 2000 Interactive CD-ROM'
     version: '8'
     url: /frs/demos/director/d8/en/unwrap-mac.zip
 -
-    id: unwrap
+    id: 'director:unwrap'
     platform: win
     lang: en
     title: 'Unwrap the Magic: Holiday 2000 Interactive CD-ROM'
     version: '8'
     url: /frs/demos/director/d8/en/unwrap-win.zip
 -
-    id: vug2005
+    id: 'director:vug2005'
     platform: mac
     lang: en
     title: 'Vivendi Universal Games 2005 E3 DPK'
     version: '8'
     url: /frs/demos/director/d8/en/vug2005-mac.zip
 -
-    id: vug2005
+    id: 'director:vug2005'
     platform: win
     lang: en
     title: 'Vivendi Universal Games 2005 E3 DPK'
     version: '8'
     url: /frs/demos/director/d8/en/vug2005-win.zip
 -
-    id: westwood
+    id: 'director:westwood'
     platform: mac
     lang: en
     title: 'Westwood Studios Digital Press Kit 2000'
     version: '8'
     url: /frs/demos/director/d8/en/westwood-mac.zip
 -
-    id: westwood
+    id: 'director:westwood'
     platform: win
     lang: en
     title: 'Westwood Studios Digital Press Kit 2000'
     version: '8'
     url: /frs/demos/director/d8/en/westwood-win.zip
 -
-    id: barbpauper
+    id: 'director:barbpauper'
     platform: win
     lang: en
     title: 'Barbie as the Princess and the Pauper'
     version: '9'
     url: /frs/demos/director/d9/en/barbpauper-demo-win.zip
 -
-    id: barbswanlake
+    id: 'director:barbswanlake'
     platform: win
     lang: en
     title: 'Barbie of Swan Lake: The Enchanted Forest'
     version: '9'
     url: /frs/demos/director/d9/en/barbswanlake-demo-win.zip
 -
-    id: bobteam
+    id: 'director:bobteam'
     platform: win
     lang: en
     title: 'Bob the Builder: Teamwork'
     version: '9'
     url: /frs/demos/director/d9/en/bobteam-demo-win.zip
 -
-    id: gp2006
+    id: 'director:gp2006'
     platform: mac
     lang: en
     title: 'Grand Prix 2006 & Auto Directory'
     version: '9'
     url: /frs/demos/director/d9/en/gp2006-mac.zip
 -
-    id: gp2006
+    id: 'director:gp2006'
     platform: win
     lang: en
     title: 'Grand Prix 2006 & Auto Directory'
     version: '9'
     url: /frs/demos/director/d9/en/gp2006-win.zip
 -
-    id: stalker
+    id: 'director:stalker'
     platform: win
     lang: en
     title: 'S.T.A.L.K.E.R.: Shadow of Chernobyl'
     version: '9'
     url: /frs/demos/director/d9/en/stalker-win.zip
 -
-    id: tokimemotypegs
+    id: 'director:tokimemotypegs'
     platform: win
     lang: ja
     title: ときメモGSタイピング

--- a/data/en/game_demos.yaml
+++ b/data/en/game_demos.yaml
@@ -1,6 +1,6 @@
 # This is a generated file, please do not edit manually
 -
-    id: amazon
+    id: 'access:amazon'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -9,7 +9,7 @@
     language3: ''
     url: /frs/demos/access/amazon-dos-ni-demo-en.zip
 -
-    id: martian
+    id: 'access:martian'
     platform: dos
     '': ''
     category: ''
@@ -18,7 +18,7 @@
     language3: ''
     url: /frs/demos/access/martian-demo.zip
 -
-    id: agidemo
+    id: 'agi:agidemo'
     platform: apple2gs
     '': ''
     category: 'King''s Quest 3, Leisure Suit Larry, Police Quest, Thexder, Space Quest'
@@ -27,7 +27,7 @@
     language3: ''
     url: /frs/demos/agi/agi-2gs-demo-pack-en.zip
 -
-    id: agidemo
+    id: 'agi:agidemo'
     platform: dos
     '': ''
     category: 'King''s Quest 3, Space Quest'
@@ -36,7 +36,7 @@
     language3: ''
     url: /frs/demos/agi/agi-dos-kq3-sp1-demo-en.zip
 -
-    id: agidemo
+    id: 'agi:agidemo'
     platform: dos
     '': ''
     category: '3-D Helicopter Sim, Police Quest, Thexder, Space Quest 2, Mixed-up Mother Goose, Leisure Suit Larry'
@@ -45,7 +45,7 @@
     language3: ''
     url: /frs/demos/agi/agi-dos-pack1-demo-en.zip
 -
-    id: agidemo
+    id: 'agi:agidemo'
     platform: dos
     '': ''
     category: '3-D Helicopter Sim, Space Quest 2, Thexder, King''s Quest 3, Mixed- up Mother Goose, King''s Quest 2, Police Quest, Leisure Suit Larry, Space Quest'
@@ -54,7 +54,7 @@
     language3: ''
     url: /frs/demos/agi/agi-dos-pack2-demo-en.zip
 -
-    id: agidemo
+    id: 'agi:agidemo'
     platform: dos
     '': ''
     category: '3-D Helicopter Sim, Space Quest 2, Police Quest, King''s Quest 3, Mixed-up Mother Goose, Leisure Suit Larry'
@@ -63,7 +63,7 @@
     language3: ''
     url: /frs/demos/agi/agi-dos-pack3-demo-en.zip
 -
-    id: agidemo
+    id: 'agi:agidemo'
     platform: dos
     '': ''
     category: 'Gold Rush!, Manhunter: NewYork, Mixed-up Mother Goose, Police Quest, Space Quest 2, Leisure Suit Larry'
@@ -72,7 +72,7 @@
     language3: ''
     url: /frs/demos/agi/agi-dos-pack4-demo-en.zip
 -
-    id: agidemo
+    id: 'agi:agidemo'
     platform: dos
     '': ''
     category: 'Space Quest, Donald Duck''s Playground, King''s Quest 3, Leisure Suit Larry'
@@ -81,7 +81,7 @@
     language3: ''
     url: /frs/demos/agi/agi-dos-pack5-demo-en.zip
 -
-    id: agidemo
+    id: 'agi:agidemo'
     platform: dos
     '': ''
     category: Tandy
@@ -90,7 +90,7 @@
     language3: ''
     url: /frs/demos/agi/agidemo-tandy-demo.zip
 -
-    id: kq4
+    id: 'agi:kq4'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -99,7 +99,7 @@
     language3: ''
     url: /frs/demos/agi/kq4-dos-ni-demo-en.zip
 -
-    id: lsl1
+    id: 'agi:lsl1'
     platform: dos
     '': ''
     category: Polish
@@ -108,7 +108,7 @@
     language3: ''
     url: /frs/demos/agi/lsl1-demo-pl.zip
 -
-    id: qfg1
+    id: 'agi:qfg1'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -117,7 +117,7 @@
     language3: ''
     url: /frs/demos/sci/qfg1-dos-ni-demo-en.zip
 -
-    id: xmascard
+    id: 'agi:xmascard'
     platform: coco3
     '': ''
     category: ''
@@ -126,7 +126,7 @@
     language3: ''
     url: /frs/demos/agi/xmascard-coco3-en.zip
 -
-    id: xmascard
+    id: 'agi:xmascard'
     platform: dos
     '': ''
     category: ''
@@ -135,7 +135,7 @@
     language3: ''
     url: /frs/demos/agi/xmascard-dos-en.zip
 -
-    id: elvira1
+    id: 'agos:elvira1'
     platform: amiga
     '': ''
     category: Non-Interactive
@@ -144,7 +144,7 @@
     language3: ''
     url: /frs/demos/agos/elvira1-amiga-ni-demo-en.zip
 -
-    id: elvira1
+    id: 'agos:elvira1'
     platform: atarist
     '': ''
     category: Non-Interactive
@@ -153,7 +153,7 @@
     language3: ''
     url: /frs/demos/agos/elvira1-atari-ni-demo-en.zip
 -
-    id: elvira1
+    id: 'agos:elvira1'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -162,7 +162,7 @@
     language3: ''
     url: /frs/demos/agos/elvira1-dos-ni-demo-en.zip
 -
-    id: feeble
+    id: 'agos:feeble'
     platform: dos
     '': ''
     category: 'German Non-Interactive'
@@ -171,7 +171,7 @@
     language3: ''
     url: /frs/demos/agos/feeble-dos-ni-demo-de.zip
 -
-    id: feeble
+    id: 'agos:feeble'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -180,7 +180,7 @@
     language3: ''
     url: /frs/demos/agos/feeble-dos-ni-demo-en.zip
 -
-    id: pn
+    id: 'agos:pn'
     platform: atarist
     '': ''
     category: Non-Interactive
@@ -189,7 +189,7 @@
     language3: ''
     url: /frs/demos/agos/pn-atari-ni-demo-en.zip
 -
-    id: simon1
+    id: 'agos:simon1'
     platform: acorn
     '': ''
     category: CD
@@ -198,7 +198,7 @@
     language3: ''
     url: /frs/demos/agos/simon1-acorn-cd-demo-en.zip
 -
-    id: simon1
+    id: 'agos:simon1'
     platform: acorn
     '': ''
     category: ''
@@ -207,7 +207,7 @@
     language3: ''
     url: /frs/demos/agos/simon1-acorn-demo-en.zip
 -
-    id: simon1
+    id: 'agos:simon1'
     platform: acorn
     '': ''
     category: Non-Interactive
@@ -216,7 +216,7 @@
     language3: ''
     url: /frs/demos/agos/simon1-acorn-ni-demo-en.zip
 -
-    id: simon1
+    id: 'agos:simon1'
     platform: amigacd32
     '': ''
     category: ''
@@ -225,7 +225,7 @@
     language3: ''
     url: /frs/demos/agos/simon1-amiga-cd32-demo-en.zip
 -
-    id: simon1
+    id: 'agos:simon1'
     platform: amiga
     '': ''
     category: ''
@@ -234,7 +234,7 @@
     language3: ''
     url: /frs/demos/agos/simon1-amiga-floppy-demo-en.zip
 -
-    id: simon1
+    id: 'agos:simon1'
     platform: dos
     '': ''
     category: CD
@@ -243,7 +243,7 @@
     language3: ''
     url: /frs/demos/agos/simon1-dos-cd-demo-en.zip
 -
-    id: simon1
+    id: 'agos:simon1'
     platform: dos
     '': ''
     category: Alternative
@@ -252,7 +252,7 @@
     language3: ''
     url: /frs/demos/agos/simon1-dos-cd-demo2-en.zip
 -
-    id: simon1
+    id: 'agos:simon1'
     platform: dos
     '': ''
     category: ''
@@ -261,7 +261,7 @@
     language3: ''
     url: /frs/demos/agos/simon1-dos-floppy-demo-en.zip
 -
-    id: simon2
+    id: 'agos:simon2'
     platform: dos
     '': ''
     category: 'German CD'
@@ -270,7 +270,7 @@
     language3: ''
     url: /frs/demos/agos/simon2-dos-cd-demo-de.zip
 -
-    id: simon2
+    id: 'agos:simon2'
     platform: dos
     '': ''
     category: CD
@@ -279,7 +279,7 @@
     language3: ''
     url: /frs/demos/agos/simon2-dos-cd-demo-en.zip
 -
-    id: simon2
+    id: 'agos:simon2'
     platform: dos
     '': ''
     category: 'German CD Non-Interactive'
@@ -288,7 +288,7 @@
     language3: ''
     url: /frs/demos/agos/simon2-dos-cd-ni-demo-de.zip
 -
-    id: waxworks
+    id: 'agos:waxworks'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -297,7 +297,7 @@
     language3: ''
     url: /frs/demos/agos/waxworks-dos-ni-demo-en.zip
 -
-    id: alemmo
+    id: 'ags:alemmo'
     platform: win
     '': ''
     category: ''
@@ -306,7 +306,7 @@
     language3: ''
     url: /frs/demos/ags/al_emmo-demo.zip
 -
-    id: beyondowlsgard
+    id: 'ags:beyondowlsgard'
     platform: win
     '': ''
     category: ''
@@ -315,7 +315,7 @@
     language3: ''
     url: /frs/demos/ags/owlsgard-de-demo.zip
 -
-    id: beyondowlsgard
+    id: 'ags:beyondowlsgard'
     platform: win
     '': ''
     category: ''
@@ -324,7 +324,7 @@
     language3: ''
     url: /frs/demos/ags/owlsgard-en-demo.zip
 -
-    id: blackwell1
+    id: 'ags:blackwell1'
     platform: win
     '': ''
     category: ''
@@ -333,7 +333,7 @@
     language3: ''
     url: /frs/demos/ags/blackwell_legacy-demo.zip
 -
-    id: blackwell2
+    id: 'ags:blackwell2'
     platform: win
     '': ''
     category: ''
@@ -342,7 +342,7 @@
     language3: ''
     url: /frs/demos/ags/blackwell_unbound-demo.zip
 -
-    id: blackwell3
+    id: 'ags:blackwell3'
     platform: win
     '': ''
     category: ''
@@ -351,7 +351,7 @@
     language3: ''
     url: /frs/demos/ags/blackwell_convergence-demo.zip
 -
-    id: blackwell4
+    id: 'ags:blackwell4'
     platform: win
     '': ''
     category: ''
@@ -360,7 +360,7 @@
     language3: ''
     url: /frs/demos/ags/blackwell_deception-demo.zip
 -
-    id: blackwell5
+    id: 'ags:blackwell5'
     platform: win
     '': ''
     category: ''
@@ -369,7 +369,7 @@
     language3: ''
     url: /frs/demos/ags/blackwell_epiphany-demo.zip
 -
-    id: danewguys2
+    id: 'ags:danewguys2'
     platform: win
     '': ''
     category: ''
@@ -378,7 +378,7 @@
     language3: ''
     url: /frs/demos/ags/da_new_guys2-demo.zip
 -
-    id: geminirue
+    id: 'ags:geminirue'
     platform: win
     '': ''
     category: ''
@@ -387,7 +387,7 @@
     language3: ''
     url: /frs/demos/ags/gemini_rue-demo.zip
 -
-    id: goldenwake
+    id: 'ags:goldenwake'
     platform: win
     '': ''
     category: ''
@@ -396,7 +396,7 @@
     language3: ''
     url: /frs/demos/ags/golden_wake-demo.zip
 -
-    id: mage
+    id: 'ags:mage'
     platform: win
     '': ''
     category: ''
@@ -405,7 +405,7 @@
     language3: ''
     url: /frs/demos/ags/mage_initiation-demo.zip
 -
-    id: mybigsister
+    id: 'ags:mybigsister'
     platform: win
     '': ''
     category: ''
@@ -414,7 +414,7 @@
     language3: ''
     url: /frs/demos/ags/my_big_sister-demo.zip
 -
-    id: phantomfellows
+    id: 'ags:phantomfellows'
     platform: win
     '': ''
     category: ''
@@ -423,7 +423,7 @@
     language3: ''
     url: /frs/demos/ags/the_phantom_fellows-demo.zip
 -
-    id: primordia
+    id: 'ags:primordia'
     platform: win
     '': ''
     category: ''
@@ -432,7 +432,7 @@
     language3: ''
     url: /frs/demos/ags/primordia-demo.zip
 -
-    id: qfi
+    id: 'ags:qfi'
     platform: win
     '': ''
     category: ''
@@ -441,7 +441,7 @@
     language3: ''
     url: /frs/demos/ags/quest_for_infamy-demo.zip
 -
-    id: resonance
+    id: 'ags:resonance'
     platform: win
     '': ''
     category: ''
@@ -450,7 +450,7 @@
     language3: ''
     url: /frs/demos/ags/resonance-demo.zip
 -
-    id: samaritan
+    id: 'ags:samaritan'
     platform: win
     '': ''
     category: ''
@@ -459,7 +459,7 @@
     language3: ''
     url: /frs/demos/ags/samaritan-paradox-demo.zip
 -
-    id: shardlight
+    id: 'ags:shardlight'
     platform: win
     '': ''
     category: ''
@@ -468,7 +468,7 @@
     language3: ''
     url: /frs/demos/ags/shardlight-demo.zip
 -
-    id: shivah
+    id: 'ags:shivah'
     platform: win
     '': ''
     category: ''
@@ -477,7 +477,7 @@
     language3: ''
     url: /frs/demos/ags/shivah-demo.zip
 -
-    id: technobabylon
+    id: 'ags:technobabylon'
     platform: win
     '': ''
     category: ''
@@ -486,7 +486,7 @@
     language3: ''
     url: /frs/demos/ags/technobabylon-demo.zip
 -
-    id: zniwadventure
+    id: 'ags:zniwadventure'
     platform: win
     '': ''
     category: ''
@@ -495,7 +495,7 @@
     language3: ''
     url: /frs/demos/ags/zniw_adventure-demo.zip
 -
-    id: sanitarium
+    id: 'asylum:sanitarium'
     platform: win
     '': ''
     category: ''
@@ -504,7 +504,7 @@
     language3: ''
     url: /frs/demos/asylum/asylum-demo.zip
 -
-    id: sanitarium
+    id: 'asylum:sanitarium'
     platform: win
     '': ''
     category: Alternative
@@ -513,7 +513,7 @@
     language3: ''
     url: /frs/demos/asylum/asylum-demo2.zip
 -
-    id: bbvs
+    id: 'bbvs:bbvs'
     platform: win
     '': ''
     category: 'Loogie Alternative'
@@ -522,7 +522,7 @@
     language3: ''
     url: /frs/demos/bbvs/bbvs-demo-loogie-2.zip
 -
-    id: bbvs
+    id: 'bbvs:bbvs'
     platform: win
     '': ''
     category: Loogie
@@ -531,7 +531,7 @@
     language3: ''
     url: /frs/demos/bbvs/bbvs-demo-loogie.zip
 -
-    id: bbvs
+    id: 'bbvs:bbvs'
     platform: win
     '': ''
     category: ''
@@ -540,7 +540,7 @@
     language3: ''
     url: /frs/demos/bbvs/bbvs-demo.zip
 -
-    id: bladerunner
+    id: 'bladerunner:bladerunner'
     platform: win
     '': ''
     category: Non-Interactive
@@ -549,7 +549,7 @@
     language3: ''
     url: /frs/demos/bladerunner/bladerunner-win-ni-demo-en.zip
 -
-    id: buried
+    id: 'buried:buried'
     platform: win
     '': ''
     category: ''
@@ -558,7 +558,7 @@
     language3: ''
     url: /frs/demos/buried/buried-demo-win-ca.zip
 -
-    id: buried
+    id: 'buried:buried'
     platform: win
     '': ''
     category: ''
@@ -567,7 +567,7 @@
     language3: ''
     url: /frs/demos/buried/buried-win-demo-en.zip
 -
-    id: soltys
+    id: 'cge:soltys'
     platform: dos
     '': ''
     category: ''
@@ -576,7 +576,7 @@
     language3: ''
     url: /frs/demos/cge/soltys-demo.zip
 -
-    id: sfinx
+    id: 'cge2:sfinx'
     platform: dos
     '': ''
     category: ''
@@ -585,7 +585,7 @@
     language3: ''
     url: /frs/demos/cge2/sfinx-demo-pl.zip
 -
-    id: chewy
+    id: 'chewy:chewy'
     platform: dos
     '': ''
     category: German
@@ -594,7 +594,7 @@
     language3: ''
     url: /frs/demos/chewy/chewy-dos-demo-de.zip
 -
-    id: fw
+    id: 'cine:fw'
     platform: amiga
     '': ''
     category: Non-Interactive
@@ -603,7 +603,7 @@
     language3: ''
     url: /frs/demos/cine/fw-amiga-ni-demo-en.zip
 -
-    id: os
+    id: 'cine:os'
     platform: amiga
     '': ''
     category: Non-Interactive
@@ -612,7 +612,7 @@
     language3: ''
     url: /frs/demos/cine/os-amiga-ni-demo-en.zip
 -
-    id: os
+    id: 'cine:os'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -621,7 +621,7 @@
     language3: ''
     url: /frs/demos/cine/os-dos-ni-demo-en.zip
 -
-    id: babayaga
+    id: 'composer:babayaga'
     platform: mac
     '': ''
     category: ''
@@ -630,7 +630,7 @@
     language3: ''
     url: /frs/demos/composer/babayaga-demo-mac.zip
 -
-    id: babayaga
+    id: 'composer:babayaga'
     platform: win
     '': ''
     category: ''
@@ -639,7 +639,7 @@
     language3: ''
     url: /frs/demos/composer/babayaga-demo-win.zip
 -
-    id: littlesamurai
+    id: 'composer:littlesamurai'
     platform: mac
     '': ''
     category: ''
@@ -648,7 +648,7 @@
     language3: ''
     url: /frs/demos/composer/littlesamurai-demo-mac.zip
 -
-    id: littlesamurai
+    id: 'composer:littlesamurai'
     platform: win
     '': ''
     category: ''
@@ -657,7 +657,7 @@
     language3: ''
     url: /frs/demos/composer/littlesamurai-demo-win.zip
 -
-    id: magictales
+    id: 'composer:magictales'
     platform: mac
     '': ''
     category: ''
@@ -666,7 +666,7 @@
     language3: ''
     url: f/rs/demos/composer/magictales-demo-mac-he.zip
 -
-    id: magictales
+    id: 'composer:magictales'
     platform: win
     '': ''
     category: ''
@@ -675,7 +675,7 @@
     language3: ''
     url: /frs/demos/composer/magictales-demo-win-he.zip
 -
-    id: losteden
+    id: 'cryo:losteden'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -684,7 +684,7 @@
     language3: ''
     url: /frs/demos/cryo/losteden-dos-demo-ni.zip
 -
-    id: losteden
+    id: 'cryo:losteden'
     platform: dos
     '': ''
     category: ''
@@ -693,7 +693,7 @@
     language3: ''
     url: /frs/demos/cryo/losteden-dos-demo.zip
 -
-    id: versailles
+    id: 'cryomni3d:versailles'
     platform: win
     '': ''
     category: ''
@@ -702,7 +702,7 @@
     language3: ''
     url: /frs/demos/cryomni3d/versailles-dos-demo-ni.zip
 -
-    id: director
+    id: 'director:director'
     platform: mac
     '': ''
     category: 'The Apartment D2'
@@ -711,7 +711,7 @@
     language3: ''
     url: /frs/demos/director/theapartment2.zip
 -
-    id: director
+    id: 'director:director'
     platform: mac
     '': ''
     category: 'The Apartment D3'
@@ -720,7 +720,7 @@
     language3: ''
     url: /frs/demos/director/theapartment3.zip
 -
-    id: director
+    id: 'director:director'
     platform: mac
     '': ''
     category: 'The Apartment D4'
@@ -729,7 +729,7 @@
     language3: ''
     url: /frs/demos/director/theapartment4.zip
 -
-    id: warlock
+    id: 'director:warlock'
     platform: win
     '': ''
     category: ''
@@ -738,7 +738,7 @@
     language3: ''
     url: /frs/demos/director/warlock-win-demo.zip
 -
-    id: dm
+    id: 'dm:dm'
     platform: amiga
     '': ''
     category: ''
@@ -747,7 +747,7 @@
     language3: ''
     url: /frs/demos/dm/dm-amiga-demo-en.zip
 -
-    id: dreamweb
+    id: 'dreamweb:dreamweb'
     platform: amiga
     '': ''
     category: ''
@@ -756,7 +756,7 @@
     language3: ''
     url: /frs/demos/dreamweb/dreamweb-amiga-demo-en.zip
 -
-    id: dreamweb
+    id: 'dreamweb:dreamweb'
     platform: dos
     '': ''
     category: CD
@@ -765,7 +765,7 @@
     language3: ''
     url: /frs/demos/dreamweb/dreamweb-dos-demo-cd-en.zip
 -
-    id: dreamweb
+    id: 'dreamweb:dreamweb'
     platform: dos
     '': ''
     category: ''
@@ -774,7 +774,7 @@
     language3: ''
     url: /frs/demos/dreamweb/dreamweb-dos-demo-en.zip
 -
-    id: 3dkit-fanmade
+    id: 'freescape:3dkit-fanmade'
     platform: acorn
     '': ''
     category: ''
@@ -783,7 +783,7 @@
     language3: ''
     url: /frs/demos/freescape/3dkit-acorn-demo-en.zip
 -
-    id: 3dkit-fanmade
+    id: 'freescape:3dkit-fanmade'
     platform: acorn
     '': ''
     category: Alternative
@@ -792,7 +792,7 @@
     language3: ''
     url: /frs/demos/freescape/3dkit-acorn-demo2-en.zip
 -
-    id: driller
+    id: 'freescape:driller'
     platform: amiga
     '': ''
     category: ''
@@ -801,7 +801,7 @@
     language3: ''
     url: /frs/demos/freescape/driller-amiga-demo.zip
 -
-    id: driller
+    id: 'freescape:driller'
     platform: atarist
     '': ''
     category: ''
@@ -810,7 +810,7 @@
     language3: ''
     url: /frs/demos/freescape/driller-atarist-demo.zip
 -
-    id: driller
+    id: 'freescape:driller'
     platform: dos
     '': ''
     category: ''
@@ -819,7 +819,7 @@
     language3: ''
     url: /frs/demos/freescape/driller-dos-demo.zip
 -
-    id: adi2
+    id: 'gob:adi2'
     platform: win
     '': ''
     category: ''
@@ -828,7 +828,7 @@
     language3: ''
     url: /frs/demos/gob/adi2-win-ni-demo-en-fr-de.zip
 -
-    id: adi2
+    id: 'gob:adi2'
     platform: win
     '': ''
     category: ''
@@ -837,7 +837,7 @@
     language3: ''
     url: /frs/demos/gob/adi2-win-ni-demo-fr.zip
 -
-    id: adi4
+    id: 'gob:adi4'
     platform: win
     '': ''
     category: ''
@@ -846,7 +846,7 @@
     language3: ''
     url: /frs/demos/gob/adi4-adibou3-win-demo-fr.zip
 -
-    id: adi4
+    id: 'gob:adi4'
     platform: win
     '': ''
     category: ''
@@ -855,7 +855,7 @@
     language3: ''
     url: /frs/demos/gob/adi4-win-demo-fr.zip
 -
-    id: adibou1
+    id: 'gob:adibou1'
     platform: win
     '': ''
     category: ''
@@ -864,7 +864,7 @@
     language3: ''
     url: /frs/demos/gob/adibou-win-ni-demo-fr.zip
 -
-    id: adibou2
+    id: 'gob:adibou2'
     platform: dos
     '': ''
     category: French
@@ -873,7 +873,7 @@
     language3: ''
     url: /frs/demos/gob/adibou2-dos-demo-fr.zip
 -
-    id: dynasty
+    id: 'gob:dynasty'
     platform: dos
     '': ''
     category: ''
@@ -882,7 +882,7 @@
     language3: ''
     url: /frs/demos/gob/dynasty-dos-ni-demo-en.zip
 -
-    id: dynasty
+    id: 'gob:dynasty'
     platform: win
     '': ''
     category: ''
@@ -891,7 +891,7 @@
     language3: ''
     url: /frs/demos/gob/dynasty-win-demo-de.zip
 -
-    id: dynasty
+    id: 'gob:dynasty'
     platform: win
     '': ''
     category: Non-Interactive
@@ -900,7 +900,7 @@
     language3: ''
     url: /frs/demos/gob/dynasty-win-ni-demo1-en.zip
 -
-    id: dynasty
+    id: 'gob:dynasty'
     platform: win
     '': ''
     category: Non-Interactive
@@ -909,7 +909,7 @@
     language3: ''
     url: /frs/demos/gob/dynasty-win-ni-demo2-en.zip
 -
-    id: dynastywood
+    id: 'gob:dynastywood'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -918,7 +918,7 @@
     language3: ''
     url: /frs/demos/gob/dynastywood-dos-ni-demo-en.zip
 -
-    id: gob1
+    id: 'gob:gob1'
     platform: amiga
     '': ''
     category: ''
@@ -927,7 +927,7 @@
     language3: ''
     url: /frs/demos/gob/gob1-amiga_demo_en.zip
 -
-    id: gob1
+    id: 'gob:gob1'
     platform: cdi
     '': ''
     category: ''
@@ -936,7 +936,7 @@
     language3: ''
     url: /frs/demos/gob/gob1-cdi-demo-fr.zip
 -
-    id: gob1
+    id: 'gob:gob1'
     platform: dos
     '': ''
     category: French
@@ -945,7 +945,7 @@
     language3: ''
     url: /frs/demos/gob/gob1-dos-demo-fr.zip
 -
-    id: gob1
+    id: 'gob:gob1'
     platform: dos
     '': ''
     category: ''
@@ -954,7 +954,7 @@
     language3: ''
     url: /frs/demos/gob/gob1-dos-demo1-en.zip
 -
-    id: gob1
+    id: 'gob:gob1'
     platform: dos
     '': ''
     category: Alternative
@@ -963,7 +963,7 @@
     language3: ''
     url: /frs/demos/gob/gob1-dos-demo2-en.zip
 -
-    id: gob2
+    id: 'gob:gob2'
     platform: amiga
     '': ''
     category: ''
@@ -972,7 +972,7 @@
     language3: ''
     url: /frs/demos/gob/gob2-amiga-demo1-en.zip
 -
-    id: gob2
+    id: 'gob:gob2'
     platform: amiga
     '': ''
     category: Alternative
@@ -981,7 +981,7 @@
     language3: ''
     url: /frs/demos/gob/gob2-amiga-demo2-en.zip
 -
-    id: gob2
+    id: 'gob:gob2'
     platform: dos
     '': ''
     category: ''
@@ -990,7 +990,7 @@
     language3: ''
     url: /frs/demos/gob/gob2-dos-demo-en.zip
 -
-    id: gob2
+    id: 'gob:gob2'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -999,7 +999,7 @@
     language3: ''
     url: /frs/demos/gob/gob2-dos-ni-demo-en.zip
 -
-    id: gob3
+    id: 'gob:gob3'
     platform: dos
     '': ''
     category: ''
@@ -1008,7 +1008,7 @@
     language3: ''
     url: /frs/demos/gob/gob3-dos-demo-en.zip
 -
-    id: gob3
+    id: 'gob:gob3'
     platform: dos
     '': ''
     category: French
@@ -1017,7 +1017,7 @@
     language3: ''
     url: /frs/demos/gob/gob3-dos-demo1-fr.zip
 -
-    id: gob3
+    id: 'gob:gob3'
     platform: dos
     '': ''
     category: 'French Alternative'
@@ -1026,7 +1026,7 @@
     language3: ''
     url: /frs/demos/gob/gob3-dos-demo2-fr.zip
 -
-    id: gob3
+    id: 'gob:gob3'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -1035,7 +1035,7 @@
     language3: ''
     url: /frs/demos/gob/gob3-dos-ni-demo-en.zip
 -
-    id: inca
+    id: 'gob:inca'
     platform: dos
     '': ''
     category: 'Not-Supported, Non-Interactive'
@@ -1044,7 +1044,7 @@
     language3: ''
     url: /frs/demos/gob/inca-dos-ni-demo-en.zip
 -
-    id: inca2
+    id: 'gob:inca2'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -1053,7 +1053,7 @@
     language3: ''
     url: /frs/demos/gob/inca2-dos-ni-demo-en.zip
 -
-    id: lit
+    id: 'gob:lit'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -1062,7 +1062,7 @@
     language3: ''
     url: /frs/demos/gob/lostintime-dos-ni-demo-en.zip
 -
-    id: playtoons1
+    id: 'gob:playtoons1'
     platform: dos
     '': ''
     category: 'Italian Non-Interactive'
@@ -1071,7 +1071,7 @@
     language3: ''
     url: /frs/demos/gob/archibald-dos-ni-demo-it.zip
 -
-    id: playtoons1
+    id: 'gob:playtoons1'
     platform: dos
     '': ''
     category: 'Spanish Non-Interactive'
@@ -1080,7 +1080,7 @@
     language3: ''
     url: /frs/demos/gob/archibald-dos-ni-demo-sp.zip
 -
-    id: playtoons1
+    id: 'gob:playtoons1'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -1089,7 +1089,7 @@
     language3: ''
     url: /frs/demos/gob/archibald-dos-ni-demo2-en.zip
 -
-    id: playtoonsdemo
+    id: 'gob:playtoonsdemo'
     platform: dos
     '': ''
     category: ''
@@ -1098,7 +1098,7 @@
     language3: ''
     url: /frs/demos/gob/archibald-dos-ni-demo1-en.zip
 -
-    id: urban
+    id: 'gob:urban'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -1107,7 +1107,7 @@
     language3: ''
     url: /frs/demos/gob/urban-win-ni-demo-en.zip
 -
-    id: ween
+    id: 'gob:ween'
     platform: dos
     '': ''
     category: ''
@@ -1116,7 +1116,7 @@
     language3: ''
     url: /frs/demos/gob/ween-dos-demo-en.zip
 -
-    id: ween
+    id: 'gob:ween'
     platform: dos
     '': ''
     category: ''
@@ -1125,7 +1125,7 @@
     language3: ''
     url: /frs/demos/gob/ween-dos-demo2-uk.zip
 -
-    id: woodruff
+    id: 'gob:woodruff'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -1134,7 +1134,7 @@
     language3: ''
     url: /frs/demos/gob/woodruff-dos-ni-demo-en.zip
 -
-    id: grim
+    id: 'grim:grim'
     platform: win
     '': ''
     category: German
@@ -1143,7 +1143,7 @@
     language3: ''
     url: /frs/demos/grim/grim-win-demo-de.zip
 -
-    id: grim
+    id: 'grim:grim'
     platform: win
     '': ''
     category: French
@@ -1152,7 +1152,7 @@
     language3: ''
     url: /frs/demos/grim/grim-win-demo-fr.zip
 -
-    id: grim
+    id: 'grim:grim'
     platform: win
     '': ''
     category: Italian
@@ -1161,7 +1161,7 @@
     language3: ''
     url: /frs/demos/grim/grim-win-demo-it.zip
 -
-    id: grim
+    id: 'grim:grim'
     platform: win
     '': ''
     category: Spanish
@@ -1170,7 +1170,7 @@
     language3: ''
     url: /frs/demos/grim/grim-win-demo-sp.zip
 -
-    id: grim
+    id: 'grim:grim'
     platform: win
     '': ''
     category: Small
@@ -1179,7 +1179,7 @@
     language3: ''
     url: /frs/demos/grim/grim-win-demo1-en.zip
 -
-    id: grim
+    id: 'grim:grim'
     platform: win
     '': ''
     category: Large
@@ -1188,7 +1188,7 @@
     language3: ''
     url: /frs/demos/grim/grim-win-demo2-en.zip
 -
-    id: monkey4
+    id: 'grim:monkey4'
     platform: mac
     '': ''
     category: ''
@@ -1197,7 +1197,7 @@
     language3: ''
     url: /frs/demos/grim/efmi_large_demo.sea
 -
-    id: monkey4
+    id: 'grim:monkey4'
     platform: win
     '': ''
     category: German
@@ -1206,7 +1206,7 @@
     language3: ''
     url: /frs/demos/grim/emi-win-demo-de.zip
 -
-    id: monkey4
+    id: 'grim:monkey4'
     platform: win
     '': ''
     category: ''
@@ -1215,7 +1215,7 @@
     language3: ''
     url: /frs/demos/grim/emi-win-demo-en.zip
 -
-    id: monkey4
+    id: 'grim:monkey4'
     platform: win
     '': ''
     category: Spanish
@@ -1224,7 +1224,7 @@
     language3: ''
     url: /frs/demos/grim/emi-win-demo-sp.zip
 -
-    id: monkey4
+    id: 'grim:monkey4'
     platform: win
     '': ''
     category: CD
@@ -1233,7 +1233,7 @@
     language3: ''
     url: /frs/demos/grim/monkey4-win-cd-demo-en.zip
 -
-    id: monkey4
+    id: 'grim:monkey4'
     platform: win
     '': ''
     category: French
@@ -1242,7 +1242,7 @@
     language3: ''
     url: /frs/demos/grim/monkey4demo-fre.zip
 -
-    id: 11h
+    id: 'groovie:11h'
     platform: dos
     '': ''
     category: 'Both Interactive and Non-Interactive'
@@ -1251,7 +1251,7 @@
     language3: ''
     url: /frs/demos/groovie/11h-dos-cd-demo1-en.zip
 -
-    id: 11h
+    id: 'groovie:11h'
     platform: dos
     '': ''
     category: Interactive
@@ -1260,7 +1260,7 @@
     language3: ''
     url: /frs/demos/groovie/11h-dos-cd-demo2-en.zip
 -
-    id: 11h
+    id: 'groovie:11h'
     platform: dos
     '': ''
     category: ''
@@ -1269,7 +1269,7 @@
     language3: ''
     url: /frs/demos/groovie/11h-dos-demo-en.zip
 -
-    id: 11h
+    id: 'groovie:11h'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -1278,7 +1278,7 @@
     language3: ''
     url: /frs/demos/groovie/11h-dos-ni-demo-en.zip
 -
-    id: clandestiny
+    id: 'groovie:clandestiny'
     platform: dos
     '': ''
     category: Interactive
@@ -1287,7 +1287,7 @@
     language3: ''
     url: /frs/demos/groovie/clandestiny-dos-cd-demo-en.zip
 -
-    id: clandestiny
+    id: 'groovie:clandestiny'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -1296,7 +1296,7 @@
     language3: ''
     url: /frs/demos/groovie/clandestiny-dos-ni-demo-en.zip
 -
-    id: clandestiny
+    id: 'groovie:clandestiny'
     platform: mac
     '': ''
     category: ''
@@ -1305,7 +1305,7 @@
     language3: ''
     url: /frs/demos/groovie/clandestiny-mac-ni-demo.zip
 -
-    id: t7g
+    id: 'groovie:t7g'
     platform: dos
     '': ''
     category: ''
@@ -1314,7 +1314,7 @@
     language3: ''
     url: /frs/demos/groovie/t7g-dos-demo-en.zip
 -
-    id: tlc
+    id: 'groovie:tlc'
     platform: win
     '': ''
     category: 'German Both Interactive and Non-Interactive'
@@ -1323,7 +1323,7 @@
     language3: ''
     url: /frs/demos/groovie/tlc-win-demo-de.zip
 -
-    id: hdb
+    id: 'hdb:hdb'
     platform: linux
     '': ''
     category: ''
@@ -1332,7 +1332,7 @@
     language3: ''
     url: /frs/demos/hdb/hdb-demo-linux.zip
 -
-    id: hdb
+    id: 'hdb:hdb'
     platform: pocketpc
     '': ''
     category: Handango
@@ -1341,7 +1341,7 @@
     language3: ''
     url: /frs/demos/hdb/hdb-demo-ppc-alt.zip
 -
-    id: hdb
+    id: 'hdb:hdb'
     platform: pocketpc
     '': ''
     category: ''
@@ -1350,7 +1350,7 @@
     language3: ''
     url: /frs/demos/hdb/hdb-demo-ppc.zip
 -
-    id: hdb
+    id: 'hdb:hdb'
     platform: win
     '': ''
     category: ''
@@ -1359,7 +1359,7 @@
     language3: ''
     url: /frs/demos/hdb/hdb-demo-win.zip
 -
-    id: hopkins
+    id: 'hopkins:hopkins'
     platform: linux
     '': ''
     category: ''
@@ -1368,7 +1368,7 @@
     language3: ''
     url: /frs/demos/hopkins/hopkins-linux-en.zip
 -
-    id: hopkins
+    id: 'hopkins:hopkins'
     platform: win
     '': ''
     category: ''
@@ -1377,7 +1377,7 @@
     language3: ''
     url: /frs/demos/hopkins/hopkins-win95-en.zip
 -
-    id: hopkins
+    id: 'hopkins:hopkins'
     platform: win
     '': ''
     category: Polish
@@ -1386,7 +1386,7 @@
     language3: ''
     url: /frs/demos/hopkins/hopkins-win95-pl.zip
 -
-    id: hugo1
+    id: 'hugo:hugo1'
     platform: dos
     '': ''
     category: V1.1
@@ -1395,7 +1395,7 @@
     language3: ''
     url: /frs/demos/hugo/hugo1-dos-1.1-demo-en.zip
 -
-    id: hugo1
+    id: 'hugo:hugo1'
     platform: dos
     '': ''
     category: V1.2
@@ -1404,7 +1404,7 @@
     language3: ''
     url: /frs/demos/hugo/hugo1-dos-1.2-demo-en.zip
 -
-    id: hugo1
+    id: 'hugo:hugo1'
     platform: dos
     '': ''
     category: V1.3
@@ -1413,7 +1413,7 @@
     language3: ''
     url: /frs/demos/hugo/hugo1-dos-1.3-demo-en.zip
 -
-    id: hugo1
+    id: 'hugo:hugo1'
     platform: dos
     '': ''
     category: V1.5
@@ -1422,7 +1422,7 @@
     language3: ''
     url: /frs/demos/hugo/hugo1-dos-1.5-demo-en.zip
 -
-    id: hugo1
+    id: 'hugo:hugo1'
     platform: dos
     '': ''
     category: V1.6
@@ -1431,7 +1431,7 @@
     language3: ''
     url: /frs/demos/hugo/hugo1-dos-1.6-demo-en.zip
 -
-    id: hugo1
+    id: 'hugo:hugo1'
     platform: dos
     '': ''
     category: V1.8
@@ -1440,7 +1440,7 @@
     language3: ''
     url: /frs/demos/hugo/hugo1-dos-1.8-demo-en.zip
 -
-    id: hugo1
+    id: 'hugo:hugo1'
     platform: dos
     '': ''
     category: V1.9
@@ -1449,7 +1449,7 @@
     language3: ''
     url: /frs/demos/hugo/hugo1-dos-1.9-demo-en.zip
 -
-    id: hugo1
+    id: 'hugo:hugo1'
     platform: dos
     '': ''
     category: 'V2,0'
@@ -1458,7 +1458,7 @@
     language3: ''
     url: /frs/demos/hugo/hugo1-dos-2.0-demo-en.zip
 -
-    id: hugo1
+    id: 'hugo:hugo1'
     platform: dos
     '': ''
     category: V2.1
@@ -1467,7 +1467,7 @@
     language3: ''
     url: /frs/demos/hugo/hugo1-dos-2.1-demo-en.zip
 -
-    id: hugo2
+    id: 'hugo:hugo2'
     platform: dos
     '': ''
     category: V1.0
@@ -1476,7 +1476,7 @@
     language3: ''
     url: /frs/demos/hugo/hugo2-dos-1.0-demo-en.zip
 -
-    id: hugo2
+    id: 'hugo:hugo2'
     platform: dos
     '': ''
     category: V1.2
@@ -1485,7 +1485,7 @@
     language3: ''
     url: /frs/demos/hugo/hugo2-dos-1.2-demo-en.zip
 -
-    id: hugo2
+    id: 'hugo:hugo2'
     platform: dos
     '': ''
     category: V2.1
@@ -1494,7 +1494,7 @@
     language3: ''
     url: /frs/demos/hugo/hugo2-dos-2.1-demo-en.zip
 -
-    id: hugo3
+    id: 'hugo:hugo3'
     platform: dos
     '': ''
     category: V1.0
@@ -1503,7 +1503,7 @@
     language3: ''
     url: /frs/demos/hugo/hugo3-dos-1.0-demo-en.zip
 -
-    id: hugo3
+    id: 'hugo:hugo3'
     platform: dos
     '': ''
     category: V1.1
@@ -1512,7 +1512,7 @@
     language3: ''
     url: /frs/demos/hugo/hugo3-dos-1.1-demo-en.zip
 -
-    id: hugo3
+    id: 'hugo:hugo3'
     platform: dos
     '': ''
     category: V2.0
@@ -1521,7 +1521,7 @@
     language3: ''
     url: /frs/demos/hugo/hugo3-dos-2.0-demo-en.zip
 -
-    id: hugo3
+    id: 'hugo:hugo3'
     platform: dos
     '': ''
     category: V2.1
@@ -1530,7 +1530,7 @@
     language3: ''
     url: /frs/demos/hugo/hugo3-dos-2.1-demo-en.zip
 -
-    id: sinistersix
+    id: 'hypno:sinistersix'
     platform: dos
     '': ''
     category: ''
@@ -1539,7 +1539,7 @@
     language3: ''
     url: /frs/demos/hypno/sinistersix-dos-demo-en.zip
 -
-    id: teacher
+    id: 'hypno:teacher'
     platform: win
     '': ''
     category: ''
@@ -1548,7 +1548,7 @@
     language3: ''
     url: /frs/demos/hypno/teacher-windows-demo-en.zip
 -
-    id: wetlands
+    id: 'hypno:wetlands'
     platform: dos
     '': ''
     category: ''
@@ -1557,7 +1557,7 @@
     language3: ''
     url: /frs/demos/hypno/wetlands-dos-demo1-en.zip
 -
-    id: wetlands
+    id: 'hypno:wetlands'
     platform: dos
     '': ''
     category: ''
@@ -1566,7 +1566,7 @@
     language3: ''
     url: /frs/demos/hypno/wetlands-dos-demo2-en.zip
 -
-    id: wetlands
+    id: 'hypno:wetlands'
     platform: dos
     '': ''
     category: ''
@@ -1575,7 +1575,7 @@
     language3: ''
     url: /frs/demos/hypno/wetlands-dos-demo3-en.zip
 -
-    id: wetlands
+    id: 'hypno:wetlands'
     platform: dos
     '': ''
     category: ''
@@ -1584,7 +1584,7 @@
     language3: ''
     url: /frs/demos/hypno/wetlands-dos-demo4-en.zip
 -
-    id: wetlands
+    id: 'hypno:wetlands'
     platform: dos
     '': ''
     category: ''
@@ -1593,7 +1593,7 @@
     language3: ''
     url: /frs/demos/hypno/wetlands-dos-demo5-en.zip
 -
-    id: wetlands
+    id: 'hypno:wetlands'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -1602,7 +1602,7 @@
     language3: ''
     url: /frs/demos/hypno/wetlands-dos-ni-demo1-en.zip
 -
-    id: wetlands
+    id: 'hypno:wetlands'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -1611,7 +1611,7 @@
     language3: ''
     url: /frs/demos/hypno/wetlands-dos-ni-demo2-en.zip
 -
-    id: icb
+    id: 'icb:icb'
     platform: win
     '': ''
     category: ''
@@ -1620,7 +1620,7 @@
     language3: ''
     url: /frs/demos/icb/icb-eng-demo.zip
 -
-    id: icb
+    id: 'icb:icb'
     platform: win
     '': ''
     category: 'English US'
@@ -1629,7 +1629,7 @@
     language3: ''
     url: /frs/demos/icb/icb-win-demo-us.zip
 -
-    id: igor
+    id: 'igor:igor'
     platform: dos
     '': ''
     category: 'Version 1.0'
@@ -1638,7 +1638,7 @@
     language3: ''
     url: /frs/demos/other/igor/igor-dos-1.0-demo-en.zip
 -
-    id: igor
+    id: 'igor:igor'
     platform: dos
     '': ''
     category: 'Version 1.1'
@@ -1647,7 +1647,7 @@
     language3: ''
     url: /frs/demos/other/igor/igor-dos-1.1-demo-en.zip
 -
-    id: duckman
+    id: 'illusions:duckman'
     platform: win
     '': ''
     category: ''
@@ -1656,7 +1656,7 @@
     language3: ''
     url: /frs/demos/illusions/duckman-demo.zip
 -
-    id: kingdom
+    id: 'kingdom:kingdom'
     platform: dos
     '': ''
     category: ''
@@ -1665,7 +1665,7 @@
     language3: ''
     url: /frs/demos/kingdom/kingdom-demo.zip
 -
-    id: eob2
+    id: 'kyra:eob2'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -1674,7 +1674,7 @@
     language3: ''
     url: /frs/demos/kyra/eob2-dos-ni-demo-en.zip
 -
-    id: kyra1
+    id: 'kyra:kyra1'
     platform: dos
     '': ''
     category: 'CD Non-Interactive'
@@ -1683,7 +1683,7 @@
     language3: ''
     url: /frs/demos/kyra/kyra1-dos-cd-ni-demo-en.zip
 -
-    id: kyra1
+    id: 'kyra:kyra1'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -1692,7 +1692,7 @@
     language3: ''
     url: /frs/demos/kyra/kyra1-dos-ni-demo-en.zip
 -
-    id: kyra2
+    id: 'kyra:kyra2'
     platform: dos
     '': ''
     category: ''
@@ -1701,7 +1701,7 @@
     language3: ''
     url: /frs/demos/kyra/kyra2-dos-cd-demo-en.zip
 -
-    id: kyra2
+    id: 'kyra:kyra2'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -1710,7 +1710,7 @@
     language3: ''
     url: /frs/demos/kyra/kyra2-dos-ni-demo1-en.zip
 -
-    id: kyra2
+    id: 'kyra:kyra2'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -1719,7 +1719,7 @@
     language3: ''
     url: /frs/demos/kyra/kyra2-dos-ni-demo2-en.zip
 -
-    id: kyra3
+    id: 'kyra:kyra3'
     platform: dos
     '': ''
     category: Non-Engine
@@ -1728,7 +1728,7 @@
     language3: ''
     url: /frs/demos/kyra/Non-Engine/kyra3-dos-ni-demo-en.zip
 -
-    id: lol
+    id: 'kyra:lol'
     platform: dos
     '': ''
     category: CD
@@ -1737,7 +1737,7 @@
     language3: ''
     url: /frs/demos/kyra/lol-dos-cd-demo-en.zip
 -
-    id: lol
+    id: 'kyra:lol'
     platform: dos
     '': ''
     category: 'Non-Interactive Intro'
@@ -1746,7 +1746,7 @@
     language3: ''
     url: /frs/demos/kyra/lol-dos-intro-ni-demo-en.zip
 -
-    id: lol
+    id: 'kyra:lol'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -1755,7 +1755,7 @@
     language3: ''
     url: /frs/demos/kyra/lol-dos-ni-demo-en.zip
 -
-    id: lastexpress
+    id: 'lastexpress:lastexpress'
     platform: win
     '': ''
     category: Trailer
@@ -1764,7 +1764,7 @@
     language3: ''
     url: /frs/demos/lastexpress/lastexpress-trailer-en.zip
 -
-    id: lastexpress
+    id: 'lastexpress:lastexpress'
     platform: win
     '': ''
     category: ''
@@ -1773,7 +1773,7 @@
     language3: ''
     url: /frs/demos/lastexpress/lastexpress-win-demo-en.zip
 -
-    id: rome
+    id: 'lilliput:rome'
     platform: dos
     '': ''
     category: ''
@@ -1782,7 +1782,7 @@
     language3: ''
     url: /frs/demos/lilliput/rome-dos-demo-en.zip
 -
-    id: lure
+    id: 'lure:lure'
     platform: atarist
     '': ''
     category: ''
@@ -1791,7 +1791,7 @@
     language3: ''
     url: /frs/demos/lure/lure-st-demo-en.zip
 -
-    id: burger
+    id: 'm4:burger'
     platform: dos
     '': ''
     category: ''
@@ -1800,7 +1800,7 @@
     language3: ''
     url: /frs/demos/m4/burger-dos-demo-en.zip
 -
-    id: burger
+    id: 'm4:burger'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -1809,7 +1809,7 @@
     language3: ''
     url: /frs/demos/m4/burger-dos-ni-demo-en.zip
 -
-    id: riddle
+    id: 'm4:riddle'
     platform: dos
     '': ''
     category: ''
@@ -1818,7 +1818,7 @@
     language3: ''
     url: /frs/demos/m4/riddle-dos-demo-en.zip
 -
-    id: shadowgate
+    id: 'macventure:shadowgate'
     platform: win
     '': ''
     category: ''
@@ -1827,7 +1827,7 @@
     language3: ''
     url: /frs/demos/macventure/shadowgate-win-demo-en.zip
 -
-    id: uninvited
+    id: 'macventure:uninvited'
     platform: mac
     '': ''
     category: ''
@@ -1836,7 +1836,7 @@
     language3: ''
     url: /frs/demos/macventure/uninvited-mac-demo-en.zip
 -
-    id: rtz
+    id: 'made:rtz'
     platform: dos
     '': ''
     category: CD
@@ -1845,7 +1845,7 @@
     language3: ''
     url: /frs/demos/made/rtz-dos-cd-demo1-en.zip
 -
-    id: rtz
+    id: 'made:rtz'
     platform: dos
     '': ''
     category: 'CD Alternative'
@@ -1854,7 +1854,7 @@
     language3: ''
     url: /frs/demos/made/rtz-dos-cd-demo2-en.zip
 -
-    id: rtz
+    id: 'made:rtz'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -1863,7 +1863,7 @@
     language3: ''
     url: /frs/demos/made/rtz-dos-ni-demo-en.zip
 -
-    id: rtz
+    id: 'made:rtz'
     platform: mac
     '': ''
     category: ''
@@ -1872,7 +1872,7 @@
     language3: ''
     url: /frs/demos/made/rtz-mac-demo-en.zip
 -
-    id: dragonsphere
+    id: 'mads:dragonsphere'
     platform: dos
     '': ''
     category: ''
@@ -1881,7 +1881,7 @@
     language3: ''
     url: /frs/demos/mads/dragon-dos-demo-en.zip
 -
-    id: nebular
+    id: 'mads:nebular'
     platform: dos
     '': ''
     category: ''
@@ -1890,7 +1890,7 @@
     language3: ''
     url: /frs/demos/mads/rex-dos-demo-en.zip
 -
-    id: phantom
+    id: 'mads:phantom'
     platform: dos
     '': ''
     category: ''
@@ -1899,7 +1899,7 @@
     language3: ''
     url: /frs/demos/mads/phantom-dos-demo-en.zip
 -
-    id: alientales
+    id: 'mohawk:alientales'
     platform: win
     '': ''
     category: ''
@@ -1908,7 +1908,7 @@
     language3: ''
     url: /frs/demos/mohawk/alientales-win-demo-en.zip
 -
-    id: arthur
+    id: 'mohawk:arthur'
     platform: mac
     '': ''
     category: English/Spanish
@@ -1917,7 +1917,7 @@
     language3: ''
     url: /frs/demos/mohawk/arthur-mac-demo-en-es.zip
 -
-    id: arthur
+    id: 'mohawk:arthur'
     platform: mac
     '': ''
     category: ''
@@ -1926,7 +1926,7 @@
     language3: ''
     url: /frs/demos/mohawk/arthur-mac-demo-en.zip
 -
-    id: arthur
+    id: 'mohawk:arthur'
     platform: mac
     '': ''
     category: Alternative
@@ -1935,7 +1935,7 @@
     language3: ''
     url: /frs/demos/mohawk/arthur-mac-demo2-en.zip
 -
-    id: arthur
+    id: 'mohawk:arthur'
     platform: win
     '': ''
     category: Alternative
@@ -1944,7 +1944,7 @@
     language3: ''
     url: /frs/demos/mohawk/arthur-win-demo-en-v1.1.zip
 -
-    id: arthur
+    id: 'mohawk:arthur'
     platform: win
     '': ''
     category: ''
@@ -1953,7 +1953,7 @@
     language3: ''
     url: /frs/demos/mohawk/arthur-win-demo-en.zip
 -
-    id: arthurbday
+    id: 'mohawk:arthurbday'
     platform: mac
     '': ''
     category: ''
@@ -1962,7 +1962,7 @@
     language3: ''
     url: /frs/demos/mohawk/arthurbday-mac-demo-en.zip
 -
-    id: arthurbday
+    id: 'mohawk:arthurbday'
     platform: win
     '': ''
     category: ''
@@ -1971,7 +1971,7 @@
     language3: ''
     url: /frs/demos/mohawk/arthurbday-win-demo-en.zip
 -
-    id: cstime
+    id: 'mohawk:cstime'
     platform: win
     '': ''
     category: ''
@@ -1980,7 +1980,7 @@
     language3: ''
     url: /frs/demos/mohawk/cstime-win-demo-en.zip
 -
-    id: csusa
+    id: 'mohawk:csusa'
     platform: win
     '': ''
     category: ''
@@ -1989,7 +1989,7 @@
     language3: ''
     url: /frs/demos/mohawk/csusa-win-demo-en.zip
 -
-    id: csworld
+    id: 'mohawk:csworld'
     platform: win
     '': ''
     category: ''
@@ -1998,7 +1998,7 @@
     language3: ''
     url: /frs/demos/mohawk/csworld-win-demo-en.zip
 -
-    id: daniel
+    id: 'mohawk:daniel'
     platform: win
     '': ''
     category: ''
@@ -2007,7 +2007,7 @@
     language3: ''
     url: /frs/demos/mohawk/daniel-win-demo.zip
 -
-    id: grandma
+    id: 'mohawk:grandma'
     platform: mac
     '': ''
     category: English/Japanese/Spanish
@@ -2016,7 +2016,7 @@
     language3: ja
     url: /frs/demos/mohawk/grandma-mac-demo-en-es-jp.zip
 -
-    id: grandma
+    id: 'mohawk:grandma'
     platform: mac
     '': ''
     category: ''
@@ -2025,7 +2025,7 @@
     language3: ''
     url: /frs/demos/mohawk/grandma-mac-demo-en.zip
 -
-    id: grandma
+    id: 'mohawk:grandma'
     platform: mac
     '': ''
     category: Alternative
@@ -2034,7 +2034,7 @@
     language3: ''
     url: /frs/demos/mohawk/grandma-mac-demo2-en.zip
 -
-    id: grandma
+    id: 'mohawk:grandma'
     platform: win
     '': ''
     category: Alternative
@@ -2043,7 +2043,7 @@
     language3: ''
     url: /frs/demos/mohawk/grandma-win-demo-en-v1.1.zip
 -
-    id: grandma
+    id: 'mohawk:grandma'
     platform: win
     '': ''
     category: ''
@@ -2052,7 +2052,7 @@
     language3: ''
     url: /frs/demos/mohawk/grandma-win-demo-en.zip
 -
-    id: greeneggs
+    id: 'mohawk:greeneggs'
     platform: win
     '': ''
     category: ''
@@ -2061,7 +2061,7 @@
     language3: ''
     url: /frs/demos/mohawk/greeneggs-win-demo-en.zip
 -
-    id: harryhh
+    id: 'mohawk:harryhh'
     platform: win
     '': ''
     category: English/Spanish
@@ -2070,7 +2070,7 @@
     language3: ''
     url: /frs/demos/mohawk/harryhh-win-demo-en-es.zip
 -
-    id: koala
+    id: 'mohawk:koala'
     platform: win
     '': ''
     category: ''
@@ -2079,7 +2079,7 @@
     language3: ''
     url: /frs/demos/mohawk/koala-win-demo-en.zip
 -
-    id: lbsampler
+    id: 'mohawk:lbsampler'
     platform: mac
     '': ''
     category: V1
@@ -2088,7 +2088,7 @@
     language3: ''
     url: /frs/demos/mohawk/lbsampler-demo-mac-en-v1.zip
 -
-    id: lbsampler
+    id: 'mohawk:lbsampler'
     platform: mac
     '': ''
     category: V2
@@ -2097,7 +2097,7 @@
     language3: ''
     url: /frs/demos/mohawk/lbsampler-demo-mac-en-v2.zip
 -
-    id: lbsampler
+    id: 'mohawk:lbsampler'
     platform: mac
     '': ''
     category: V3
@@ -2106,7 +2106,7 @@
     language3: ''
     url: /frs/demos/mohawk/lbsampler-demo-mac-en-v3.zip
 -
-    id: lbsampler
+    id: 'mohawk:lbsampler'
     platform: win
     '': ''
     category: V1
@@ -2115,7 +2115,7 @@
     language3: ''
     url: /frs/demos/mohawk/lbsampler-demo-win-en-v1.zip
 -
-    id: lbsampler
+    id: 'mohawk:lbsampler'
     platform: win
     '': ''
     category: V2
@@ -2124,7 +2124,7 @@
     language3: ''
     url: /frs/demos/mohawk/lbsampler-demo-win-en-v2.zip
 -
-    id: lbsampler
+    id: 'mohawk:lbsampler'
     platform: win
     '': ''
     category: V3
@@ -2133,7 +2133,7 @@
     language3: ''
     url: /frs/demos/mohawk/lbsampler-demo-win-en-v3.zip
 -
-    id: myst
+    id: 'mohawk:myst'
     platform: win
     '': ''
     category: CD
@@ -2142,7 +2142,7 @@
     language3: ''
     url: /frs/demos/mohawk/myst-win-cd-demo-en.zip
 -
-    id: myst
+    id: 'mohawk:myst'
     platform: win
     '': ''
     category: ''
@@ -2151,7 +2151,7 @@
     language3: ''
     url: /frs/demos/mohawk/myst-win-demo-en.zip
 -
-    id: newkid
+    id: 'mohawk:newkid'
     platform: mac
     '': ''
     category: ''
@@ -2160,7 +2160,7 @@
     language3: ''
     url: /frs/demos/mohawk/newkid-demo-mac-en.zip
 -
-    id: newkid
+    id: 'mohawk:newkid'
     platform: win
     '': ''
     category: Alternative
@@ -2169,7 +2169,7 @@
     language3: ''
     url: /frs/demos/mohawk/newkid-win-demo-en-v1.1.zip
 -
-    id: newkid
+    id: 'mohawk:newkid'
     platform: win
     '': ''
     category: ''
@@ -2178,7 +2178,7 @@
     language3: ''
     url: /frs/demos/mohawk/newkid-win-demo-en.zip
 -
-    id: orly
+    id: 'mohawk:orly'
     platform: win
     '': ''
     category: ''
@@ -2187,7 +2187,7 @@
     language3: ''
     url: /frs/demos/mohawk/orly-win-demo-en.zip
 -
-    id: riven
+    id: 'mohawk:riven'
     platform: win
     '': ''
     category: ''
@@ -2196,7 +2196,7 @@
     language3: ''
     url: /frs/demos/mohawk/riven-win-demo-en.zip
 -
-    id: ruff
+    id: 'mohawk:ruff'
     platform: mac
     '': ''
     category: ''
@@ -2205,7 +2205,7 @@
     language3: ''
     url: /frs/demos/mohawk/ruff-mac-demo-en.zip
 -
-    id: ruff
+    id: 'mohawk:ruff'
     platform: win
     '': ''
     category: ''
@@ -2214,7 +2214,7 @@
     language3: ''
     url: /frs/demos/mohawk/ruff-win-demo-en.zip
 -
-    id: tortoise
+    id: 'mohawk:tortoise'
     platform: mac
     '': ''
     category: ''
@@ -2223,7 +2223,7 @@
     language3: ''
     url: /frs/demos/mohawk/tortoise-mac-demo-en.zip
 -
-    id: tortoise
+    id: 'mohawk:tortoise'
     platform: win
     '': ''
     category: Alternative
@@ -2232,7 +2232,7 @@
     language3: ''
     url: /frs/demos/mohawk/tortoise-win-demo-en-v1.1.zip
 -
-    id: tortoise
+    id: 'mohawk:tortoise'
     platform: win
     '': ''
     category: ''
@@ -2241,7 +2241,7 @@
     language3: ''
     url: /frs/demos/mohawk/tortoise-win-demo-en.zip
 -
-    id: zoombini
+    id: 'mohawk:zoombini'
     platform: mac
     '': ''
     category: ''
@@ -2250,7 +2250,7 @@
     language3: ''
     url: /frs/demos/mohawk/zoombini-mac-demo-en.zip
 -
-    id: zoombini
+    id: 'mohawk:zoombini'
     platform: mac
     '': ''
     category: ''
@@ -2259,7 +2259,7 @@
     language3: ''
     url: /frs/demos/mohawk/zoombini-mac-demo-ja.zip
 -
-    id: zoombini
+    id: 'mohawk:zoombini'
     platform: win
     '': ''
     category: ''
@@ -2268,7 +2268,7 @@
     language3: ''
     url: /frs/demos/mohawk/zoombini-win-demo-en.zip
 -
-    id: zoombini
+    id: 'mohawk:zoombini'
     platform: win
     '': ''
     category: Alternative
@@ -2277,7 +2277,7 @@
     language3: ''
     url: /frs/demos/mohawk/zoombini-win-demo2-en.zip
 -
-    id: obsidian
+    id: 'mtropolis:obsidian'
     platform: mac
     '': ''
     category: 'Demo w/Cinematic Trailer, SegaSoft CD'
@@ -2286,7 +2286,7 @@
     language3: ''
     url: /frs/demos/mtropolis/obsidian-mac-demo.zip
 -
-    id: obsidian
+    id: 'mtropolis:obsidian'
     platform: win
     '': ''
     category: 'Demo, 26th October 1996, PC Gamer 2.12 (Jan ''97)'
@@ -2295,7 +2295,7 @@
     language3: ''
     url: /frs/demos/mtropolis/obsidian-win-demo.zip
 -
-    id: obsidian
+    id: 'mtropolis:obsidian'
     platform: win
     '': ''
     category: 'Demo, 22nd October 1996'
@@ -2304,7 +2304,7 @@
     language3: ''
     url: /frs/demos/mtropolis/obsidian-win-demo2.zip
 -
-    id: obsidian
+    id: 'mtropolis:obsidian'
     platform: win
     '': ''
     category: 'Demo w/Cinematic Trailer, 4th October 1996, Ocean/Infogrames Show Case December 1997'
@@ -2313,7 +2313,7 @@
     language3: ''
     url: /frs/demos/mtropolis/obsidian-win-demo3.zip
 -
-    id: obsidian
+    id: 'mtropolis:obsidian'
     platform: win
     '': ''
     category: 'Demo w/Cinematic Trailer, 3rd October 1996'
@@ -2322,7 +2322,7 @@
     language3: ''
     url: /frs/demos/mtropolis/obsidian-win-demo4.zip
 -
-    id: mutationofjb
+    id: 'mutationofjb:mutationofjb'
     platform: dos
     '': ''
     category: ''
@@ -2331,7 +2331,7 @@
     language3: ''
     url: /frs/demos/mutationofjb/mutationofjb-dos-demo-sk.zip
 -
-    id: neverhood
+    id: 'neverhood:neverhood'
     platform: win
     '': ''
     category: Large
@@ -2340,7 +2340,7 @@
     language3: ''
     url: /frs/demos/neverhood/neverhood-demo-big-en.zip
 -
-    id: neverhood
+    id: 'neverhood:neverhood'
     platform: win
     '': ''
     category: ''
@@ -2349,7 +2349,7 @@
     language3: ''
     url: /frs/demos/neverhood/neverhood-win-demo-en.zip
 -
-    id: neverhood
+    id: 'neverhood:neverhood'
     platform: win
     '': ''
     category: Alternative
@@ -2358,7 +2358,7 @@
     language3: ''
     url: /frs/demos/neverhood/neverhood-win-demo2-en.zip
 -
-    id: neverhood
+    id: 'neverhood:neverhood'
     platform: win
     '': ''
     category: Small
@@ -2367,7 +2367,7 @@
     language3: ''
     url: /frs/demos/neverhood/neverhood-win-lite-demo-en.zip
 -
-    id: fullpipe
+    id: 'ngi:fullpipe'
     platform: win
     '': ''
     category: German
@@ -2376,7 +2376,7 @@
     language3: ''
     url: /frs/demos/fullpipe/fullpipe-demo-de.zip
 -
-    id: fullpipe
+    id: 'ngi:fullpipe'
     platform: win
     '': ''
     category: Russian
@@ -2385,7 +2385,7 @@
     language3: ''
     url: /frs/demos/fullpipe/fullpipe-demo-ru.zip
 -
-    id: fullpipe
+    id: 'ngi:fullpipe'
     platform: win
     '': ''
     category: '1997 Demo Release'
@@ -2394,7 +2394,7 @@
     language3: ''
     url: /frs/demos/ngi/fullpipe-97-demo-ru.zip
 -
-    id: bra
+    id: 'parallaction:bra'
     platform: amiga
     '': ''
     category: ''
@@ -2403,7 +2403,7 @@
     language3: ''
     url: /frs/demos/parallaction/bra-amiga-demo-en.zip
 -
-    id: bra
+    id: 'parallaction:bra'
     platform: dos
     '': ''
     category: ''
@@ -2412,7 +2412,7 @@
     language3: ''
     url: /frs/demos/parallaction/bra-dos-demo-en.zip
 -
-    id: nippon
+    id: 'parallaction:nippon'
     platform: amiga
     '': ''
     category: ''
@@ -2421,7 +2421,7 @@
     language3: ''
     url: /frs/demos/parallaction/nippon-amiga-demo-en.zip
 -
-    id: pegasus
+    id: 'pegasus:pegasus'
     platform: mac
     '': ''
     category: DVD
@@ -2430,7 +2430,7 @@
     language3: ''
     url: /frs/demos/pegasus/pegasus-dvd-mac-demo-en.zip
 -
-    id: pegasus
+    id: 'pegasus:pegasus'
     platform: win
     '': ''
     category: DVD
@@ -2439,7 +2439,7 @@
     language3: ''
     url: /frs/demos/pegasus/pegasus-dvd-win-demo-en.zip
 -
-    id: pegasus
+    id: 'pegasus:pegasus'
     platform: mac
     '': ''
     category: 'Mac 1997 release'
@@ -2448,7 +2448,7 @@
     language3: ''
     url: /frs/demos/pegasus/pegasus-mac-97-demo-en.zip
 -
-    id: pegasus
+    id: 'pegasus:pegasus'
     platform: mac
     '': ''
     category: ''
@@ -2457,7 +2457,7 @@
     language3: ''
     url: /frs/demos/pegasus/pegasus-mac-demo-en-nonmac-format.zip
 -
-    id: pegasus
+    id: 'pegasus:pegasus'
     platform: mac
     '': ''
     category: ''
@@ -2466,7 +2466,7 @@
     language3: ''
     url: /frs/demos/pegasus/pegasus-mac-demo-en.zip
 -
-    id: petka1
+    id: 'petka:petka1'
     platform: win
     '': ''
     category: Russian
@@ -2475,7 +2475,7 @@
     language3: ''
     url: /frs/demos/petka/petka1-ru-demo.zip
 -
-    id: private-eye
+    id: 'private:private-eye'
     platform: win
     '': ''
     category: German
@@ -2484,7 +2484,7 @@
     language3: ''
     url: /frs/demos/private/private-eye-demo-de.zip
 -
-    id: private-eye
+    id: 'private:private-eye'
     platform: win
     '': ''
     category: ''
@@ -2493,7 +2493,7 @@
     language3: ''
     url: /frs/demos/private/private-eye-demo-en.zip
 -
-    id: private-eye
+    id: 'private:private-eye'
     platform: win
     '': ''
     category: Spanish
@@ -2502,7 +2502,7 @@
     language3: ''
     url: /frs/demos/private/private-eye-demo-es.zip
 -
-    id: private-eye
+    id: 'private:private-eye'
     platform: win
     '': ''
     category: French
@@ -2511,7 +2511,7 @@
     language3: ''
     url: /frs/demos/private/private-eye-demo-fr.zip
 -
-    id: private-eye
+    id: 'private:private-eye'
     platform: win
     '': ''
     category: UK
@@ -2520,7 +2520,7 @@
     language3: ''
     url: /frs/demos/private/private-eye-demo-uk.zip
 -
-    id: private-eye
+    id: 'private:private-eye'
     platform: mac
     '': ''
     category: US
@@ -2529,7 +2529,7 @@
     language3: ''
     url: /frs/demos/private/private-eye-mac-demo-us.zip
 -
-    id: private-eye
+    id: 'private:private-eye'
     platform: win
     '': ''
     category: US
@@ -2538,7 +2538,7 @@
     language3: ''
     url: /frs/demos/private/private-eye-win-demo-us.zip
 -
-    id: queen
+    id: 'queen:queen'
     platform: amiga
     '': ''
     category: ''
@@ -2547,7 +2547,7 @@
     language3: ''
     url: /frs/demos/queen/queen-amiga-demo-en.zip
 -
-    id: queen
+    id: 'queen:queen'
     platform: amiga
     '': ''
     category: ''
@@ -2556,7 +2556,7 @@
     language3: ''
     url: /frs/demos/queen/queen-amiga-demo-en.zip
 -
-    id: queen
+    id: 'queen:queen'
     platform: amiga
     '': ''
     category: Alternative
@@ -2565,7 +2565,7 @@
     language3: ''
     url: /frs/demos/queen/queen-amiga-demo2-en.zip
 -
-    id: queen
+    id: 'queen:queen'
     platform: amiga
     '': ''
     category: Interview
@@ -2574,7 +2574,7 @@
     language3: ''
     url: /frs/demos/queen/queen-amiga-interview-en.zip
 -
-    id: queen
+    id: 'queen:queen'
     platform: dos
     '': ''
     category: Alternative
@@ -2583,7 +2583,7 @@
     language3: ''
     url: /frs/demos/queen/queen-dos-demo-en-alt.zip
 -
-    id: queen
+    id: 'queen:queen'
     platform: dos
     '': ''
     category: ''
@@ -2592,7 +2592,7 @@
     language3: ''
     url: /frs/demos/queen/queen-dos-demo-en.zip
 -
-    id: queen
+    id: 'queen:queen'
     platform: dos
     '': ''
     category: Interview
@@ -2601,7 +2601,7 @@
     language3: ''
     url: /frs/demos/queen/queen-dos-interview-en.zip
 -
-    id: queen
+    id: 'queen:queen'
     platform: dos
     '': ''
     category: 'Russian Interview'
@@ -2610,7 +2610,7 @@
     language3: ''
     url: /frs/demos/queen/queen-dos-interview-ru.zip
 -
-    id: queen
+    id: 'queen:queen'
     platform: dos
     '': ''
     category: PCGAMES
@@ -2619,7 +2619,7 @@
     language3: ''
     url: /frs/demos/queen/queen-dos-pcgames-demo-en.zip
 -
-    id: ihnm
+    id: 'saga:ihnm'
     platform: dos
     '': ''
     category: ''
@@ -2628,7 +2628,7 @@
     language3: ''
     url: /frs/demos/saga/ihnm-dos-demo-en.zip
 -
-    id: ite
+    id: 'saga:ite'
     platform: amiga
     '': ''
     category: 'Amiga (AGA) Demo'
@@ -2637,7 +2637,7 @@
     language3: ''
     url: /frs/demos/saga/ite-amiga-aga-demo-de.zip
 -
-    id: ite
+    id: 'saga:ite'
     platform: amiga
     '': ''
     category: 'Amiiga (ECS) Demo'
@@ -2646,7 +2646,7 @@
     language3: ''
     url: /frs/demos/saga/ite-amiga-ecs-demo-de.zip
 -
-    id: ite
+    id: 'saga:ite'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -2655,7 +2655,7 @@
     language3: ''
     url: /frs/demos/saga/ite-dos-ni-demo-en.zip
 -
-    id: ite
+    id: 'saga:ite'
     platform: linux
     '': ''
     category: 'Trial Version'
@@ -2664,7 +2664,7 @@
     language3: ''
     url: /frs/demos/saga/ite-linux-trial-demo-en.zip
 -
-    id: ite
+    id: 'saga:ite'
     platform: mac
     '': ''
     category: 'Trial Version'
@@ -2673,7 +2673,7 @@
     language3: ''
     url: /frs/demos/saga/ite-mac-trial-demo-en.zip
 -
-    id: ite
+    id: 'saga:ite'
     platform: win
     '': ''
     category: ''
@@ -2682,7 +2682,7 @@
     language3: ''
     url: /frs/demos/saga/ite-win-new-demo-en.zip
 -
-    id: ite
+    id: 'saga:ite'
     platform: win
     '': ''
     category: ''
@@ -2691,7 +2691,7 @@
     language3: ''
     url: /frs/demos/saga/ite-win-old-demo-en.zip
 -
-    id: ite
+    id: 'saga:ite'
     platform: win
     '': ''
     category: 'Trial Version'
@@ -2700,7 +2700,7 @@
     language3: ''
     url: /frs/demos/saga/ite-win-trial-demo-en.zip
 -
-    id: astrochicken
+    id: 'sci:astrochicken'
     platform: dos
     '': ''
     category: ''
@@ -2709,7 +2709,7 @@
     language3: ''
     url: /frs/demos/sci/astrochicken-dos-demo-en.zip
 -
-    id: camelot
+    id: 'sci:camelot'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -2718,7 +2718,7 @@
     language3: ''
     url: /frs/demos/sci/camelot-dos-ni-demo-en.zip
 -
-    id: castlebrain
+    id: 'sci:castlebrain'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -2727,7 +2727,7 @@
     language3: ''
     url: /frs/demos/sci/castlebrain-dos-ni-demo-en.zip
 -
-    id: christmas1988
+    id: 'sci:christmas1988'
     platform: dos
     '': ''
     category: ''
@@ -2736,7 +2736,7 @@
     language3: ''
     url: /frs/demos/sci/christmas1988-dos-en.zip
 -
-    id: christmas1990
+    id: 'sci:christmas1990'
     platform: dos
     '': ''
     category: EGA
@@ -2745,7 +2745,7 @@
     language3: ''
     url: /frs/demos/sci/christmas1990-dos-ega-en.zip
 -
-    id: christmas1990
+    id: 'sci:christmas1990'
     platform: dos
     '': ''
     category: VGA
@@ -2754,7 +2754,7 @@
     language3: ''
     url: /frs/demos/sci/christmas1990-dos-vga-en.zip
 -
-    id: christmas1992
+    id: 'sci:christmas1992'
     platform: dos
     '': ''
     category: ''
@@ -2763,7 +2763,7 @@
     language3: ''
     url: /frs/demos/sci/christmas1992-dos-en.zip
 -
-    id: ecoquest
+    id: 'sci:ecoquest'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -2772,7 +2772,7 @@
     language3: ''
     url: /frs/demos/sci/ecoquest-dos-ni-demo-en.zip
 -
-    id: ecoquest2
+    id: 'sci:ecoquest2'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -2781,7 +2781,7 @@
     language3: ''
     url: /frs/demos/sci/ecoquest2-dos-ni-demo-en.zip
 -
-    id: fairytales
+    id: 'sci:fairytales'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -2790,7 +2790,7 @@
     language3: ''
     url: /frs/demos/sci/fairytales-dos-ni-demo-en.zip
 -
-    id: freddypharkas
+    id: 'sci:freddypharkas'
     platform: dos
     '': ''
     category: ''
@@ -2799,7 +2799,7 @@
     language3: ''
     url: /frs/demos/sci/freddypharkas-dos-demo1-en.zip
 -
-    id: freddypharkas
+    id: 'sci:freddypharkas'
     platform: dos
     '': ''
     category: Alternative
@@ -2808,7 +2808,7 @@
     language3: ''
     url: /frs/demos/sci/freddypharkas-dos-demo2-en.zip
 -
-    id: freddypharkas
+    id: 'sci:freddypharkas'
     platform: win
     '': ''
     category: ''
@@ -2817,7 +2817,7 @@
     language3: ''
     url: /frs/demos/sci/freddypharkas-win-cd-demo-en.zip
 -
-    id: funseeker
+    id: 'sci:funseeker'
     platform: dos
     '': ''
     category: ''
@@ -2826,7 +2826,7 @@
     language3: ''
     url: /frs/demos/sci/funseeker-dos-demo-en.zip
 -
-    id: gk1
+    id: 'sci:gk1'
     platform: dos
     '': ''
     category: ''
@@ -2835,7 +2835,7 @@
     language3: ''
     url: /frs/demos/sci/gk1-dos-demo-en.zip
 -
-    id: gk2
+    id: 'sci:gk2'
     platform: win
     '': ''
     category: Non-Interactive
@@ -2844,7 +2844,7 @@
     language3: ''
     url: /frs/demos/sci/gk2-win-ni-demo-en.zip
 -
-    id: hoyle3
+    id: 'sci:hoyle3'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -2853,7 +2853,7 @@
     language3: ''
     url: /frs/demos/sci/hoyle3-dos-ni-demo-en.zip
 -
-    id: hoyle4
+    id: 'sci:hoyle4'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -2862,7 +2862,7 @@
     language3: ''
     url: /frs/demos/sci/hoyle4-dos-ni-demo-en.zip
 -
-    id: hoyle5
+    id: 'sci:hoyle5'
     platform: dos
     '': ''
     category: ''
@@ -2871,7 +2871,7 @@
     language3: ''
     url: /frs/demos/sci/hoyle5-win-demo-en.zip
 -
-    id: iceman
+    id: 'sci:iceman'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -2880,7 +2880,7 @@
     language3: ''
     url: /frs/demos/sci/iceman-dos-ni-demo-en.zip
 -
-    id: inndemo
+    id: 'sci:inndemo'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -2889,7 +2889,7 @@
     language3: ''
     url: /frs/demos/sci/inn-dos-ni-demo-en.zip
 -
-    id: islandbrain
+    id: 'sci:islandbrain'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -2898,7 +2898,7 @@
     language3: ''
     url: /frs/demos/sci/islandbrain-dos-ni-demo-en.zip
 -
-    id: kq1sci
+    id: 'sci:kq1sci'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -2907,7 +2907,7 @@
     language3: ''
     url: /frs/demos/sci/kq1sci-dos-ni-demo-en.zip
 -
-    id: kq4sci
+    id: 'sci:kq4sci'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -2916,7 +2916,7 @@
     language3: ''
     url: /frs/demos/sci/kq4sci-dos-ni-demo-en.zip
 -
-    id: kq6
+    id: 'sci:kq6'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -2925,7 +2925,7 @@
     language3: ''
     url: /frs/demos/sci/kq6-dos-ni-demo-en.zip
 -
-    id: kq7
+    id: 'sci:kq7'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -2934,7 +2934,7 @@
     language3: ''
     url: /frs/demos/sci/kq7-dos-win-ni-demo-en.zip
 -
-    id: laurabow
+    id: 'sci:laurabow'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -2943,7 +2943,7 @@
     language3: ''
     url: /frs/demos/sci/laurabow-dos-ni-demo-en.zip
 -
-    id: laurabow2
+    id: 'sci:laurabow2'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -2952,7 +2952,7 @@
     language3: ''
     url: /frs/demos/sci/laurabow2-dos-ni-demo-en.zip
 -
-    id: lighthouse
+    id: 'sci:lighthouse'
     platform: win
     '': ''
     category: ''
@@ -2961,7 +2961,7 @@
     language3: ''
     url: /frs/demos/sci/lighthouse-win-demo-en.zip
 -
-    id: lighthouse
+    id: 'sci:lighthouse'
     platform: win
     '': ''
     category: ''
@@ -2970,7 +2970,7 @@
     language3: ''
     url: /frs/demos/sci/lighthouse-win-demo2-en.zip
 -
-    id: lighthouse
+    id: 'sci:lighthouse'
     platform: win
     '': ''
     category: Non-Interactive
@@ -2979,7 +2979,7 @@
     language3: ''
     url: /frs/demos/sci/lighthouse-win-ni-demo-en.zip
 -
-    id: longbow
+    id: 'sci:longbow'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -2988,7 +2988,7 @@
     language3: ''
     url: /frs/demos/sci/longbow-dos-ni-demo-en.zip
 -
-    id: lsl1sci
+    id: 'sci:lsl1sci'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -2997,7 +2997,7 @@
     language3: ''
     url: /frs/demos/sci/lsl1sci-dos-ni-demo-en.zip
 -
-    id: lsl2
+    id: 'sci:lsl2'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -3006,7 +3006,7 @@
     language3: ''
     url: /frs/demos/sci/lsl2-dos-ni-demo-en.zip
 -
-    id: lsl3
+    id: 'sci:lsl3'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -3015,7 +3015,7 @@
     language3: ''
     url: /frs/demos/sci/lsl3-dos-ni-demo-en.zip
 -
-    id: lsl5
+    id: 'sci:lsl5'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -3024,7 +3024,7 @@
     language3: ''
     url: /frs/demos/sci/lsl5-dos-ni-demo-en.zip
 -
-    id: lsl6
+    id: 'sci:lsl6'
     platform: dos
     '': ''
     category: Non-Engine
@@ -3033,7 +3033,7 @@
     language3: ''
     url: /frs/demos/sci/Non-Engine/lsl6-dos-ni-demo-en.zip
 -
-    id: lsl7
+    id: 'sci:lsl7'
     platform: dos
     '': ''
     category: ''
@@ -3042,7 +3042,7 @@
     language3: ''
     url: /frs/demos/sci/lsl7-dos-demo-en.zip
 -
-    id: mothergoose
+    id: 'sci:mothergoose'
     platform: dos
     '': ''
     category: ''
@@ -3051,7 +3051,7 @@
     language3: ''
     url: /frs/demos/sci/mothergoose-win-demo-en.zip
 -
-    id: msastrochicken
+    id: 'sci:msastrochicken'
     platform: dos
     '': ''
     category: ''
@@ -3060,7 +3060,7 @@
     language3: ''
     url: /frs/demos/sci/msastrochicken-dos-demo-en.zip
 -
-    id: pepper
+    id: 'sci:pepper'
     platform: dos
     '': ''
     category: ''
@@ -3069,7 +3069,7 @@
     language3: ''
     url: /frs/demos/sci/pepper-dos-demo-en.zip
 -
-    id: pepper
+    id: 'sci:pepper'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -3078,7 +3078,7 @@
     language3: ''
     url: /frs/demos/sci/pepper-dos-ni-demo-en.zip
 -
-    id: pepper
+    id: 'sci:pepper'
     platform: win
     '': ''
     category: ''
@@ -3087,7 +3087,7 @@
     language3: ''
     url: /frs/demos/sci/pepper-dos-win-demo-en.zip
 -
-    id: phantasmagoria
+    id: 'sci:phantasmagoria'
     platform: dos
     '': ''
     category: ''
@@ -3096,7 +3096,7 @@
     language3: ''
     url: /frs/demos/sci/phantasmagoria-dos-win-demo-en.zip
 -
-    id: phantasmagoria
+    id: 'sci:phantasmagoria'
     platform: dos
     '': ''
     category: Alternative
@@ -3105,7 +3105,7 @@
     language3: ''
     url: /frs/demos/sci/phantasmagoria-dos-win-demo1-en.zip
 -
-    id: pq2
+    id: 'sci:pq2'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -3114,7 +3114,7 @@
     language3: ''
     url: /frs/demos/sci/pq2-dos-ni-demo-en.zip
 -
-    id: pq3
+    id: 'sci:pq3'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -3123,7 +3123,7 @@
     language3: ''
     url: /frs/demos/sci/pq3-dos-ni-demo-en.zip
 -
-    id: pq4
+    id: 'sci:pq4'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -3132,7 +3132,7 @@
     language3: ''
     url: /frs/demos/sci/pq4-dos-ni-demo-en.zip
 -
-    id: pqswat
+    id: 'sci:pqswat'
     platform: win
     '': ''
     category: Unsupported
@@ -3141,7 +3141,7 @@
     language3: ''
     url: /frs/demos/sci/pqswat-win-demo-en.zip
 -
-    id: qfg1vga
+    id: 'sci:qfg1vga'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -3150,7 +3150,7 @@
     language3: ''
     url: /frs/demos/sci/qfg1vga-dos-ni-demo-en.zip
 -
-    id: qfg2
+    id: 'sci:qfg2'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -3159,7 +3159,7 @@
     language3: ''
     url: /frs/demos/sci/qfg2-dos-ni-demo-en.zip
 -
-    id: qfg3
+    id: 'sci:qfg3'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -3168,7 +3168,7 @@
     language3: ''
     url: /frs/demos/sci/qfg3-dos-ni-demo-en.zip
 -
-    id: qfg4
+    id: 'sci:qfg4'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -3177,7 +3177,7 @@
     language3: ''
     url: /frs/demos/sci/qfg4-dos-ni-demo-en.zip
 -
-    id: rama
+    id: 'sci:rama'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -3186,7 +3186,7 @@
     language3: ''
     url: /frs/demos/sci/rama-dos-win-ni-demo-en.zip
 -
-    id: realm
+    id: 'sci:realm'
     platform: win
     '': ''
     category: ''
@@ -3195,7 +3195,7 @@
     language3: ''
     url: /frs/demos/sci/realm-win-demo-en.zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'Fanmade Game'
@@ -3204,7 +3204,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/120_Degrees_Below_Zero.zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'Al Pond 2: Island Quest'
@@ -3213,7 +3213,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/Al_Pond_2-_Island_Quest.zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'Another DG Game: I Want My C64 Back'
@@ -3222,7 +3222,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/Another_DG_Game-_I_want_my_C64_back_(French).zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'Another DG Game: I Want My C64 Back'
@@ -3231,7 +3231,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/Another_DG_Game-_I_want_my_C64_back.zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'Aquarius: An Aquatic Experience'
@@ -3240,7 +3240,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/Aquarius-_an_Aquatic_Experience.zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'Betrayed Alliance'
@@ -3249,7 +3249,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/BetrayedAllianceSetupSRC.exe
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'Bluntman and Chronic (Politically Correct Version)'
@@ -3258,7 +3258,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/Bluntman_and_Chronic_PC_version.zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'Cascade Quest'
@@ -3267,7 +3267,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/Cascade_Quest_Demo.zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'Circus Quest'
@@ -3276,7 +3276,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/Circus_Quest.zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'Demo Quest'
@@ -3285,7 +3285,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/Demo_Quest.zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'Edy Oliver into the Cave of Whistling Skulls Demo'
@@ -3294,7 +3294,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/Edy_Oliver_into_the_Cave_of_Whistling_Skulls.zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'The Farm Nightmare'
@@ -3303,7 +3303,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/Farm_Nightmare.zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'Footsteps Sound Demo'
@@ -3312,7 +3312,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/Footsteps_Sound_Demo.zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'The Gem Scenario'
@@ -3321,7 +3321,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/Gem_Scenario.zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'Grostesteing: Plus Mechant que Jamais (French)'
@@ -3330,7 +3330,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/Grostesteing-_plus_mechant_que_jamais.zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'Humanoid Demo'
@@ -3339,7 +3339,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/HUMANOID_Demo_(Polish).zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'Island of Secrets Demo 0.3'
@@ -3348,7 +3348,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/Island_of_Secrets_v0_3_(Demo).zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'Jim''s Quest 1: The Phantom Thesis'
@@ -3357,7 +3357,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/Jims_Quest_1-_The_Phantom_Thesis.zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'Dr. Jummybummy''s Space Adventure 2'
@@ -3366,7 +3366,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/jummy2.zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'King''s Quest II SCI Pre-Alpha Version'
@@ -3375,7 +3375,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/Kings_Quest_II_SCI_2013-02-01.zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'Knight''s Quest Demo 1.0'
@@ -3384,7 +3384,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/Knights_Quest_Demo.zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'The Legend of the Lost Jewel'
@@ -3393,7 +3393,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/Legend_of_the_Lost_Jewel_Demo.zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'LockerGnome Quest Redux'
@@ -3402,7 +3402,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/LockerGnome_Quest_Redux.zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'LockerGnome Quest'
@@ -3411,7 +3411,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/LockerGnome_Quest.zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'Ocean Battle'
@@ -3420,7 +3420,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/Ocean_Battle.zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'Osama Been Skatin'
@@ -3429,7 +3429,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/Osama_Been_Skatin.zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'Quest for the Cheat'
@@ -3438,7 +3438,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/Quest_for_the_Cheat.zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'Robust Parse Demo 1.2'
@@ -3447,7 +3447,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/Robust_Parse_Demo_v1_2.zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'SCI Capture the Flag'
@@ -3456,7 +3456,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/SCI_Capture_the_Flag_(minigame).zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'SCI Logging Demo'
@@ -3465,7 +3465,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/SCI_Logging_Demo.zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'SCI Narration Demo'
@@ -3474,7 +3474,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/SCI_Narration_Demo.zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'SCI Quest'
@@ -3483,7 +3483,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/SCI_Quest.zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: SCI-Man
@@ -3492,7 +3492,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/SCI-Man.zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'Text Views Demo'
@@ -3501,7 +3501,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/Text_Views_(demo).zip
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     platform: dos
     '': ''
     category: 'Winter Wonderland'
@@ -3510,7 +3510,7 @@
     language3: ''
     url: /frs/demos/sci/fangame/Winter_Wonderland.zip
 -
-    id: shivers
+    id: 'sci:shivers'
     platform: win
     '': ''
     category: CD
@@ -3519,7 +3519,7 @@
     language3: ''
     url: /frs/demos/sci/shivers-win-cd-demo-en.zip
 -
-    id: shivers
+    id: 'sci:shivers'
     platform: win
     '': ''
     category: Non-Interactive
@@ -3528,7 +3528,7 @@
     language3: ''
     url: /frs/demos/sci/shivers-win-demo-en.zip
 -
-    id: shivers
+    id: 'sci:shivers'
     platform: win
     '': ''
     category: ''
@@ -3537,7 +3537,7 @@
     language3: ''
     url: /frs/demos/sci/shivers-win-demo2-en.zip
 -
-    id: shivers2
+    id: 'sci:shivers2'
     platform: win
     '': ''
     category: Non-Engine
@@ -3546,7 +3546,7 @@
     language3: ''
     url: /frs/demos/sci/Non-Engine/shivers2-win-demo-en.zip
 -
-    id: slater
+    id: 'sci:slater'
     platform: dos
     '': ''
     category: ''
@@ -3555,7 +3555,7 @@
     language3: ''
     url: /frs/demos/sci/slater-dos-demo.en.zip
 -
-    id: sq1sci
+    id: 'sci:sq1sci'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -3564,7 +3564,7 @@
     language3: ''
     url: /frs/demos/sci/sq1sci-dos-ni-demo-en.zip
 -
-    id: sq3
+    id: 'sci:sq3'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -3573,7 +3573,7 @@
     language3: ''
     url: /frs/demos/sci/sq3-dos-ni-demo-en.zip
 -
-    id: sq5
+    id: 'sci:sq5'
     platform: dos
     '': ''
     category: Non-Engine
@@ -3582,7 +3582,7 @@
     language3: ''
     url: /frs/demos/sci/Non-Engine/sq5-dos-ni-demo-en.zip
 -
-    id: sq6
+    id: 'sci:sq6'
     platform: dos
     '': ''
     category: ''
@@ -3591,7 +3591,7 @@
     language3: ''
     url: /frs/demos/sci/sq6-dos-demo-en.zip
 -
-    id: sq6
+    id: 'sci:sq6'
     platform: win
     '': ''
     category: ''
@@ -3600,7 +3600,7 @@
     language3: ''
     url: /frs/demos/sci/sq6-win-demo1-en.zip
 -
-    id: sq6
+    id: 'sci:sq6'
     platform: win
     '': ''
     category: Alternative
@@ -3609,7 +3609,7 @@
     language3: ''
     url: /frs/demos/sci/sq6-win-demo2-en.zip
 -
-    id: torin
+    id: 'sci:torin'
     platform: win
     '': ''
     category: ''
@@ -3618,7 +3618,7 @@
     language3: ''
     url: /frs/demos/sci/torin-dos-win-demo-en.zip
 -
-    id: airport
+    id: 'scumm:airport'
     platform: mac
     '': ''
     category: ''
@@ -3627,7 +3627,7 @@
     language3: ''
     url: /frs/demos/scumm/he/airport-mac-demo-us.zip
 -
-    id: airport
+    id: 'scumm:airport'
     platform: win
     '': ''
     category: Dutch
@@ -3636,7 +3636,7 @@
     language3: ''
     url: /frs/demos/scumm/he/airport-win-demo-nl.zip
 -
-    id: airport
+    id: 'scumm:airport'
     platform: win
     '': ''
     category: ''
@@ -3645,7 +3645,7 @@
     language3: ''
     url: /frs/demos/scumm/he/airport-win-demo-us.zip
 -
-    id: airport
+    id: 'scumm:airport'
     platform: win
     '': ''
     category: Updated
@@ -3654,7 +3654,7 @@
     language3: ''
     url: /frs/demos/scumm/he/airport-win-updated-demo1-us.zip
 -
-    id: airport
+    id: 'scumm:airport'
     platform: win
     '': ''
     category: 'Updated Alternative'
@@ -3663,7 +3663,7 @@
     language3: ''
     url: /frs/demos/scumm/he/airport-win-updated-demo2-us.zip
 -
-    id: atlantis
+    id: 'scumm:atlantis'
     platform: dos
     '': ''
     category: ''
@@ -3672,7 +3672,7 @@
     language3: ''
     url: /frs/demos/scumm/atlantis-dos-demo1-en.zip
 -
-    id: atlantis
+    id: 'scumm:atlantis'
     platform: dos
     '': ''
     category: Alternative
@@ -3681,7 +3681,7 @@
     language3: ''
     url: /frs/demos/scumm/atlantis-dos-demo2-en.zip
 -
-    id: atlantis
+    id: 'scumm:atlantis'
     platform: dos
     '': ''
     category: 'Alternative 2'
@@ -3690,7 +3690,7 @@
     language3: ''
     url: /frs/demos/scumm/atlantis-dos-demo3-en.zip
 -
-    id: atlantis
+    id: 'scumm:atlantis'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -3699,7 +3699,7 @@
     language3: ''
     url: /frs/demos/scumm/atlantis-dos-ni-demo-en.zip
 -
-    id: atlantis
+    id: 'scumm:atlantis'
     platform: fmtowns
     '': ''
     category: 'Japanese Non-Interactive'
@@ -3708,7 +3708,7 @@
     language3: ''
     url: /frs/demos/scumm/atlantis-fmtowns-ni-demo-jp.zip
 -
-    id: atlantis
+    id: 'scumm:atlantis'
     platform: mac
     '': ''
     category: ''
@@ -3717,7 +3717,7 @@
     language3: ''
     url: /frs/demos/scumm/atlantis-mac-demo.zip
 -
-    id: baseball
+    id: 'scumm:baseball'
     platform: win
     '': ''
     category: Preview
@@ -3726,7 +3726,7 @@
     language3: ''
     url: /frs/demos/scumm/he/baseball-win-preview1-us.zip
 -
-    id: baseball
+    id: 'scumm:baseball'
     platform: win
     '': ''
     category: 'Alternative Preview'
@@ -3735,7 +3735,7 @@
     language3: ''
     url: /frs/demos/scumm/he/baseball-win-preview2-us.zip
 -
-    id: baseball2001
+    id: 'scumm:baseball2001'
     platform: win
     '': ''
     category: ''
@@ -3744,7 +3744,7 @@
     language3: ''
     url: /frs/demos/scumm/he/baseball2001-win-demo-us.zip
 -
-    id: bluesabctime
+    id: 'scumm:bluesabctime'
     platform: win
     '': ''
     category: ''
@@ -3753,7 +3753,7 @@
     language3: ''
     url: /frs/demos/scumm/he/BluesABCTime-win-demo1-us.zip
 -
-    id: bluesabctime
+    id: 'scumm:bluesabctime'
     platform: win
     '': ''
     category: Alternative
@@ -3762,7 +3762,7 @@
     language3: ''
     url: /frs/demos/scumm/he/BluesABCTime-win-demo2-us.zip
 -
-    id: bluesabctime
+    id: 'scumm:bluesabctime'
     platform: win
     '': ''
     category: Preview
@@ -3771,7 +3771,7 @@
     language3: ''
     url: /frs/demos/scumm/he/BluesABCTime-win-preview-us.zip
 -
-    id: bluesbirthday
+    id: 'scumm:bluesbirthday'
     platform: win
     '': ''
     category: ''
@@ -3780,7 +3780,7 @@
     language3: ''
     url: /frs/demos/scumm/he/BluesBirthday-win-demo1-us.zip
 -
-    id: bluesbirthday
+    id: 'scumm:bluesbirthday'
     platform: win
     '': ''
     category: Alternative
@@ -3789,7 +3789,7 @@
     language3: ''
     url: /frs/demos/scumm/he/BluesBirthday-win-demo2-us.zip
 -
-    id: bluesbirthday
+    id: 'scumm:bluesbirthday'
     platform: win
     '': ''
     category: Preview
@@ -3798,7 +3798,7 @@
     language3: ''
     url: /frs/demos/scumm/he/BluesBirthday-win-preview-us.zip
 -
-    id: brstorm
+    id: 'scumm:brstorm'
     platform: dos
     '': ''
     category: ''
@@ -3807,7 +3807,7 @@
     language3: ''
     url: /frs/demos/scumm/he/brstorm-dos-demo-us.zip
 -
-    id: catalog
+    id: 'scumm:catalog'
     platform: win
     '': ''
     category: ''
@@ -3816,7 +3816,7 @@
     language3: ''
     url: /frs/demos/scumm/he/catalog-win-demo-en.zip
 -
-    id: catalog
+    id: 'scumm:catalog'
     platform: win
     '': ''
     category: German
@@ -3825,7 +3825,7 @@
     language3: ''
     url: /frs/demos/scumm/he/catalog-win-preview-de.zip
 -
-    id: catalog
+    id: 'scumm:catalog'
     platform: win
     '': ''
     category: French
@@ -3834,7 +3834,7 @@
     language3: ''
     url: /frs/demos/scumm/he/catalog-win-preview-fr.zip
 -
-    id: catalog
+    id: 'scumm:catalog'
     platform: win
     '': ''
     category: UK
@@ -3843,7 +3843,7 @@
     language3: ''
     url: /frs/demos/scumm/he/catalog-win-preview-uk.zip
 -
-    id: catalog
+    id: 'scumm:catalog'
     platform: win
     '': ''
     category: US
@@ -3852,7 +3852,7 @@
     language3: ''
     url: /frs/demos/scumm/he/catalog-win-preview-us.zip
 -
-    id: comi
+    id: 'scumm:comi'
     platform: win
     '': ''
     category: Large
@@ -3861,7 +3861,7 @@
     language3: ''
     url: /frs/demos/scumm/comi-win-large-demo-en.zip
 -
-    id: comi
+    id: 'scumm:comi'
     platform: win
     '': ''
     category: Small
@@ -3870,7 +3870,7 @@
     language3: ''
     url: /frs/demos/scumm/comi-win-small-demo-en.zip
 -
-    id: dig
+    id: 'scumm:dig'
     platform: dos
     '': ''
     category: CD
@@ -3879,7 +3879,7 @@
     language3: ''
     url: /frs/demos/scumm/dig-dos-demo-en.zip
 -
-    id: dig
+    id: 'scumm:dig'
     platform: mac
     '': ''
     category: ''
@@ -3888,7 +3888,7 @@
     language3: ''
     url: /frs/demos/scumm/dig-mac-demo-en.zip
 -
-    id: farm
+    id: 'scumm:farm'
     platform: win
     '': ''
     category: Dutch
@@ -3897,7 +3897,7 @@
     language3: ''
     url: /frs/demos/scumm/he/farm-win-demo-nl.zip
 -
-    id: farm
+    id: 'scumm:farm'
     platform: win
     '': ''
     category: ''
@@ -3906,7 +3906,7 @@
     language3: ''
     url: /frs/demos/scumm/he/farm-win-demo-us.zip
 -
-    id: farm
+    id: 'scumm:farm'
     platform: win
     '': ''
     category: Updated
@@ -3915,7 +3915,7 @@
     language3: ''
     url: /frs/demos/scumm/he/farm-win-updated-demo-us.zip
 -
-    id: fbear
+    id: 'scumm:fbear'
     platform: dos
     '': ''
     category: ''
@@ -3924,7 +3924,7 @@
     language3: ''
     url: /frs/demos/scumm/he/fbear-dos-demo-us.zip
 -
-    id: fbear
+    id: 'scumm:fbear'
     platform: mac
     '': ''
     category: ''
@@ -3933,7 +3933,7 @@
     language3: ''
     url: /frs/demos/scumm/he/fbear-mac-demo-us.zip
 -
-    id: fbear
+    id: 'scumm:fbear'
     platform: win
     '': ''
     category: ''
@@ -3942,7 +3942,7 @@
     language3: ''
     url: /frs/demos/scumm/he/fbear-win-demo-us.zip
 -
-    id: football
+    id: 'scumm:football'
     platform: win
     '': ''
     category: ''
@@ -3951,7 +3951,7 @@
     language3: ''
     url: /frs/demos/scumm/he/football-win-demo-us.zip
 -
-    id: freddi
+    id: 'scumm:freddi'
     platform: mac
     '': ''
     category: ''
@@ -3960,7 +3960,7 @@
     language3: ''
     url: /frs/demos/scumm/he/freddi-mac-demo_us.zip
 -
-    id: freddi
+    id: 'scumm:freddi'
     platform: win
     '': ''
     category: German
@@ -3969,7 +3969,7 @@
     language3: ''
     url: /frs/demos/scumm/he/freddi-win-demo-de.zip
 -
-    id: freddi
+    id: 'scumm:freddi'
     platform: win
     '': ''
     category: French
@@ -3978,7 +3978,7 @@
     language3: ''
     url: /frs/demos/scumm/he/freddi-win-demo-fr.zip
 -
-    id: freddi
+    id: 'scumm:freddi'
     platform: win
     '': ''
     category: Dutch
@@ -3987,7 +3987,7 @@
     language3: ''
     url: /frs/demos/scumm/he/freddi-win-demo-nl.zip
 -
-    id: freddi
+    id: 'scumm:freddi'
     platform: win
     '': ''
     category: ''
@@ -3996,7 +3996,7 @@
     language3: ''
     url: /frs/demos/scumm/he/freddi-win-demo-us.zip
 -
-    id: freddi
+    id: 'scumm:freddi'
     platform: win
     '': ''
     category: Updated
@@ -4005,7 +4005,7 @@
     language3: ''
     url: /frs/demos/scumm/he/freddi-win-updated-demo-us.zip
 -
-    id: freddi2
+    id: 'scumm:freddi2'
     platform: win
     '': ''
     category: Dutch
@@ -4014,7 +4014,7 @@
     language3: ''
     url: /frs/demos/scumm/he/freddi2-win-demo-nl.zip
 -
-    id: freddi2
+    id: 'scumm:freddi2'
     platform: win
     '': ''
     category: ''
@@ -4023,7 +4023,7 @@
     language3: ''
     url: /frs/demos/scumm/he/freddi2-win-demo-us.zip
 -
-    id: freddi2
+    id: 'scumm:freddi2'
     platform: win
     '': ''
     category: Updated
@@ -4032,7 +4032,7 @@
     language3: ''
     url: /frs/demos/scumm/he/freddi2-win-updated-demo-us.zip
 -
-    id: freddi3
+    id: 'scumm:freddi3'
     platform: win
     '': ''
     category: French
@@ -4041,7 +4041,7 @@
     language3: ''
     url: /frs/demos/scumm/he/freddi3-win-demo-fr.zip
 -
-    id: freddi3
+    id: 'scumm:freddi3'
     platform: win
     '': ''
     category: Hebrew
@@ -4050,7 +4050,7 @@
     language3: ''
     url: /frs/demos/scumm/he/freddi3-win-demo-hb.zip
 -
-    id: freddi3
+    id: 'scumm:freddi3'
     platform: win
     '': ''
     category: Dutch
@@ -4059,7 +4059,7 @@
     language3: ''
     url: /frs/demos/scumm/he/freddi3-win-demo-nl.zip
 -
-    id: freddi3
+    id: 'scumm:freddi3'
     platform: win
     '': ''
     category: ''
@@ -4068,7 +4068,7 @@
     language3: ''
     url: /frs/demos/scumm/he/freddi3-win-demo-us.zip
 -
-    id: freddi4
+    id: 'scumm:freddi4'
     platform: win
     '': ''
     category: German
@@ -4077,7 +4077,7 @@
     language3: ''
     url: /frs/demos/scumm/he/freddi4-win-demo-de.zip
 -
-    id: freddi4
+    id: 'scumm:freddi4'
     platform: win
     '': ''
     category: Italian
@@ -4086,7 +4086,7 @@
     language3: ''
     url: /frs/demos/scumm/he/freddi4-win-demo-it.zip
 -
-    id: freddi4
+    id: 'scumm:freddi4'
     platform: win
     '': ''
     category: UK
@@ -4095,7 +4095,7 @@
     language3: ''
     url: /frs/demos/scumm/he/freddi4-win-demo-uk.zip
 -
-    id: freddi4
+    id: 'scumm:freddi4'
     platform: win
     '': ''
     category: ''
@@ -4104,7 +4104,7 @@
     language3: ''
     url: /frs/demos/scumm/he/freddi4-win-demo-us.zip
 -
-    id: freddi4
+    id: 'scumm:freddi4'
     platform: win
     '': ''
     category: French
@@ -4113,7 +4113,7 @@
     language3: ''
     url: /frs/demos/scumm/he/freddi4-win-demo.fr.zip
 -
-    id: freddi4
+    id: 'scumm:freddi4'
     platform: win
     '': ''
     category: Dutch
@@ -4122,7 +4122,7 @@
     language3: ''
     url: /frs/demos/scumm/he/freddi4-win-demo1-nl.zip
 -
-    id: freddi4
+    id: 'scumm:freddi4'
     platform: win
     '': ''
     category: 'Dutch Alternative'
@@ -4131,7 +4131,7 @@
     language3: ''
     url: /frs/demos/scumm/he/freddi4-win-demo2-nl.zip
 -
-    id: freddi4
+    id: 'scumm:freddi4'
     platform: win
     '': ''
     category: 'Dutch Alternative 2'
@@ -4140,7 +4140,7 @@
     language3: ''
     url: /frs/demos/scumm/he/freddi4-win-demo3-nl.zip
 -
-    id: freddi4
+    id: 'scumm:freddi4'
     platform: win
     '': ''
     category: Updated
@@ -4149,7 +4149,7 @@
     language3: ''
     url: /frs/demos/scumm/he/freddi4-win-updated-demo-us.zip
 -
-    id: freddicove
+    id: 'scumm:freddicove'
     platform: win
     '': ''
     category: ''
@@ -4158,7 +4158,7 @@
     language3: ''
     url: /frs/demos/scumm/he/arttime-win-demo-us.zip
 -
-    id: freddicove
+    id: 'scumm:freddicove'
     platform: win
     '': ''
     category: Dutch
@@ -4167,7 +4167,7 @@
     language3: ''
     url: /frs/demos/scumm/he/freddicove-win-demo-nl.zip
 -
-    id: freddicove
+    id: 'scumm:freddicove'
     platform: win
     '': ''
     category: ''
@@ -4176,7 +4176,7 @@
     language3: ''
     url: /frs/demos/scumm/he/freddicove-win-demo-us.zip
 -
-    id: freddicove
+    id: 'scumm:freddicove'
     platform: win
     '': ''
     category: ''
@@ -4185,7 +4185,7 @@
     language3: ''
     url: /frs/demos/scumm/he/readtime-win-demo-us.zip
 -
-    id: ft
+    id: 'scumm:ft'
     platform: dos
     '': ''
     category: ''
@@ -4194,7 +4194,7 @@
     language3: ''
     url: /frs/demos/scumm/ft-dos-demo-en.zip
 -
-    id: ft
+    id: 'scumm:ft'
     platform: mac
     '': ''
     category: ''
@@ -4203,7 +4203,7 @@
     language3: ''
     url: /frs/demos/scumm/ft-mac-demo-en.zip
 -
-    id: ft
+    id: 'scumm:ft'
     platform: mac
     '': ''
     category: Trailer
@@ -4212,7 +4212,7 @@
     language3: ''
     url: /frs/demos/scumm/ft-mac-ni-demo-en.zip
 -
-    id: indy3
+    id: 'scumm:indy3'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -4221,7 +4221,7 @@
     language3: ''
     url: /frs/demos/scumm/indy3-ega-ni-demo-en.zip
 -
-    id: loom
+    id: 'scumm:loom'
     platform: dos
     '': ''
     category: 'Long Non-Interactive'
@@ -4230,7 +4230,7 @@
     language3: ''
     url: /frs/demos/scumm/loom-dos-long-demo-en.zip
 -
-    id: loom
+    id: 'scumm:loom'
     platform: dos
     '': ''
     category: 'Short Non-Interactive'
@@ -4239,7 +4239,7 @@
     language3: ''
     url: /frs/demos/scumm/loom-dos-short-demo-en.zip
 -
-    id: lost
+    id: 'scumm:lost'
     platform: win
     '': ''
     category: ''
@@ -4248,7 +4248,7 @@
     language3: ''
     url: /frs/demos/scumm/he/lost-win-demo-us.zip
 -
-    id: maniac
+    id: 'scumm:maniac'
     platform: c64
     '': ''
     category: ''
@@ -4257,7 +4257,7 @@
     language3: ''
     url: /frs/demos/scumm/maniac-c64-demo-en.zip
 -
-    id: maniac
+    id: 'scumm:maniac'
     platform: dos
     '': ''
     category: 'V1 Non-Interactive'
@@ -4266,7 +4266,7 @@
     language3: ''
     url: /frs/demos/scumm/maniac-dos-v1-ni-demo-en.zip
 -
-    id: maniac
+    id: 'scumm:maniac'
     platform: dos
     '': ''
     category: 'V2 Non-Interactive'
@@ -4275,7 +4275,7 @@
     language3: ''
     url: /frs/demos/scumm/maniac-dos-v2-ni-demo-en.zip
 -
-    id: monkey
+    id: 'scumm:monkey'
     platform: amiga
     '': ''
     category: ''
@@ -4284,7 +4284,7 @@
     language3: ''
     url: /frs/demos/scumm/monkey1-amiga-demo-en.zip
 -
-    id: monkey
+    id: 'scumm:monkey'
     platform: dos
     '': ''
     category: 'German EGA'
@@ -4293,7 +4293,7 @@
     language3: ''
     url: /frs/demos/scumm/monkey1-dos-ega-demo-de.zip
 -
-    id: monkey
+    id: 'scumm:monkey'
     platform: dos
     '': ''
     category: EGA
@@ -4302,7 +4302,7 @@
     language3: ''
     url: /frs/demos/scumm/monkey1-dos-ega-demo-en.zip
 -
-    id: monkey2
+    id: 'scumm:monkey2'
     platform: dos
     '': ''
     category: Unsupported
@@ -4311,7 +4311,7 @@
     language3: ''
     url: /frs/demos/scumm/monkey2-dos-ni-demo-en.zip
 -
-    id: monkey2
+    id: 'scumm:monkey2'
     platform: dos
     '': ''
     category: 'Non-Engine (Slideshow)'
@@ -4320,7 +4320,7 @@
     language3: ''
     url: /frs/demos/scumm/Non-Engine/mi2-dos-ni-slideshow-demo-en.zip
 -
-    id: moonbase
+    id: 'scumm:moonbase'
     platform: win
     '': ''
     category: ''
@@ -4329,7 +4329,7 @@
     language3: ''
     url: /frs/demos/scumm/he/moonbase-win-demo-us.zip
 -
-    id: pajama
+    id: 'scumm:pajama'
     platform: win
     '': ''
     category: French
@@ -4338,7 +4338,7 @@
     language3: ''
     url: /frs/demos/scumm/he/pajama-win-demo-fr.zip
 -
-    id: pajama
+    id: 'scumm:pajama'
     platform: win
     '': ''
     category: ''
@@ -4347,7 +4347,7 @@
     language3: ''
     url: /frs/demos/scumm/he/pajama-win-demo-us.zip
 -
-    id: pajama
+    id: 'scumm:pajama'
     platform: win
     '': ''
     category: Updated
@@ -4356,7 +4356,7 @@
     language3: ''
     url: /frs/demos/scumm/he/pajama-win-updated-demo-us.zip
 -
-    id: pajama2
+    id: 'scumm:pajama2'
     platform: win
     '': ''
     category: Hebrew
@@ -4365,7 +4365,7 @@
     language3: ''
     url: /frs/demos/scumm/he/pajama2-win-demo-hb.zip
 -
-    id: pajama2
+    id: 'scumm:pajama2'
     platform: win
     '': ''
     category: Dutch
@@ -4374,7 +4374,7 @@
     language3: ''
     url: /frs/demos/scumm/he/pajama2-win-demo-nl.zip
 -
-    id: pajama2
+    id: 'scumm:pajama2'
     platform: win
     '': ''
     category: ''
@@ -4383,7 +4383,7 @@
     language3: ''
     url: /frs/demos/scumm/he/pajama2-win-demo-us.zip
 -
-    id: pajama3
+    id: 'scumm:pajama3'
     platform: win
     '': ''
     category: German
@@ -4392,7 +4392,7 @@
     language3: ''
     url: /frs/demos/scumm/he/pajama3-win-demo-de.zip
 -
-    id: pajama3
+    id: 'scumm:pajama3'
     platform: win
     '': ''
     category: French
@@ -4401,7 +4401,7 @@
     language3: ''
     url: /frs/demos/scumm/he/pajama3-win-demo-fr.zip
 -
-    id: pajama3
+    id: 'scumm:pajama3'
     platform: win
     '': ''
     category: Italian
@@ -4410,7 +4410,7 @@
     language3: ''
     url: /frs/demos/scumm/he/pajama3-win-demo-it.zip
 -
-    id: pajama3
+    id: 'scumm:pajama3'
     platform: win
     '': ''
     category: Dutch
@@ -4419,7 +4419,7 @@
     language3: ''
     url: /frs/demos/scumm/he/pajama3-win-demo-nl.zip
 -
-    id: pajama3
+    id: 'scumm:pajama3'
     platform: win
     '': ''
     category: UK
@@ -4428,7 +4428,7 @@
     language3: ''
     url: /frs/demos/scumm/he/pajama3-win-demo-uk.zip
 -
-    id: pajama3
+    id: 'scumm:pajama3'
     platform: win
     '': ''
     category: ''
@@ -4437,7 +4437,7 @@
     language3: ''
     url: /frs/demos/scumm/he/pajama3-win-demo-us.zip
 -
-    id: pajama3
+    id: 'scumm:pajama3'
     platform: win
     '': ''
     category: Updated
@@ -4446,7 +4446,7 @@
     language3: ''
     url: /frs/demos/scumm/he/pajama3-win-updated-demo-us.zip
 -
-    id: pass
+    id: 'scumm:pass'
     platform: dos
     '': ''
     category: EGA
@@ -4455,7 +4455,7 @@
     language3: ''
     url: /frs/demos/scumm/pass-dos-en.zip
 -
-    id: puttcircus
+    id: 'scumm:puttcircus'
     platform: win
     '': ''
     category: French
@@ -4464,7 +4464,7 @@
     language3: ''
     url: /frs/demos/scumm/he/puttcircus-win-demo-fr.zip
 -
-    id: puttcircus
+    id: 'scumm:puttcircus'
     platform: win
     '': ''
     category: Hebrew
@@ -4473,7 +4473,7 @@
     language3: ''
     url: /frs/demos/scumm/he/puttcircus-win-demo-hb.zip
 -
-    id: puttcircus
+    id: 'scumm:puttcircus'
     platform: win
     '': ''
     category: US
@@ -4482,7 +4482,7 @@
     language3: ''
     url: /frs/demos/scumm/he/puttcircus-win-demo-us.zip
 -
-    id: puttmoon
+    id: 'scumm:puttmoon'
     platform: dos
     '': ''
     category: ''
@@ -4491,7 +4491,7 @@
     language3: ''
     url: /frs/demos/scumm/he/puttmoon-dos-demo-us.zip
 -
-    id: puttmoon
+    id: 'scumm:puttmoon'
     platform: mac
     '': ''
     category: ''
@@ -4500,7 +4500,7 @@
     language3: ''
     url: /frs/demos/scumm/he/puttmoon-mac-demo-us.zip
 -
-    id: puttmoon
+    id: 'scumm:puttmoon'
     platform: win
     '': ''
     category: ''
@@ -4509,7 +4509,7 @@
     language3: ''
     url: /frs/demos/scumm/he/puttmoon-win-demo-us.zip
 -
-    id: puttputt
+    id: 'scumm:puttputt'
     platform: dos
     '': ''
     category: ''
@@ -4518,7 +4518,7 @@
     language3: ''
     url: /frs/demos/scumm/he/puttputt-dos-demo-us.zip
 -
-    id: puttputt
+    id: 'scumm:puttputt'
     platform: mac
     '': ''
     category: ''
@@ -4527,7 +4527,7 @@
     language3: ''
     url: /frs/demos/scumm/he/puttputt-mac-demo-us.zip
 -
-    id: puttputt
+    id: 'scumm:puttputt'
     platform: win
     '': ''
     category: ''
@@ -4536,7 +4536,7 @@
     language3: ''
     url: /frs/demos/scumm/he/puttputt-win-demo-us.zip
 -
-    id: puttrace
+    id: 'scumm:puttrace'
     platform: win
     '': ''
     category: German
@@ -4545,7 +4545,7 @@
     language3: ''
     url: /frs/demos/scumm/he/puttrace-win-demo-de.zip
 -
-    id: puttrace
+    id: 'scumm:puttrace'
     platform: win
     '': ''
     category: French
@@ -4554,7 +4554,7 @@
     language3: ''
     url: /frs/demos/scumm/he/puttrace-win-demo-fr.zip
 -
-    id: puttrace
+    id: 'scumm:puttrace'
     platform: win
     '': ''
     category: Italian
@@ -4563,7 +4563,7 @@
     language3: ''
     url: /frs/demos/scumm/he/puttrace-win-demo-it.zip
 -
-    id: puttrace
+    id: 'scumm:puttrace'
     platform: win
     '': ''
     category: Dutch
@@ -4572,7 +4572,7 @@
     language3: ''
     url: /frs/demos/scumm/he/puttrace-win-demo-nl.zip
 -
-    id: puttrace
+    id: 'scumm:puttrace'
     platform: win
     '': ''
     category: UK
@@ -4581,7 +4581,7 @@
     language3: ''
     url: /frs/demos/scumm/he/puttrace-win-demo-uk.zip
 -
-    id: puttrace
+    id: 'scumm:puttrace'
     platform: win
     '': ''
     category: ''
@@ -4590,7 +4590,7 @@
     language3: ''
     url: /frs/demos/scumm/he/puttrace-win-demo-us.zip
 -
-    id: puttrace
+    id: 'scumm:puttrace'
     platform: win
     '': ''
     category: Preview
@@ -4599,7 +4599,7 @@
     language3: ''
     url: /frs/demos/scumm/he/puttrace-win-preview-us.zip
 -
-    id: puttrace
+    id: 'scumm:puttrace'
     platform: win
     '': ''
     category: 'Dutch Updated'
@@ -4608,7 +4608,7 @@
     language3: ''
     url: /frs/demos/scumm/he/puttrace-win-updated-demo-nl.zip
 -
-    id: putttime
+    id: 'scumm:putttime'
     platform: win
     '': ''
     category: German
@@ -4617,7 +4617,7 @@
     language3: ''
     url: /frs/demos/scumm/he/putttime-win-demo-de.zip
 -
-    id: putttime
+    id: 'scumm:putttime'
     platform: win
     '': ''
     category: French
@@ -4626,7 +4626,7 @@
     language3: ''
     url: /frs/demos/scumm/he/putttime-win-demo-fr.zip
 -
-    id: putttime
+    id: 'scumm:putttime'
     platform: win
     '': ''
     category: Dutch
@@ -4635,7 +4635,7 @@
     language3: ''
     url: /frs/demos/scumm/he/putttime-win-demo-nl.zip
 -
-    id: putttime
+    id: 'scumm:putttime'
     platform: win
     '': ''
     category: ''
@@ -4644,7 +4644,7 @@
     language3: ''
     url: /frs/demos/scumm/he/putttime-win-demo-us.zip
 -
-    id: putttime
+    id: 'scumm:putttime'
     platform: win
     '': ''
     category: Updated
@@ -4653,7 +4653,7 @@
     language3: ''
     url: /frs/demos/scumm/he/putttime-win-updated-demo-us.zip
 -
-    id: puttzoo
+    id: 'scumm:puttzoo'
     platform: mac
     '': ''
     category: ''
@@ -4662,7 +4662,7 @@
     language3: ''
     url: /frs/demos/scumm/he/puttzoo-mac-demo-us.zip
 -
-    id: puttzoo
+    id: 'scumm:puttzoo'
     platform: win
     '': ''
     category: German
@@ -4671,7 +4671,7 @@
     language3: ''
     url: /frs/demos/scumm/he/puttzoo-win-demo-de.zip
 -
-    id: puttzoo
+    id: 'scumm:puttzoo'
     platform: win
     '': ''
     category: French
@@ -4680,7 +4680,7 @@
     language3: ''
     url: /frs/demos/scumm/he/puttzoo-win-demo-fr.zip
 -
-    id: puttzoo
+    id: 'scumm:puttzoo'
     platform: win
     '': ''
     category: Dutch
@@ -4689,7 +4689,7 @@
     language3: ''
     url: /frs/demos/scumm/he/puttzoo-win-demo-nl.zip
 -
-    id: puttzoo
+    id: 'scumm:puttzoo'
     platform: win
     '': ''
     category: ''
@@ -4698,7 +4698,7 @@
     language3: ''
     url: /frs/demos/scumm/he/puttzoo-win-demo-us.zip
 -
-    id: puttzoo
+    id: 'scumm:puttzoo'
     platform: win
     '': ''
     category: Updated
@@ -4707,7 +4707,7 @@
     language3: ''
     url: /frs/demos/scumm/he/puttzoo-win-updated-demo-us.zip
 -
-    id: samnmax
+    id: 'scumm:samnmax'
     platform: dos
     '': ''
     category: CD
@@ -4716,7 +4716,7 @@
     language3: ''
     url: /frs/demos/scumm/samnmax-dos-cd-demo-en.zip
 -
-    id: samnmax
+    id: 'scumm:samnmax'
     platform: dos
     '': ''
     category: German
@@ -4725,7 +4725,7 @@
     language3: ''
     url: /frs/demos/scumm/samnmax-dos-demo-de.zip
 -
-    id: samnmax
+    id: 'scumm:samnmax'
     platform: dos
     '': ''
     category: ''
@@ -4734,7 +4734,7 @@
     language3: ''
     url: /frs/demos/scumm/samnmax-dos-demo-en.zip
 -
-    id: samnmax
+    id: 'scumm:samnmax'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -4743,7 +4743,7 @@
     language3: ''
     url: /frs/demos/scumm/samnmax-dos-ni-demo-en.zip
 -
-    id: samnmax
+    id: 'scumm:samnmax'
     platform: dos
     '': ''
     category: WIP
@@ -4752,7 +4752,7 @@
     language3: ''
     url: /frs/demos/scumm/samnmax-dos-wip-demo-en.zip
 -
-    id: samnmax
+    id: 'scumm:samnmax'
     platform: mac
     '': ''
     category: ''
@@ -4761,7 +4761,7 @@
     language3: ''
     url: /frs/demos/scumm/samnmax-mac-demo-en.zip
 -
-    id: spyfox
+    id: 'scumm:spyfox'
     platform: win
     '': ''
     category: French
@@ -4770,7 +4770,7 @@
     language3: ''
     url: /frs/demos/scumm/he/spyfox-win-demo-fr.zip
 -
-    id: spyfox
+    id: 'scumm:spyfox'
     platform: win
     '': ''
     category: Dutch
@@ -4779,7 +4779,7 @@
     language3: ''
     url: /frs/demos/scumm/he/spyfox-win-demo-nl.zip
 -
-    id: spyfox
+    id: 'scumm:spyfox'
     platform: win
     '': ''
     category: ''
@@ -4788,7 +4788,7 @@
     language3: ''
     url: /frs/demos/scumm/he/spyfox-win-demo1-us.zip
 -
-    id: spyfox
+    id: 'scumm:spyfox'
     platform: win
     '': ''
     category: Alternative
@@ -4797,7 +4797,7 @@
     language3: ''
     url: /frs/demos/scumm/he/spyfox-win-demo2-us.zip
 -
-    id: spyfox
+    id: 'scumm:spyfox'
     platform: win
     '': ''
     category: Updated
@@ -4806,7 +4806,7 @@
     language3: ''
     url: /frs/demos/scumm/he/spyfox-win-updated-demo-us.zip
 -
-    id: spyfox2
+    id: 'scumm:spyfox2'
     platform: win
     '': ''
     category: German
@@ -4815,7 +4815,7 @@
     language3: ''
     url: /frs/demos/scumm/he/spyfox2-win-demo-de.zip
 -
-    id: spyfox2
+    id: 'scumm:spyfox2'
     platform: win
     '': ''
     category: French
@@ -4824,7 +4824,7 @@
     language3: ''
     url: /frs/demos/scumm/he/spyfox2-win-demo-fr.zip
 -
-    id: spyfox2
+    id: 'scumm:spyfox2'
     platform: win
     '': ''
     category: Italian
@@ -4833,7 +4833,7 @@
     language3: ''
     url: /frs/demos/scumm/he/spyfox2-win-demo-it.zip
 -
-    id: spyfox2
+    id: 'scumm:spyfox2'
     platform: win
     '': ''
     category: Dutch
@@ -4842,7 +4842,7 @@
     language3: ''
     url: /frs/demos/scumm/he/spyfox2-win-demo-nl.zip
 -
-    id: spyfox2
+    id: 'scumm:spyfox2'
     platform: win
     '': ''
     category: UK
@@ -4851,7 +4851,7 @@
     language3: ''
     url: /frs/demos/scumm/he/spyfox2-win-demo-uk.zip
 -
-    id: spyfox2
+    id: 'scumm:spyfox2'
     platform: win
     '': ''
     category: ''
@@ -4860,7 +4860,7 @@
     language3: ''
     url: /frs/demos/scumm/he/spyfox2-win-demo-us.zip
 -
-    id: spyfox2
+    id: 'scumm:spyfox2'
     platform: win
     '': ''
     category: Preview
@@ -4869,7 +4869,7 @@
     language3: ''
     url: /frs/demos/scumm/he/spyfox2-win-preview-us.zip
 -
-    id: spyozon
+    id: 'scumm:spyozon'
     platform: win
     '': ''
     category: French
@@ -4878,7 +4878,7 @@
     language3: ''
     url: /frs/demos/scumm/he/spyozon-win-demo-fr.zip
 -
-    id: spyozon
+    id: 'scumm:spyozon'
     platform: win
     '': ''
     category: ''
@@ -4887,7 +4887,7 @@
     language3: ''
     url: /frs/demos/scumm/he/spyozon-win-demo-us.zip
 -
-    id: spyozon
+    id: 'scumm:spyozon'
     platform: win
     '': ''
     category: Preview
@@ -4896,7 +4896,7 @@
     language3: ''
     url: /frs/demos/scumm/he/spyozon-win-preview-us.zip
 -
-    id: tentacle
+    id: 'scumm:tentacle'
     platform: dos
     '': ''
     category: 'German Non-Interactive'
@@ -4905,7 +4905,7 @@
     language3: ''
     url: /frs/demos/scumm/dott-dos-ni-demo-de.zip
 -
-    id: tentacle
+    id: 'scumm:tentacle'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -4914,7 +4914,7 @@
     language3: ''
     url: /frs/demos/scumm/dott-dos-ni-demo-en.zip
 -
-    id: tentacle
+    id: 'scumm:tentacle'
     platform: dos
     '': ''
     category: 'French Non-Interactive'
@@ -4923,7 +4923,7 @@
     language3: ''
     url: /frs/demos/scumm/dott-dos-ni-demo-fr.zip
 -
-    id: tentacle
+    id: 'scumm:tentacle'
     platform: mac
     '': ''
     category: Non-Interactive
@@ -4932,7 +4932,7 @@
     language3: ''
     url: /frs/demos/scumm/dott-mac-ni-demo-en.zip
 -
-    id: thinker1
+    id: 'scumm:thinker1'
     platform: win
     '': ''
     category: ''
@@ -4941,7 +4941,7 @@
     language3: ''
     url: /frs/demos/scumm/he/thinker1-win-demo-us.zip
 -
-    id: thinkerk
+    id: 'scumm:thinkerk'
     platform: win
     '': ''
     category: ''
@@ -4950,7 +4950,7 @@
     language3: ''
     url: /frs/demos/scumm/he/thinkerk-win-demo-us.zip
 -
-    id: zak
+    id: 'scumm:zak'
     platform: atarist
     '': ''
     category: Non-Interactive
@@ -4959,7 +4959,7 @@
     language3: ''
     url: /frs/demos/scumm/zak-atari-ni-demo.zip
 -
-    id: zak
+    id: 'scumm:zak'
     platform: fmtowns
     '': ''
     category: Non-Interactive
@@ -4968,7 +4968,7 @@
     language3: ''
     url: /frs/demos/scumm/zak-fmtowns-indyloom-ni-demo.zip
 -
-    id: zak
+    id: 'scumm:zak'
     platform: fmtowns
     '': ''
     category: Non-Interactive
@@ -4977,7 +4977,7 @@
     language3: ''
     url: /frs/demos/scumm/zak-fmtowns-indyzak-ni-demo.zip
 -
-    id: zak
+    id: 'scumm:zak'
     platform: fmtowns
     '': ''
     category: Non-Interactive
@@ -4986,7 +4986,7 @@
     language3: ''
     url: /frs/demos/scumm/zak-fmtowns-zakloom-ni-demo.zip
 -
-    id: scalpel
+    id: 'sherlock:scalpel'
     platform: dos
     '': ''
     category: ''
@@ -4995,7 +4995,7 @@
     language3: ''
     url: /frs/demos/sherlock/scalpel-dos-demo-en.zip
 -
-    id: scalpel
+    id: 'sherlock:scalpel'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -5004,7 +5004,7 @@
     language3: ''
     url: /frs/demos/sherlock/scalpel-dos-ni-demo-en.zip
 -
-    id: sky
+    id: 'sky:sky'
     platform: amiga
     '': ''
     category: ''
@@ -5013,7 +5013,7 @@
     language3: ''
     url: /frs/demos/sky/sky-amiga-demo-en.zip
 -
-    id: sky
+    id: 'sky:sky'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -5022,7 +5022,7 @@
     language3: ''
     url: /frs/demos/sky/sky-dos-ni-anm-demo-en.zip
 -
-    id: sky
+    id: 'sky:sky'
     platform: dos
     '': ''
     category: v0109
@@ -5031,7 +5031,7 @@
     language3: ''
     url: /frs/demos/sky/sky-dos-v0109-demo-en.zip
 -
-    id: sky
+    id: 'sky:sky'
     platform: dos
     '': ''
     category: v0267
@@ -5040,7 +5040,7 @@
     language3: ''
     url: /frs/demos/sky/sky-dos-v0267-demo-en.zip
 -
-    id: sky
+    id: 'sky:sky'
     platform: dos
     '': ''
     category: 'German v0272'
@@ -5049,7 +5049,7 @@
     language3: ''
     url: /frs/demos/sky/sky-dos-v0272-demo-de.zip
 -
-    id: sky
+    id: 'sky:sky'
     platform: dos
     '': ''
     category: 'v0365 CD'
@@ -5058,7 +5058,7 @@
     language3: ''
     url: /frs/demos/sky/sky-dos-v0365-cd-demo-en.zip
 -
-    id: tlj
+    id: 'stark:tlj'
     platform: win
     '': ''
     category: Early
@@ -5067,7 +5067,7 @@
     language3: ''
     url: /frs/demos/stark/tlj-demo-en-early.zip
 -
-    id: tlj
+    id: 'stark:tlj'
     platform: win
     '': ''
     category: New
@@ -5076,7 +5076,7 @@
     language3: ''
     url: /frs/demos/stark/tlj-demo-en-new.zip
 -
-    id: tlj
+    id: 'stark:tlj'
     platform: win
     '': ''
     category: ''
@@ -5085,7 +5085,7 @@
     language3: ''
     url: /frs/demos/stark/tlj-demo-en.zip
 -
-    id: tlj
+    id: 'stark:tlj'
     platform: win
     '': ''
     category: French
@@ -5094,7 +5094,7 @@
     language3: ''
     url: /frs/demos/stark/tlj-demo-fr.zip
 -
-    id: tlj
+    id: 'stark:tlj'
     platform: win
     '': ''
     category: Norwegian
@@ -5103,7 +5103,7 @@
     language3: ''
     url: /frs/demos/stark/tlj-demo-nor-new.zip
 -
-    id: tlj
+    id: 'stark:tlj'
     platform: win
     '': ''
     category: Swedish
@@ -5112,7 +5112,7 @@
     language3: ''
     url: /frs/demos/stark/tlj-demo-swe.zip
 -
-    id: st25
+    id: 'startrek:st25'
     platform: dos
     '': ''
     category: CD
@@ -5121,7 +5121,7 @@
     language3: ''
     url: /frs/demos/startrek/st25-dos-demo-cd-en.zip
 -
-    id: st25
+    id: 'startrek:st25'
     platform: dos
     '': ''
     category: ''
@@ -5130,7 +5130,7 @@
     language3: ''
     url: /frs/demos/startrek/st25-dos-demo-en.zip
 -
-    id: st25
+    id: 'startrek:st25'
     platform: mac
     '': ''
     category: ''
@@ -5139,7 +5139,7 @@
     language3: ''
     url: /frs/demos/startrek/st25-mac-demo-en.zip
 -
-    id: stjr
+    id: 'startrek:stjr'
     platform: dos
     '': ''
     category: ''
@@ -5148,7 +5148,7 @@
     language3: ''
     url: /frs/demos/startrek/stjr-dos-demo-en.zip
 -
-    id: sword1
+    id: 'sword1:sword1'
     platform: mac
     '': ''
     category: ''
@@ -5157,7 +5157,7 @@
     language3: ''
     url: /frs/demos/sword1/sword1-mac-demo-en.zip
 -
-    id: sword1
+    id: 'sword1:sword1'
     platform: psx
     '': ''
     category: ''
@@ -5166,7 +5166,7 @@
     language3: ''
     url: /frs/demos/sword1/sword1-psx-demo-en.zip
 -
-    id: sword1
+    id: 'sword1:sword1'
     platform: win
     '': ''
     category: ''
@@ -5175,7 +5175,7 @@
     language3: ''
     url: /frs/demos/sword1/sword1-win-demo-en.zip
 -
-    id: sword1
+    id: 'sword1:sword1'
     platform: win
     '': ''
     category: Spanish
@@ -5184,7 +5184,7 @@
     language3: ''
     url: /frs/demos/sword1/sword1-win-demo-es.zip
 -
-    id: sword1
+    id: 'sword1:sword1'
     platform: win
     '': ''
     category: Preview
@@ -5193,7 +5193,7 @@
     language3: ''
     url: /frs/demos/sword1/sword1-win-preview-en.zip
 -
-    id: sword2
+    id: 'sword2:sword2'
     platform: psx
     '': ''
     category: ''
@@ -5202,7 +5202,7 @@
     language3: ''
     url: /frs/demos/sword2/sword2-psx-demo-en.zip
 -
-    id: sword2
+    id: 'sword2:sword2'
     platform: win
     '': ''
     category: ''
@@ -5211,7 +5211,7 @@
     language3: ''
     url: /frs/demos/sword2/sword2-win-demo-en.zip
 -
-    id: sword2
+    id: 'sword2:sword2'
     platform: win
     '': ''
     category: Spanish
@@ -5220,7 +5220,7 @@
     language3: ''
     url: /frs/demos/sword2/sword2-win-demo-es.zip
 -
-    id: teenagent
+    id: 'teenagent:teenagent'
     platform: dos
     '': ''
     category: Union
@@ -5229,7 +5229,7 @@
     language3: ''
     url: /frs/demos/teen/teen-dos-union-demo-en.zip
 -
-    id: teenagent
+    id: 'teenagent:teenagent'
     platform: dos
     '': ''
     category: WizTech
@@ -5238,7 +5238,7 @@
     language3: ''
     url: /frs/demos/teen/teen-dos-wiztech-demo-en.zip
 -
-    id: noir
+    id: 'tinsel:noir'
     platform: dos
     '': ''
     category: ''
@@ -5247,7 +5247,7 @@
     language3: ''
     url: /frs/demos/tinsel/Discworld_Noir_demo.zip
 -
-    id: dw
+    id: 'tinsel:dw'
     platform: dos
     '': ''
     category: CD
@@ -5256,7 +5256,7 @@
     language3: ''
     url: /frs/demos/tinsel/dw-dos-cd-demo-en.zip
 -
-    id: dw
+    id: 'tinsel:dw'
     platform: dos
     '': ''
     category: Floppy
@@ -5265,7 +5265,7 @@
     language3: ''
     url: /frs/demos/tinsel/dw-dos-floppy-demo-en.zip
 -
-    id: dw
+    id: 'tinsel:dw'
     platform: mac
     '': ''
     category: ''
@@ -5274,7 +5274,7 @@
     language3: ''
     url: /frs/demos/tinsel/dw-mac-cd-demo-en.zip
 -
-    id: noir
+    id: 'tinsel:noir'
     platform: dos
     '': ''
     category: ''
@@ -5283,7 +5283,7 @@
     language3: ''
     url: /frs/demos/tinsel/dw-noir-demo-en.zip
 -
-    id: dw
+    id: 'tinsel:dw'
     platform: psx
     '': ''
     category: ''
@@ -5292,7 +5292,7 @@
     language3: ''
     url: /frs/demos/tinsel/dw-psx-demo-en.zip
 -
-    id: dw2
+    id: 'tinsel:dw2'
     platform: psx
     '': ''
     category: ''
@@ -5301,7 +5301,7 @@
     language3: ''
     url: /frs/demos/tinsel/dw2-psx-demo-en.zip
 -
-    id: dw2
+    id: 'tinsel:dw2'
     platform: win
     '': ''
     category: ''
@@ -5310,7 +5310,7 @@
     language3: ''
     url: /frs/demos/tinsel/dw2-win-demo-2-en.zip
 -
-    id: dw2
+    id: 'tinsel:dw2'
     platform: win
     '': ''
     category: ''
@@ -5319,7 +5319,7 @@
     language3: ''
     url: /frs/demos/tinsel/dw2-win-demo-en.zip
 -
-    id: toltecs
+    id: 'toltecs:toltecs'
     platform: dos
     '': ''
     category: German
@@ -5328,7 +5328,7 @@
     language3: ''
     url: /frs/demos/toltecs/toltecs-demo-de.zip
 -
-    id: toltecs
+    id: 'toltecs:toltecs'
     platform: dos
     '': ''
     category: ''
@@ -5337,7 +5337,7 @@
     language3: ''
     url: /frs/demos/toltecs/toltecs-demo.zip
 -
-    id: tony
+    id: 'tony:tony'
     platform: win
     '': ''
     category: Extracted
@@ -5346,7 +5346,7 @@
     language3: ''
     url: /frs/demos/tony/tony-demo.zip
 -
-    id: toon
+    id: 'toon:toon'
     platform: dos
     '': ''
     category: ''
@@ -5355,7 +5355,7 @@
     language3: ''
     url: /frs/demos/toon/toon-demo.zip
 -
-    id: toon
+    id: 'toon:toon'
     platform: dos
     '': ''
     category: German
@@ -5364,7 +5364,7 @@
     language3: ''
     url: /frs/demos/toon/toon-dos-demo-de.zip
 -
-    id: touche
+    id: 'touche:touche'
     platform: dos
     '': ''
     category: ''
@@ -5373,7 +5373,7 @@
     language3: ''
     url: /frs/demos/touche/touche-dos-demo-en.zip
 -
-    id: nl
+    id: 'trecision:nl'
     platform: win
     '': ''
     category: German
@@ -5382,7 +5382,7 @@
     language3: ''
     url: /frs/demos/trecision/nl-win-demo-de.zip
 -
-    id: nl
+    id: 'trecision:nl'
     platform: win
     '': ''
     category: ''
@@ -5391,7 +5391,7 @@
     language3: ''
     url: /frs/demos/trecision/nl-win-demo-en.zip
 -
-    id: blueforce
+    id: 'tsage:blueforce'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -5400,7 +5400,7 @@
     language3: ''
     url: /frs/demos/tsage/blueforce-dos-ni-demo-en.zip
 -
-    id: flashtraffic
+    id: 'tsage:flashtraffic'
     platform: dos
     '': ''
     category: ''
@@ -5409,7 +5409,7 @@
     language3: ''
     url: /frs/demos/tsage/flashtraffic-dos-demo-en.zip
 -
-    id: protostar
+    id: 'tsage:protostar'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -5418,7 +5418,7 @@
     language3: ''
     url: /frs/demos/tsage/protostar-dos-ni-demo-en.zip
 -
-    id: ringworld
+    id: 'tsage:ringworld'
     platform: dos
     '': ''
     category: Alternative
@@ -5427,7 +5427,7 @@
     language3: ''
     url: /frs/demos/tsage/ringworld-demo-alt.zip
 -
-    id: ringworld
+    id: 'tsage:ringworld'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -5436,7 +5436,7 @@
     language3: ''
     url: /frs/demos/tsage/ringworld-dos-ni-demo-en.zip
 -
-    id: ringworld2
+    id: 'tsage:ringworld2'
     platform: dos
     '': ''
     category: ''
@@ -5445,7 +5445,7 @@
     language3: ''
     url: /frs/demos/tsage/returntoringworld-dos-demo-en.zip
 -
-    id: tucker
+    id: 'tucker:tucker'
     platform: dos
     '': ''
     category: ''
@@ -5454,7 +5454,7 @@
     language3: ''
     url: /frs/demos/tucker/tucker-dos-demo.zip
 -
-    id: tucker
+    id: 'tucker:tucker'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -5463,7 +5463,7 @@
     language3: ''
     url: /frs/demos/tucker/tucker-dos-ni-demo.zip
 -
-    id: lba
+    id: 'twine:lba'
     platform: dos
     '': ''
     category: Multilanguage
@@ -5472,7 +5472,7 @@
     language3: ''
     url: /frs/demos/twine/lba-demo-mult.zip
 -
-    id: regret
+    id: 'ultima:regret'
     platform: dos
     '': ''
     category: ''
@@ -5481,7 +5481,7 @@
     language3: ''
     url: /frs/demos/ultima/regret-dos-demo-en.zip
 -
-    id: remorse
+    id: 'ultima:remorse'
     platform: dos
     '': ''
     category: ''
@@ -5490,7 +5490,7 @@
     language3: ''
     url: /frs/demos/ultima/remorse-dos-demo-en.zip
 -
-    id: voyeur
+    id: 'voyeur:voyeur'
     platform: win
     '': ''
     category: ''
@@ -5499,7 +5499,7 @@
     language3: ''
     url: /frs/demos/voyeur/voyeur-dos-demo-en.zip
 -
-    id: alphapolaris
+    id: 'wintermute:alphapolaris'
     platform: win
     '': ''
     category: German
@@ -5508,7 +5508,7 @@
     language3: ''
     url: /frs/demos/wintermute/alpha_polaris-demo-de.zip
 -
-    id: alphapolaris
+    id: 'wintermute:alphapolaris'
     platform: win
     '': ''
     category: ''
@@ -5517,7 +5517,7 @@
     language3: ''
     url: /frs/demos/wintermute/alpha_polaris-demo-en.zip
 -
-    id: alphapolaris
+    id: 'wintermute:alphapolaris'
     platform: win
     '': ''
     category: Polish
@@ -5526,7 +5526,7 @@
     language3: ''
     url: /frs/demos/wintermute/alpha_polaris-demo-pl.zip
 -
-    id: artofmurder1
+    id: 'wintermute:artofmurder1'
     platform: win
     '': ''
     category: German
@@ -5535,7 +5535,7 @@
     language3: ''
     url: /frs/demos/wintermute/art_of_murder-de-demo.zip
 -
-    id: artofmurder1
+    id: 'wintermute:artofmurder1'
     platform: win
     '': ''
     category: Polish
@@ -5544,7 +5544,7 @@
     language3: ''
     url: /frs/demos/wintermute/art_of_murder-pl-demo.zip
 -
-    id: carolreed5
+    id: 'wintermute:carolreed5'
     platform: win
     '': ''
     category: ''
@@ -5553,7 +5553,7 @@
     language3: ''
     url: /frs/demos/wintermute/carol_reed5-en-demo.zip
 -
-    id: colorsoncanvas
+    id: 'wintermute:colorsoncanvas'
     platform: win
     '': ''
     category: ''
@@ -5562,7 +5562,7 @@
     language3: ''
     url: /frs/demos/wintermute/colors_on_canvas-demo-en.zip
 -
-    id: conspiracao
+    id: 'wintermute:conspiracao'
     platform: win
     '': ''
     category: Portuguese
@@ -5571,7 +5571,7 @@
     language3: ''
     url: /frs/demos/wintermute/conspiracao_dumont-demo.zip
 -
-    id: facenoir
+    id: 'wintermute:facenoir'
     platform: win
     '': ''
     category: ''
@@ -5580,7 +5580,7 @@
     language3: ''
     url: /frs/demos/wintermute/face_noir-demo-en.zip
 -
-    id: facenoir
+    id: 'wintermute:facenoir'
     platform: win
     '': ''
     category: Polish
@@ -5589,7 +5589,7 @@
     language3: ''
     url: /frs/demos/wintermute/face_noir-demo-pl.zip
 -
-    id: framed
+    id: 'wintermute:framed'
     platform: win
     '': ''
     category: ''
@@ -5598,7 +5598,7 @@
     language3: ''
     url: /frs/demos/wintermute/framed-demo-beta-en.zip
 -
-    id: ghostsheet
+    id: 'wintermute:ghostsheet'
     platform: win
     '': ''
     category: ''
@@ -5607,7 +5607,7 @@
     language3: ''
     url: /frs/demos/wintermute/ghost_in_the_sheet-en-demo.zip
 -
-    id: helga
+    id: 'wintermute:helga'
     platform: win
     '': ''
     category: ''
@@ -5616,7 +5616,7 @@
     language3: ''
     url: /frs/demos/wintermute/helga_deep_in_trouble-demo.zip
 -
-    id: jamesperis
+    id: 'wintermute:jamesperis'
     platform: win
     '': ''
     category: Old
@@ -5625,7 +5625,7 @@
     language3: ''
     url: /frs/demos/wintermute/james_peris1-en-old-demo.zip
 -
-    id: jamesperis
+    id: 'wintermute:jamesperis'
     platform: win
     '': ''
     category: 'Old Spanish'
@@ -5634,7 +5634,7 @@
     language3: ''
     url: /frs/demos/wintermute/james_peris1-spanish-old-demo.zip
 -
-    id: julia
+    id: 'wintermute:julia'
     platform: win
     '': ''
     category: Preview
@@ -5643,7 +5643,7 @@
     language3: ''
     url: /frs/demos/wintermute/julia_greenlight-en-demo.zip
 -
-    id: julia
+    id: 'wintermute:julia'
     platform: win
     '': ''
     category: ''
@@ -5652,7 +5652,7 @@
     language3: ''
     url: /frs/demos/wintermute/julia-en-demo.zip
 -
-    id: kulivocko
+    id: 'wintermute:kulivocko'
     platform: win
     '': ''
     category: Czech
@@ -5661,7 +5661,7 @@
     language3: ''
     url: /frs/demos/wintermute/kulivocko-cz-demo.zip
 -
-    id: lonelyrobot
+    id: 'wintermute:lonelyrobot'
     platform: win
     '': ''
     category: ''
@@ -5670,7 +5670,7 @@
     language3: ''
     url: /frs/demos/wintermute/project_lonely_robot-demo-beta.zip
 -
-    id: machumayu
+    id: 'wintermute:machumayu'
     platform: win
     '': ''
     category: ''
@@ -5679,7 +5679,7 @@
     language3: ''
     url: /frs/demos/wintermute/machu_mayu-en-demo.zip
 -
-    id: nighttrain
+    id: 'wintermute:nighttrain'
     platform: win
     '': ''
     category: ''
@@ -5688,7 +5688,7 @@
     language3: ''
     url: /frs/demos/wintermute/night_train-en-demo.zip
 -
-    id: one
+    id: 'wintermute:one'
     platform: win
     '': ''
     category: ''
@@ -5697,7 +5697,7 @@
     language3: ''
     url: /frs/demos/wintermute/one-en-demo.zip
 -
-    id: palladion
+    id: 'wintermute:palladion'
     platform: win
     '': ''
     category: German
@@ -5706,7 +5706,7 @@
     language3: ''
     url: /frs/demos/wintermute/palladion-demo-de.zip
 -
-    id: projectdoom
+    id: 'wintermute:projectdoom'
     platform: win
     '': ''
     category: ''
@@ -5715,7 +5715,7 @@
     language3: ''
     url: /frs/demos/wintermute/project_doom-demo-beta-en.zip
 -
-    id: projectjoe
+    id: 'wintermute:projectjoe'
     platform: win
     '': ''
     category: ''
@@ -5724,7 +5724,7 @@
     language3: ''
     url: /frs/demos/wintermute/project_joe-demo-en.zip
 -
-    id: rebeccacarlson1
+    id: 'wintermute:rebeccacarlson1'
     platform: win
     '': ''
     category: ''
@@ -5733,7 +5733,7 @@
     language3: ''
     url: /frs/demos/wintermute/silent_footsteps-en-demo.zip
 -
-    id: reptilesquest
+    id: 'wintermute:reptilesquest'
     platform: win
     '': ''
     category: ''
@@ -5742,7 +5742,7 @@
     language3: ''
     url: /frs/demos/wintermute/on_the_tracks_of_dinosaurs-demo-en.zip
 -
-    id: rhiannon
+    id: 'wintermute:rhiannon'
     platform: win
     '': ''
     category: 'Chapter 1'
@@ -5751,7 +5751,7 @@
     language3: ''
     url: /frs/demos/wintermute/rhiannon-demo-c1.zip
 -
-    id: rhiannon
+    id: 'wintermute:rhiannon'
     platform: win
     '': ''
     category: 'Chapter 5'
@@ -5760,7 +5760,7 @@
     language3: ''
     url: /frs/demos/wintermute/rhiannon-demo-c5.zip
 -
-    id: ritter
+    id: 'wintermute:ritter'
     platform: win
     '': ''
     category: ''
@@ -5769,7 +5769,7 @@
     language3: ''
     url: /frs/demos/wintermute/ritter-demo-de.zip
 -
-    id: satanandsons
+    id: 'wintermute:satanandsons'
     platform: win
     '': ''
     category: ''
@@ -5778,7 +5778,7 @@
     language3: ''
     url: /frs/demos/wintermute/satan_and_sons-demo-en.zip
 -
-    id: spaceinvaders
+    id: 'wintermute:spaceinvaders'
     platform: win
     '': ''
     category: ''
@@ -5787,7 +5787,7 @@
     language3: ''
     url: /frs/demos/wintermute/space_invaders-en-demo.zip
 -
-    id: spacemadness
+    id: 'wintermute:spacemadness'
     platform: win
     '': ''
     category: ''
@@ -5796,7 +5796,7 @@
     language3: ''
     url: /frs/demos/wintermute/space_madness-demo-en.zip
 -
-    id: tradestory
+    id: 'wintermute:tradestory'
     platform: win
     '': ''
     category: ''
@@ -5805,7 +5805,7 @@
     language3: ''
     url: /frs/demos/wintermute/trader_of_stories-demo-en.zip
 -
-    id: wintermute
+    id: 'wintermute:wintermute'
     platform: win
     '': ''
     category: 'Alavi Detective - Murder of Miss Rojan'
@@ -5814,7 +5814,7 @@
     language3: ''
     url: /frs/demos/wintermute/informer_alavi-demo-beta.zip
 -
-    id: wintermute
+    id: 'wintermute:wintermute'
     platform: win
     '': ''
     category: 'Sunrise: The game (German)'
@@ -5823,7 +5823,7 @@
     language3: ''
     url: /frs/demos/wintermute/sunrise_the_game-demo-de.zip
 -
-    id: wmedemo
+    id: 'wintermute:wmedemo'
     platform: win
     '': ''
     category: ''
@@ -5832,7 +5832,7 @@
     language3: ''
     url: /frs/demos/wintermute/wme_2d-demo.zip
 -
-    id: wmedemo3d
+    id: 'wintermute:wmedemo3d'
     platform: win
     '': ''
     category: ''
@@ -5841,7 +5841,7 @@
     language3: ''
     url: /frs/demos/wintermute/wme_3d-demo.zip
 -
-    id: cloudsofxeen
+    id: 'xeen:cloudsofxeen'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -5850,7 +5850,7 @@
     language3: ''
     url: /frs/demos/xeen/cloudsofxeen-dos-demo-en-ni.zip
 -
-    id: darksideofxeen
+    id: 'xeen:darksideofxeen'
     platform: dos
     '': ''
     category: Non-Interactive
@@ -5859,7 +5859,7 @@
     language3: ''
     url: /frs/demos/xeen/darksideofxeen-dos-demo-en-ni.zip
 -
-    id: worldofxeen
+    id: 'xeen:worldofxeen'
     platform: dos
     '': ''
     category: Non-Interactive

--- a/data/en/game_downloads.yaml
+++ b/data/en/game_downloads.yaml
@@ -1,476 +1,476 @@
 # This is a generated file, please do not edit manually
 -
     category: games
-    game_id: sky
+    game_id: 'sky:sky'
     category_icon: sky
     url: 'Beneath a Steel Sky/bass-cd-1.2.zip'
     name: 'Freeware CD Version'
     notes: ''
 -
     category: games
-    game_id: sky
+    game_id: 'sky:sky'
     category_icon: sky
     url: 'Beneath a Steel Sky/BASS-Floppy-1.3.zip'
     name: 'Freeware Floppy Version'
     notes: ''
 -
     category: games
-    game_id: sword25
+    game_id: 'sword25:sword25'
     category_icon: sword
     url: 'Broken Sword 2.5/sword25-v1.0.zip'
     name: 'Freeware Version'
     notes: ''
 -
     category: games
-    game_id: sword25
+    game_id: 'sword25:sword25'
     category_icon: sword
     url: 'Broken Sword 2.5/lang_he.b25c'
     name: 'Hebrew translation AddOn'
     notes: 'Copy it to the game directory and run detection'
 -
     category: games
-    game_id: drascula
+    game_id: 'drascula:drascula'
     category_icon: drascula
     url: 'Drascula_ The Vampire Strikes Back/drascula-1.0.zip'
     name: 'Freeware Version (English)'
     notes: ''
 -
     category: games
-    game_id: drascula
+    game_id: 'drascula:drascula'
     category_icon: mp3
     url: 'Drascula_ The Vampire Strikes Back/drascula-audio-mp3-2.0.zip'
     name: 'Freeware Version (Music AddOn, MP3 format)'
     notes: ''
 -
     category: games
-    game_id: drascula
+    game_id: 'drascula:drascula'
     category_icon: flac
     url: 'Drascula_ The Vampire Strikes Back/drascula-audio-flac-2.0.zip'
     name: 'Freeware Version (Music AddOn, FLAC format)'
     notes: ''
 -
     category: games
-    game_id: drascula
+    game_id: 'drascula:drascula'
     category_icon: ogg
     url: 'Drascula_ The Vampire Strikes Back/drascula-audio-2.0.zip'
     name: 'Freeware Version (Music AddOn, OGG format)'
     notes: ''
 -
     category: games
-    game_id: drascula
+    game_id: 'drascula:drascula'
     category_icon: drascula
     url: 'Drascula_ The Vampire Strikes Back/drascula-int-1.0.zip'
     name: 'Freeware Version (Spanish, German, French and Italian AddOn)'
     notes: ''
 -
     category: games
-    game_id: drascula
+    game_id: 'drascula:drascula'
     category_icon: drascula
     url: 'Drascula_ The Vampire Strikes Back/drascula-int-1.1.zip'
     name: 'Freeware Version (Updated Spanish, German, French and Italian AddOn) - requires ScummVM 1.3.0 or more'
     notes: ''
 -
     category: games
-    game_id: dreamweb
+    game_id: 'dreamweb:dreamweb'
     category_icon: dreamweb
     url: Dreamweb/dreamweb-uk-1.1.zip
     name: 'Freeware Floppy DOS Version (English UK)'
     notes: ''
 -
     category: games
-    game_id: dreamweb
+    game_id: 'dreamweb:dreamweb'
     category_icon: dreamweb
     url: Dreamweb/dreamweb-cd-uk-1.1.zip
     name: 'Freeware CD DOS Version (English UK)'
     notes: ''
 -
     category: games
-    game_id: dreamweb
+    game_id: 'dreamweb:dreamweb'
     category_icon: dreamweb
     url: Dreamweb/dreamweb-cd-us-1.1.zip
     name: 'Freeware CD DOS Version (English US)'
     notes: ''
 -
     category: games
-    game_id: dreamweb
+    game_id: 'dreamweb:dreamweb'
     category_icon: dreamweb
     url: Dreamweb/dreamweb-cd-fr-1.1.zip
     name: 'Freeware CD DOS Version (French)'
     notes: ''
 -
     category: games
-    game_id: dreamweb
+    game_id: 'dreamweb:dreamweb'
     category_icon: dreamweb
     url: Dreamweb/dreamweb-cd-de-1.1.zip
     name: 'Freeware CD DOS Version (German)'
     notes: ''
 -
     category: games
-    game_id: dreamweb
+    game_id: 'dreamweb:dreamweb'
     category_icon: dreamweb
     url: Dreamweb/dreamweb-cd-it-1.1.zip
     name: 'Freeware CD DOS Version (Italian)'
     notes: ''
 -
     category: games
-    game_id: dreamweb
+    game_id: 'dreamweb:dreamweb'
     category_icon: dreamweb
     url: Dreamweb/dreamweb-cd-es-1.1.zip
     name: 'Freeware CD DOS Version (Spanish)'
     notes: ''
 -
     category: games
-    game_id: dreamweb
+    game_id: 'dreamweb:dreamweb'
     category_icon: dreamweb
     url: Dreamweb/dreamweb-manuals-en-highres.zip
     name: 'Manuals (English High Resolution)'
     notes: ''
 -
     category: games
-    game_id: dreamweb
+    game_id: 'dreamweb:dreamweb'
     category_icon: dreamweb
     url: Dreamweb/dreamweb-manuals-en-lores.zip
     name: 'Manuals (English Low Resolution)'
     notes: ''
 -
     category: games
-    game_id: queen
+    game_id: 'queen:queen'
     category_icon: queen
     url: 'Flight of the Amazon Queen/FOTAQ_Talkie-original.zip'
     name: 'Freeware CD Version (unmodified original)'
     notes: 'Download this version if your ScummVM doesn''t have mp3 support'
 -
     category: games
-    game_id: queen
+    game_id: 'queen:queen'
     category_icon: queen
     url: 'Flight of the Amazon Queen/FOTAQ_Fr_Talkie_1.0.zip'
     name: 'Freeware CD Version (French voices and subtitles, ogg compressed sfx/speech)'
     notes: ''
 -
     category: games
-    game_id: queen
+    game_id: 'queen:queen'
     category_icon: queen
     url: 'Flight of the Amazon Queen/FOTAQ_Ger_talkie-1.0.zip'
     name: 'Freeware CD Version (German voices and subtitles, ogg compressed sfx/speech)'
     notes: ''
 -
     category: games
-    game_id: queen
+    game_id: 'queen:queen'
     category_icon: queen
     url: 'Flight of the Amazon Queen/FOTAQ_Heb_talkie.zip'
     name: 'Freeware CD Version (Hebrew subtitles, English voices, ogg compressed sfx/speech)'
     notes: ''
 -
     category: games
-    game_id: queen
+    game_id: 'queen:queen'
     category_icon: queen
     url: 'Flight of the Amazon Queen/FOTAQ_It_Talkie_1.0.zip'
     name: 'Freeware CD Version (Italian subtitles, English voices, ogg compressed sfx/speech)'
     notes: ''
 -
     category: games
-    game_id: queen
+    game_id: 'queen:queen'
     category_icon: queen
     url: 'Flight of the Amazon Queen/FOTAQ_Floppy.zip'
     name: 'Freeware Floppy Version'
     notes: ''
 -
     category: games
-    game_id: queen
+    game_id: 'queen:queen'
     category_icon: queen
     url: 'Flight of the Amazon Queen/FOTAQ_Fr_Floppy.zip'
     name: 'Freeware Floppy Version (French)'
     notes: ''
 -
     category: games
-    game_id: griffon
+    game_id: 'griffon:griffon'
     category_icon: griffon
     url: 'Griffon Legend/griffon-1.0.zip'
     name: 'Freeware Version'
     notes: ''
 -
     category: games
-    game_id: lure
+    game_id: 'lure:lure'
     category_icon: lure
     url: 'Lure of the Temptress/lure-1.1.zip'
     name: 'Freeware Version (English)'
     notes: ''
 -
     category: games
-    game_id: lure
+    game_id: 'lure:lure'
     category_icon: lure
     url: 'Lure of the Temptress/lure-fr-1.1.zip'
     name: 'Freeware Version (French)'
     notes: ''
 -
     category: games
-    game_id: lure
+    game_id: 'lure:lure'
     category_icon: lure
     url: 'Lure of the Temptress/lure-de-1.1.zip'
     name: 'Freeware Version (German)'
     notes: ''
 -
     category: games
-    game_id: lure
+    game_id: 'lure:lure'
     category_icon: lure
     url: 'Lure of the Temptress/lure-it-1.1.zip'
     name: 'Freeware Version (Italian)'
     notes: ''
 -
     category: games
-    game_id: lure
+    game_id: 'lure:lure'
     category_icon: lure
     url: 'Lure of the Temptress/lure-es-1.1.zip'
     name: 'Freeware Version (Spanish)'
     notes: ''
 -
     category: games
-    game_id: hires1
+    game_id: 'adl:hires1'
     category_icon: mysthous
     url: 'Mystery House/MYSTHOUS.zip'
     name: 'public domain version (Apple II)'
     notes: ''
 -
     category: games
-    game_id: hires1
+    game_id: 'adl:hires1'
     category_icon: mysthous
     url: 'Mystery House/mysthous-fr.zip'
     name: 'public domain version (French) (Apple II)'
     notes: ''
 -
     category: games
-    game_id: nippon
+    game_id: 'parallaction:nippon'
     category_icon: nippon
     url: 'Nippon Safes/nippon-1.0.zip'
     name: 'Freeware DOS Version (English/French/German/Italian)'
     notes: ''
 -
     category: games
-    game_id: nippon
+    game_id: 'parallaction:nippon'
     category_icon: nippon
     url: 'Nippon Safes/nippon-amiga-1.0.zip'
     name: 'Freeware Amiga Version (English/French/German)'
     notes: ''
 -
     category: games
-    game_id: nippon
+    game_id: 'parallaction:nippon'
     category_icon: nippon
     url: 'Nippon Safes/nippon-amiga-disks-1.0.zip'
     name: 'Disk Images of Freeware Amiga Version (English/French/German)'
     notes: ''
 -
     category: games
-    game_id: nippon
+    game_id: 'parallaction:nippon'
     category_icon: nippon
     url: 'Nippon Safes/nippon-amiga-it-1.0.zip'
     name: 'Freeware Amiga Version (Italian)'
     notes: ''
 -
     category: games
-    game_id: nippon
+    game_id: 'parallaction:nippon'
     category_icon: nippon
     url: 'Nippon Safes/nippon-manual-addons-1.0.zip'
     name: 'Manuals (English/French/German/Italian), Box, Stickers, Disk labels'
     notes: ''
 -
     category: games
-    game_id: sfinx
+    game_id: 'cge2:sfinx'
     category_icon: sfinx
     url: Sfinx/sfinx-en-v1.1.zip
     name: 'Freeware Version (English, v1.1)'
     notes: ''
 -
     category: games
-    game_id: sfinx
+    game_id: 'cge2:sfinx'
     category_icon: sfinx
     url: Sfinx/sfinx-pl-v1.1.zip
     name: 'Freeware Version (Polish, v1.1)'
     notes: ''
 -
     category: games
-    game_id: soltys
+    game_id: 'cge:soltys'
     category_icon: soltys
     url: Soltys/soltys-en-v1.0.zip
     name: 'Freeware Version (English)'
     notes: ''
 -
     category: games
-    game_id: soltys
+    game_id: 'cge:soltys'
     category_icon: soltys
     url: Soltys/soltys-pl-v1.0.zip
     name: 'Freeware Version (Polish)'
     notes: ''
 -
     category: games
-    game_id: soltys
+    game_id: 'cge:soltys'
     category_icon: soltys
     url: Soltys/soltys-es-v1.0.zip
     name: 'Freeware Version (Spanish)'
     notes: ''
 -
     category: addons
-    game_id: bladerunner
+    game_id: 'bladerunner:bladerunner'
     category_icon: bladerunner
     url: 'Blade Runner/Blade_Runner_Subtitles-v8.zip'
     name: 'Subtitles (English, French, German, Italian, Spanish Subtitles AddOn)'
     notes: 'Requires ScummVM 2.1.0'
 -
     category: addons
-    game_id: sword1
+    game_id: 'sword1:sword1'
     category_icon: flac
     url: 'Broken Sword I and II/Sword1_DXA_Cutscenes.zip'
     name: 'Cutscene Pack (English, DXA compression)'
     notes: 'Requires ScummVM 0.10.0'
 -
     category: addons
-    game_id: sword1
+    game_id: 'sword1:sword1'
     category_icon: ogg
     url: 'https://downloads.scummbr.com/Sword1_Cutscenes_BRA_Complete.zip'
     name: 'Cutscene Pack (Brazilian)'
     notes: '(38M) This is an offsite package with both Brazillian videos and audio'
 -
     category: addons
-    game_id: sword1
+    game_id: 'sword1:sword1'
     category_icon: sword
     url: 'Broken Sword I and II/Sword1_Cutscenes_Subtitles-1.0.zip'
     name: 'Cutscene Pack (all languages, Subtitles AddOn)'
     notes: 'Cutscene subtitles pack. All languages'
 -
     category: addons
-    game_id: sword1
+    game_id: 'sword1:sword1'
     category_icon: sword
     url: 'Broken Sword I and II/Sword1_Cutscenes_Subtitles-1.1.zip'
     name: 'Cutscene Pack (all languages, Updated Subtitles AddOn) - requires ScummVM 1.5.0 or more'
     notes: 'Cutscene subtitles pack. All languages'
 -
     category: addons
-    game_id: sword1
+    game_id: 'sword1:sword1'
     category_icon: flac
     url: 'Broken Sword I and II/Sword1_Cutscenes_DXA_FRE_AddOn.zip'
     name: 'Cutscene Pack (French AddOn)'
     notes: 'Overwrite files in English Pack with files from this archive'
 -
     category: addons
-    game_id: sword1
+    game_id: 'sword1:sword1'
     category_icon: flac
     url: 'Broken Sword I and II/Sword1_Cutscenes_DXA_GER_AddOn.zip'
     name: 'Cutscene Pack (German AddOn)'
     notes: 'Overwrite files in English Pack with files from this archive'
 -
     category: addons
-    game_id: sword1
+    game_id: 'sword1:sword1'
     category_icon: flac
     url: 'Broken Sword I and II/Sword1_Cutscenes_DXA_ITA_AddOn.zip'
     name: 'Cutscene Pack (Italian AddOn)'
     notes: 'Overwrite files in English Pack with files from this archive'
 -
     category: addons
-    game_id: sword1
+    game_id: 'sword1:sword1'
     category_icon: flac
     url: 'Broken Sword I and II/Sword1_Cutscenes_DXA_ESP_AddOn.zip'
     name: 'Cutscene Pack (Spanish AddOn)'
     notes: 'Overwrite files in English Pack with files from this archive'
 -
     category: addons
-    game_id: sword1
+    game_id: 'sword1:sword1'
     category_icon: flac
     url: 'Broken Sword I and II/Sword1_Demo_Cutscenes.zip'
     name: 'Demo Cutscene Pack'
     notes: 'Requires ScummVM 0.10.0'
 -
     category: addons
-    game_id: sword1
+    game_id: 'sword1:sword1'
     category_icon: ogg
     url: 'Broken Sword I and II/Sword1_OGG_Cutscenes.zip'
     name: 'Cutscene Pack (English OGG AddOn)'
     notes: 'Alternative English audio pack, for ports without FLAC support'
 -
     category: addons
-    game_id: sword1
+    game_id: 'sword1:sword1'
     category_icon: ogg
     url: 'Broken Sword I and II/Sword1_Cutscenes_FRE_AddOn.zip'
     name: 'Cutscene Pack (French OGG AddOn)'
     notes: 'Alternative French audio pack, for ports without FLAC support'
 -
     category: addons
-    game_id: sword1
+    game_id: 'sword1:sword1'
     category_icon: ogg
     url: 'Broken Sword I and II/Sword1_Cutscenes_GER_AddOn.zip'
     name: 'Cutscene Pack (German OGG AddOn)'
     notes: 'Alternative German audio pack, for ports without FLAC support'
 -
     category: addons
-    game_id: sword1
+    game_id: 'sword1:sword1'
     category_icon: ogg
     url: 'Broken Sword I and II/Sword1_Cutscenes_ITA_AddOn.zip'
     name: 'Cutscene Pack (Italian OGG AddOn)'
     notes: 'Alternative Italian audio pack, for ports without FLAC support'
 -
     category: addons
-    game_id: sword1
+    game_id: 'sword1:sword1'
     category_icon: ogg
     url: 'Broken Sword I and II/Sword1_Cutscenes_ESP_AddOn.zip'
     name: 'Cutscene Pack (Spanish OGG AddOn)'
     notes: 'Alternative Spanish audio pack, for ports without FLAC support'
 -
     category: addons
-    game_id: sword2
+    game_id: 'sword2:sword2'
     category_icon: flac
     url: 'Broken Sword I and II/Sword2_DXA_Cutscenes.zip'
     name: 'Cutscene Pack (all languages, DXA compression)'
     notes: 'Requires ScummVM 0.10.0'
 -
     category: addons
-    game_id: sword2
+    game_id: 'sword2:sword2'
     category_icon: ogg
     url: 'Broken Sword I and II/Sword2_OGG_Cutscenes.zip'
     name: 'Cutscene Pack (all languages, OGG AddOn)'
     notes: 'Alternative audio pack, for ports without FLAC support'
 -
     category: addons
-    game_id: sword2
+    game_id: 'sword2:sword2'
     category_icon: flac
     url: 'Broken Sword I and II/Sword2_Demo_Cutscenes.zip'
     name: 'Demo Cutscene Pack'
     notes: 'Requires ScummVM 0.10.0'
 -
     category: addons
-    game_id: elvira2
+    game_id: 'agos:elvira2'
     category_icon: flac
     url: 'Elvira 2/elvira2_pc_sfx.zip'
     name: 'Digital samples for sound effects in the PC version'
     notes: 'Requires ScummVM 1.8.0'
 -
     category: addons
-    game_id: feeble
+    game_id: 'agos:feeble'
     category_icon: flac
     url: 'The Feeble Files/Feeble_OmniTV_Cutscenes.zip'
     name: 'Omni TV and epilogue cutscenes for the Amiga and Macintosh versions'
     notes: 'Requires ScummVM 0.10.0'
 -
     category: addons
-    game_id: queen
+    game_id: 'queen:queen'
     category_icon: mp3
     url: 'Flight of the Amazon Queen/FOTAQ_Talkie-1.1.zip'
     name: 'Freeware CD Version (mp3 compressed sfx/speech)'
     notes: ''
 -
     category: addons
-    game_id: prince
+    game_id: 'prince:prince'
     category_icon: prince
     url: 'The Prince and the Coward/prince_translation.dat'
     name: 'Translations data file to play with English text'
     notes: 'Requires ScummVM 2.2.0'
 -
     category: addons
-    game_id: obsidian
+    game_id: 'mtropolis:obsidian'
     category_icon: obsidian
     url: Obsidian/obsidian-subtitles-main-v1.zip
     name: 'Subtitles (English)'
     notes: 'Requires ScummVM 2.7.0'
 -
     category: addons
-    game_id: toon
+    game_id: 'toon:toon'
     category_icon: toon
     url: Toonstruck/Toonstruck_Subtitles.zip
     name: 'Cutscene subtitles (English)'

--- a/data/en/games.yaml
+++ b/data/en/games.yaml
@@ -1,6 +1,6 @@
 # This is a generated file, please do not edit manually
 -
-    id: amazon
+    id: 'access:amazon'
     name: 'Amazon: Guardians of Eden'
     engine_id: access
     company_id: access
@@ -12,7 +12,7 @@
     wikipedia_page: 'Amazon:_Guardians_of_Eden'
     series_id: ''
 -
-    id: 3geeks
+    id: 'ags:3geeks'
     name: '3 GEEKS'
     engine_id: ags
     company_id: adipson
@@ -24,7 +24,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: martian
+    id: 'access:martian'
     name: 'Martian Memorandum'
     engine_id: access
     company_id: access
@@ -36,7 +36,7 @@
     wikipedia_page: Martian_Memorandum
     series_id: texmurphy
 -
-    id: 5daysastranger
+    id: 'ags:5daysastranger'
     name: '5 Days A Stranger'
     engine_id: ags
     company_id: fullyramblomatic
@@ -48,7 +48,7 @@
     wikipedia_page: ''
     series_id: chzo
 -
-    id: 5ld
+    id: 'wintermute:5ld'
     name: 'Five Lethal Demons'
     engine_id: wintermute
     company_id: offstudio
@@ -60,7 +60,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: 5ma
+    id: 'wintermute:5ma'
     name: 'Five Magical Amulets'
     engine_id: wintermute
     company_id: offstudio
@@ -72,7 +72,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: 6daysasacrifice
+    id: 'ags:6daysasacrifice'
     name: '6 Days A Sacrifice'
     engine_id: ags
     company_id: fullyramblomatic
@@ -84,7 +84,7 @@
     wikipedia_page: ''
     series_id: chzo
 -
-    id: 7daysaskeptic
+    id: 'ags:7daysaskeptic'
     name: '7 Days A Skeptic'
     engine_id: ags
     company_id: fullyramblomatic
@@ -96,7 +96,7 @@
     wikipedia_page: ''
     series_id: chzo
 -
-    id: hires0
+    id: 'adl:hires0'
     name: 'Hi-Res Adventure #0: Mission Asteroid'
     engine_id: adl
     company_id: sierra
@@ -108,7 +108,7 @@
     wikipedia_page: Mission_Asteroid
     series_id: hires
 -
-    id: hires1
+    id: 'adl:hires1'
     name: 'Hi-Res Adventure #1: Mystery House'
     engine_id: adl
     company_id: sierra
@@ -120,7 +120,7 @@
     wikipedia_page: Mystery_House
     series_id: hires
 -
-    id: actualdest
+    id: 'wintermute:actualdest'
     name: 'Actual Destination'
     engine_id: wintermute
     company_id: blekinge
@@ -132,7 +132,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: adateinthepark
+    id: 'ags:adateinthepark'
     name: 'A Date in the Park'
     engine_id: ags
     company_id: cloakdagger
@@ -144,7 +144,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: hires2
+    id: 'adl:hires2'
     name: 'Hi-Res Adventure #2: The Wizard and the Princess'
     engine_id: adl
     company_id: sierra
@@ -156,7 +156,7 @@
     wikipedia_page: Wizard_and_the_Princess
     series_id: hires
 -
-    id: hires3
+    id: 'adl:hires3'
     name: 'Hi-Res Adventure #3: Cranston Manor'
     engine_id: adl
     company_id: sierra
@@ -168,7 +168,7 @@
     wikipedia_page: Cranston_Manor
     series_id: hires
 -
-    id: hires4
+    id: 'adl:hires4'
     name: 'Hi-Res Adventure #4: Ulysses and the Golden Fleece'
     engine_id: adl
     company_id: sierra
@@ -180,7 +180,7 @@
     wikipedia_page: Ulysses_and_the_Golden_Fleece
     series_id: hires
 -
-    id: hires5
+    id: 'adl:hires5'
     name: 'Hi-Res Adventure #5: Time Zone'
     engine_id: adl
     company_id: sierra
@@ -192,7 +192,7 @@
     wikipedia_page: Time_Zone_(video_game)
     series_id: hires
 -
-    id: hires6
+    id: 'adl:hires6'
     name: 'Hi-Res Adventure #6: The Dark Crystal'
     engine_id: adl
     company_id: sierra
@@ -204,7 +204,7 @@
     wikipedia_page: The_Dark_Crystal_(video_game)
     series_id: hires
 -
-    id: agi
+    id: 'agi:agi'
     name: 'Sierra AGI game'
     engine_id: agi
     company_id: sierra
@@ -216,7 +216,7 @@
     wikipedia_page: Adventure_Game_Interpreter
     series_id: sierranoseries
 -
-    id: agidemo
+    id: 'agi:agidemo'
     name: 'AGI Demo'
     engine_id: agi
     company_id: sierra
@@ -228,7 +228,7 @@
     wikipedia_page: ''
     series_id: sierranoseries
 -
-    id: bc
+    id: 'agi:bc'
     name: 'The Black Cauldron'
     engine_id: agi
     company_id: sierra
@@ -240,7 +240,7 @@
     wikipedia_page: The_Black_Cauldron_(video_game)
     series_id: disney
 -
-    id: caitlyn
+    id: 'agi:caitlyn'
     name: 'Caitlyn''s Destiny'
     engine_id: agi
     company_id: fan
@@ -252,7 +252,7 @@
     wikipedia_page: ''
     series_id: agifan
 -
-    id: ags
+    id: 'ags:ags'
     name: 'Adventure Game Studio games'
     engine_id: ags
     company_id: unknown
@@ -264,7 +264,7 @@
     wikipedia_page: Adventure_Game_Studio
     series_id: ''
 -
-    id: ddp
+    id: 'agi:ddp'
     name: 'Donald Duck''s Playground'
     engine_id: agi
     company_id: sierra
@@ -276,7 +276,7 @@
     wikipedia_page: Donald_Duck%27s_Playground
     series_id: disney
 -
-    id: agustin
+    id: 'wintermute:agustin'
     name: 'Boredom of Agustin Cordes'
     engine_id: wintermute
     company_id: cbe
@@ -288,7 +288,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: ainthegoffantabulousw
+    id: 'ags:ainthegoffantabulousw'
     name: 'Adventures in the Galaxy of Fantabulous Wonderment'
     engine_id: ags
     company_id: fullyramblomatic
@@ -300,7 +300,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: enclosure
+    id: 'agi:enclosure'
     name: 'Enclosure 1'
     engine_id: agi
     company_id: fan
@@ -312,7 +312,7 @@
     wikipedia_page: ''
     series_id: agifan
 -
-    id: goldrush
+    id: 'agi:goldrush'
     name: 'Gold Rush!'
     engine_id: agi
     company_id: sierra
@@ -324,7 +324,7 @@
     wikipedia_page: Gold_Rush!
     series_id: sierranoseries
 -
-    id: kq1
+    id: 'agi:kq1'
     name: 'King''s Quest I: Quest for the Crown'
     engine_id: agi
     company_id: sierra
@@ -336,7 +336,7 @@
     wikipedia_page: King%27s_Quest_I
     series_id: kq
 -
-    id: alemmo
+    id: 'ags:alemmo'
     name: 'Al Emmo And The Lost Dutchman''s Mine'
     engine_id: ags
     company_id: himalaya
@@ -348,7 +348,7 @@
     wikipedia_page: Al_Emmo_and_the_Lost_Dutchman%27s_Mine
     series_id: alemmo
 -
-    id: alemmoanozira
+    id: 'ags:alemmoanozira'
     name: 'Al Emmo''s Postcards from Anozira'
     engine_id: ags
     company_id: himalaya
@@ -360,7 +360,7 @@
     wikipedia_page: ''
     series_id: alemmo
 -
-    id: kq2
+    id: 'agi:kq2'
     name: 'King''s Quest II: Romancing the Throne'
     engine_id: agi
     company_id: sierra
@@ -372,7 +372,7 @@
     wikipedia_page: King%27s_Quest_II
     series_id: kq
 -
-    id: alimardan1
+    id: 'wintermute:alimardan1'
     name: 'Alimardan''s Mischief'
     engine_id: wintermute
     company_id: rskent
@@ -384,7 +384,7 @@
     wikipedia_page: ''
     series_id: alimardan
 -
-    id: alimardan2
+    id: 'wintermute:alimardan2'
     name: 'Alimardan Meets Merlin'
     engine_id: wintermute
     company_id: rskent
@@ -396,7 +396,7 @@
     wikipedia_page: ''
     series_id: alimardan
 -
-    id: alphapolaris
+    id: 'wintermute:alphapolaris'
     name: 'Alpha Polaris'
     engine_id: wintermute
     company_id: turmoil
@@ -408,7 +408,7 @@
     wikipedia_page: Alpha_Polaris
     series_id: ''
 -
-    id: kq3
+    id: 'agi:kq3'
     name: 'King''s Quest III: To Heir Is Human'
     engine_id: agi
     company_id: sierra
@@ -420,7 +420,7 @@
     wikipedia_page: King%27s_Quest_III
     series_id: kq
 -
-    id: kq4
+    id: 'agi:kq4'
     name: 'King''s Quest IV: The Perils of Rosella'
     engine_id: agi
     company_id: sierra
@@ -432,7 +432,7 @@
     wikipedia_page: King%27s_Quest_IV
     series_id: kq
 -
-    id: lsl1
+    id: 'agi:lsl1'
     name: 'Leisure Suit Larry in the Land of the Lounge Lizards'
     engine_id: agi
     company_id: sierra
@@ -444,7 +444,7 @@
     wikipedia_page: Leisure_Suit_Larry_in_the_Land_of_the_Lounge_Lizards
     series_id: lsl
 -
-    id: apeiron
+    id: 'wintermute:apeiron'
     name: Apeiron
     engine_id: wintermute
     company_id: blekinge
@@ -456,7 +456,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: apotheosis
+    id: 'ags:apotheosis'
     name: 'The Apotheosis Project'
     engine_id: ags
     company_id: midian
@@ -468,7 +468,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: apprentice
+    id: 'ags:apprentice'
     name: Apprentice
     engine_id: ags
     company_id: herculean
@@ -480,7 +480,7 @@
     wikipedia_page: Apprentice_(video_game)
     series_id: apprentice
 -
-    id: apprentice2
+    id: 'ags:apprentice2'
     name: 'Apprentice II: The Knight''s Move'
     engine_id: ags
     company_id: herculean
@@ -492,7 +492,7 @@
     wikipedia_page: ''
     series_id: apprentice
 -
-    id: mh1
+    id: 'agi:mh1'
     name: 'Manhunter: New York'
     engine_id: agi
     company_id: sierra
@@ -504,7 +504,7 @@
     wikipedia_page: 'Manhunter:_New_York'
     series_id: manhunt
 -
-    id: mh2
+    id: 'agi:mh2'
     name: 'Manhunter 2: San Francisco'
     engine_id: agi
     company_id: sierra
@@ -516,7 +516,7 @@
     wikipedia_page: 'Manhunter_2:_San_Francisco'
     series_id: manhunt
 -
-    id: mickey
+    id: 'agi:mickey'
     name: 'Mickey''s Space Adventure'
     engine_id: agi
     company_id: sierra
@@ -528,7 +528,7 @@
     wikipedia_page: Mickey%27s_Space_Adventure
     series_id: disney
 -
-    id: mixedup
+    id: 'agi:mixedup'
     name: 'Mixed-Up Mother Goose'
     engine_id: agi
     company_id: sierra
@@ -540,7 +540,7 @@
     wikipedia_page: Mixed-Up_Mother_Goose
     series_id: mixedup
 -
-    id: pq1
+    id: 'agi:pq1'
     name: 'Police Quest: In Pursuit of the Death Angel'
     engine_id: agi
     company_id: sierra
@@ -552,7 +552,7 @@
     wikipedia_page: 'Police_Quest:_In_Pursuit_of_the_Death_Angel'
     series_id: pq
 -
-    id: artofmurder1
+    id: 'wintermute:artofmurder1'
     name: 'Art of Murder: FBI Confidential'
     engine_id: wintermute
     company_id: cityint
@@ -564,7 +564,7 @@
     wikipedia_page: 'Art_of_Murder:_FBI_Confidential'
     series_id: artmurder
 -
-    id: qfg1
+    id: 'agi:qfg1'
     name: 'Hero''s Quest: So You Want to Be a Hero'
     engine_id: agi
     company_id: sierra
@@ -576,7 +576,7 @@
     wikipedia_page: 'Quest_for_Glory:_So_You_Want_to_Be_a_Hero'
     series_id: qfg
 -
-    id: ashinaredwitch
+    id: 'ags:ashinaredwitch'
     name: 'Ashina: The Red Witch'
     engine_id: ags
     company_id: stranga
@@ -588,7 +588,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: ashpines
+    id: 'ags:ashpines'
     name: 'Ash Pines'
     engine_id: ags
     company_id: stranga
@@ -600,7 +600,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: serguei1
+    id: 'agi:serguei1'
     name: 'Serguei''s Destiny'
     engine_id: agi
     company_id: fan
@@ -612,7 +612,7 @@
     wikipedia_page: ''
     series_id: agifan
 -
-    id: serguei2
+    id: 'agi:serguei2'
     name: 'Serguei''s Destiny 2'
     engine_id: agi
     company_id: fan
@@ -624,7 +624,7 @@
     wikipedia_page: ''
     series_id: agifan
 -
-    id: atotk
+    id: 'ags:atotk'
     name: 'A Tale Of Two Kingdoms'
     engine_id: ags
     company_id: crystalshard
@@ -636,7 +636,7 @@
     wikipedia_page: A_Tale_of_Two_Kingdoms
     series_id: ''
 -
-    id: sq0
+    id: 'agi:sq0'
     name: 'Space Quest 0: Replicated'
     engine_id: agi
     company_id: fan
@@ -648,7 +648,7 @@
     wikipedia_page: ''
     series_id: agifan
 -
-    id: sq1
+    id: 'agi:sq1'
     name: 'Space Quest: Chapter I - The Sarien Encounter'
     engine_id: agi
     company_id: sierra
@@ -660,7 +660,7 @@
     wikipedia_page: Space_Quest_I
     series_id: sq
 -
-    id: sq2
+    id: 'agi:sq2'
     name: 'Space Quest II: Chapter II - Vohaul''s Revenge'
     engine_id: agi
     company_id: sierra
@@ -672,7 +672,7 @@
     wikipedia_page: Space_Quest_II
     series_id: sq
 -
-    id: sqx
+    id: 'agi:sqx'
     name: 'Space Quest: The Lost Chapter'
     engine_id: agi
     company_id: fan
@@ -684,7 +684,7 @@
     wikipedia_page: ''
     series_id: agifan
 -
-    id: tetris
+    id: 'agi:tetris'
     name: 'AGI Tetris'
     engine_id: agi
     company_id: fan
@@ -696,7 +696,7 @@
     wikipedia_page: ''
     series_id: agifan
 -
-    id: troll
+    id: 'agi:troll'
     name: 'Troll''s Tale'
     engine_id: agi
     company_id: sierra
@@ -708,7 +708,7 @@
     wikipedia_page: Troll%27s_Tale
     series_id: sierranoseries
 -
-    id: barrowhilldp
+    id: 'wintermute:barrowhilldp'
     name: 'Barrow Hill: The Dark Path'
     engine_id: wintermute
     company_id: shadowtor
@@ -720,7 +720,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: voodoo
+    id: 'agi:voodoo'
     name: 'Voodoo Girl - Queen of the Darned'
     engine_id: agi
     company_id: fan
@@ -732,7 +732,7 @@
     wikipedia_page: ''
     series_id: agifan
 -
-    id: winnie
+    id: 'agi:winnie'
     name: 'Winnie the Pooh in the Hundred Acre Wood'
     engine_id: agi
     company_id: sierra
@@ -744,7 +744,7 @@
     wikipedia_page: Winnie_the_Pooh_in_the_Hundred_Acre_Wood
     series_id: disney
 -
-    id: xmascard
+    id: 'agi:xmascard'
     name: 'Xmas Card'
     engine_id: agi
     company_id: sierra
@@ -756,7 +756,7 @@
     wikipedia_page: ''
     series_id: sierrachristmas
 -
-    id: basisoctavus
+    id: 'wintermute:basisoctavus'
     name: 'Basis Octavus'
     engine_id: wintermute
     company_id: unknown
@@ -768,7 +768,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: dimp
+    id: 'agos:dimp'
     name: 'Simon the Sorcerer''s Puzzle Pack: Demon in my Pocket'
     engine_id: agos
     company_id: adventuresoft
@@ -780,7 +780,7 @@
     wikipedia_page: 'Simon_the_Sorcerer_(series)#Simon_the_Sorcerer''s_Puzzle_Pack'
     series_id: simon
 -
-    id: elvira1
+    id: 'agos:elvira1'
     name: 'Elvira: Mistress of the Dark'
     engine_id: agos
     company_id: adventuresoft
@@ -792,7 +792,7 @@
     wikipedia_page: 'Elvira:_Mistress_of_the_Dark_(video_game)'
     series_id: elvira
 -
-    id: elvira2
+    id: 'agos:elvira2'
     name: 'Elvira II: The Jaws of Cerberus'
     engine_id: agos
     company_id: adventuresoft
@@ -804,7 +804,7 @@
     wikipedia_page: 'Elvira_II:_The_Jaws_of_Cerberus'
     series_id: elvira
 -
-    id: feeble
+    id: 'agos:feeble'
     name: 'The Feeble Files'
     engine_id: agos
     company_id: adventuresoft
@@ -816,7 +816,7 @@
     wikipedia_page: The_Feeble_Files
     series_id: ''
 -
-    id: jumble
+    id: 'agos:jumble'
     name: 'Simon the Sorcerer''s Puzzle Pack: Jumble'
     engine_id: agos
     company_id: adventuresoft
@@ -828,7 +828,7 @@
     wikipedia_page: 'Simon_the_Sorcerer_(series)#Simon_the_Sorcerer''s_Puzzle_Pack'
     series_id: simon
 -
-    id: pn
+    id: 'agos:pn'
     name: 'Personal Nightmare'
     engine_id: agos
     company_id: adventuresoft
@@ -840,7 +840,7 @@
     wikipedia_page: Personal_Nightmare
     series_id: ''
 -
-    id: beer
+    id: 'ags:beer'
     name: Beer!
     engine_id: ags
     company_id: crystalshard
@@ -852,7 +852,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: bentheredanthat
+    id: 'ags:bentheredanthat'
     name: 'Ben There, Dan That!'
     engine_id: ags
     company_id: zombiecow
@@ -864,7 +864,7 @@
     wikipedia_page: 'Ben_There,_Dan_That!'
     series_id: ''
 -
-    id: puzzle
+    id: 'agos:puzzle'
     name: 'Simon the Sorcerer''s Puzzle Pack: NoPatience'
     engine_id: agos
     company_id: adventuresoft
@@ -876,7 +876,7 @@
     wikipedia_page: 'Simon_the_Sorcerer_(series)#Simon_the_Sorcerer''s_Puzzle_Pack'
     series_id: simon
 -
-    id: beyondowlsgard
+    id: 'ags:beyondowlsgard'
     name: 'Beyond the Edge of Owlsgard'
     engine_id: ags
     company_id: watchdatoast
@@ -888,7 +888,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: bickadoodle
+    id: 'wintermute:bickadoodle'
     name: Bickadoodle
     engine_id: wintermute
     company_id: aetheric
@@ -900,7 +900,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: billymasterswasright
+    id: 'ags:billymasterswasright'
     name: 'Billy Masters Was Right'
     engine_id: ags
     company_id: postmodern
@@ -912,7 +912,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: simon1
+    id: 'agos:simon1'
     name: 'Simon the Sorcerer'
     engine_id: agos
     company_id: adventuresoft
@@ -924,7 +924,7 @@
     wikipedia_page: Simon_the_Sorcerer
     series_id: simon
 -
-    id: simon2
+    id: 'agos:simon2'
     name: 'Simon the Sorcerer II: The Lion, the Wizard and the Wardrobe'
     engine_id: agos
     company_id: adventuresoft
@@ -936,7 +936,7 @@
     wikipedia_page: 'Simon_the_Sorcerer_II:_The_Lion,_the_Wizard_and_the_Wardrobe'
     series_id: simon
 -
-    id: swampy
+    id: 'agos:swampy'
     name: 'Simon the Sorcerer''s Puzzle Pack: Swampy Adventures'
     engine_id: agos
     company_id: adventuresoft
@@ -948,7 +948,7 @@
     wikipedia_page: 'Simon_the_Sorcerer_(series)#Simon_the_Sorcerer''s_Puzzle_Pack'
     series_id: simon
 -
-    id: waxworks
+    id: 'agos:waxworks'
     name: Waxworks
     engine_id: agos
     company_id: adventuresoft
@@ -960,7 +960,7 @@
     wikipedia_page: Waxworks_(1992_video_game)
     series_id: ''
 -
-    id: blackwell1
+    id: 'ags:blackwell1'
     name: 'The Blackwell Legacy'
     engine_id: ags
     company_id: wadjet
@@ -972,7 +972,7 @@
     wikipedia_page: The_Blackwell_Legacy
     series_id: blackwell
 -
-    id: blackwell2
+    id: 'ags:blackwell2'
     name: 'Blackwell Unbound'
     engine_id: ags
     company_id: wadjet
@@ -984,7 +984,7 @@
     wikipedia_page: Blackwell_Unbound
     series_id: blackwell
 -
-    id: blackwell3
+    id: 'ags:blackwell3'
     name: 'The Blackwell Convergence'
     engine_id: ags
     company_id: wadjet
@@ -996,7 +996,7 @@
     wikipedia_page: The_Blackwell_Convergence
     series_id: blackwell
 -
-    id: blackwell4
+    id: 'ags:blackwell4'
     name: 'The Blackwell Deception'
     engine_id: ags
     company_id: wadjet
@@ -1008,7 +1008,7 @@
     wikipedia_page: The_Blackwell_Deception
     series_id: blackwell
 -
-    id: blackwell5
+    id: 'ags:blackwell5'
     name: 'The Blackwell Epiphany'
     engine_id: ags
     company_id: wadjet
@@ -1020,7 +1020,7 @@
     wikipedia_page: The_Blackwell_Epiphany
     series_id: blackwell
 -
-    id: shivah
+    id: 'ags:shivah'
     name: 'The Shivah'
     engine_id: ags
     company_id: wadjet
@@ -1032,7 +1032,7 @@
     wikipedia_page: The_Shivah
     series_id: ''
 -
-    id: sanitarium
+    id: 'asylum:sanitarium'
     name: Sanitarium
     engine_id: asylum
     company_id: dreamforge
@@ -1044,7 +1044,7 @@
     wikipedia_page: Sanitarium_(video_game)
     series_id: ''
 -
-    id: avalanche
+    id: 'avalanche:avalanche'
     name: 'Lord Avalot d''Argent'
     engine_id: avalanche
     company_id: thorsoft
@@ -1056,7 +1056,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: bbvs
+    id: 'bbvs:bbvs'
     name: 'MTV''s Beavis and Butt-Head in Virtual Stupidity'
     engine_id: bbvs
     company_id: viacom
@@ -1068,7 +1068,7 @@
     wikipedia_page: Beavis_and_Butt-Head_in_Virtual_Stupidity
     series_id: beavisbutthead
 -
-    id: bookofgron
+    id: 'wintermute:bookofgron'
     name: 'Book of Gron Part One'
     engine_id: wintermute
     company_id: maximyz
@@ -1080,7 +1080,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: bladerunner
+    id: 'bladerunner:bladerunner'
     name: 'Blade Runner'
     engine_id: bladerunner
     company_id: westwood
@@ -1092,7 +1092,7 @@
     wikipedia_page: Blade_Runner_(1997_video_game)
     series_id: ''
 -
-    id: bladerunner-final
+    id: 'bladerunner:bladerunner-final'
     name: 'Blade Runner with restored content'
     engine_id: bladerunner
     company_id: westwood
@@ -1104,7 +1104,7 @@
     wikipedia_page: Blade_Runner_(1997_video_game)
     series_id: ''
 -
-    id: bthreshold
+    id: 'wintermute:bthreshold'
     name: 'Beyond the Threshold'
     engine_id: wintermute
     company_id: nacht
@@ -1116,7 +1116,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: buried
+    id: 'buried:buried'
     name: 'The Journeyman Project 2: Buried in Time'
     engine_id: buried
     company_id: presto
@@ -1128,7 +1128,7 @@
     wikipedia_page: 'The_Journeyman_Project_2:_Buried_in_Time'
     series_id: journeyman
 -
-    id: soltys
+    id: 'cge:soltys'
     name: Sołtys
     engine_id: cge
     company_id: lkavalon
@@ -1140,7 +1140,7 @@
     wikipedia_page: Sołtys_(video_game)
     series_id: ''
 -
-    id: sfinx
+    id: 'cge2:sfinx'
     name: Sfinx
     engine_id: cge2
     company_id: lkavalon
@@ -1152,7 +1152,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: chewy
+    id: 'chewy:chewy'
     name: 'Chewy: Esc from F5'
     engine_id: chewy
     company_id: newgen
@@ -1164,7 +1164,7 @@
     wikipedia_page: 'Chewy:_Esc_from_F5'
     series_id: ''
 -
-    id: fw
+    id: 'cine:fw'
     name: 'Future Wars: Adventures in Time'
     engine_id: cine
     company_id: delphine
@@ -1176,7 +1176,7 @@
     wikipedia_page: Future_Wars
     series_id: ''
 -
-    id: os
+    id: 'cine:os'
     name: '007: James Bond - The Stealth Affair'
     engine_id: cine
     company_id: delphine
@@ -1188,7 +1188,7 @@
     wikipedia_page: Operation_Stealth
     series_id: ''
 -
-    id: babayaga
+    id: 'composer:babayaga'
     name: 'Magic Tales: Baba Yaga and the Magic Geese'
     engine_id: composer
     company_id: animationmagic
@@ -1200,7 +1200,7 @@
     wikipedia_page: Magic_Tales
     series_id: magictales
 -
-    id: carolreed10
+    id: 'wintermute:carolreed10'
     name: 'Carol Reed 10 - Bosch''s Damnation'
     engine_id: wintermute
     company_id: mdna
@@ -1212,7 +1212,7 @@
     wikipedia_page: Carol_Reed_Mysteries
     series_id: carol
 -
-    id: carolreed11
+    id: 'wintermute:carolreed11'
     name: 'Carol Reed 11 - Shades Of Black'
     engine_id: wintermute
     company_id: mdna
@@ -1224,7 +1224,7 @@
     wikipedia_page: Carol_Reed_Mysteries
     series_id: carol
 -
-    id: carolreed12
+    id: 'wintermute:carolreed12'
     name: 'Carol Reed 12 - Profound Red'
     engine_id: wintermute
     company_id: mdna
@@ -1236,7 +1236,7 @@
     wikipedia_page: Carol_Reed_Mysteries
     series_id: carol
 -
-    id: carolreed13
+    id: 'wintermute:carolreed13'
     name: 'Carol Reed 13 - The Birdwatcher'
     engine_id: wintermute
     company_id: mdna
@@ -1248,7 +1248,7 @@
     wikipedia_page: Carol_Reed_Mysteries
     series_id: carol
 -
-    id: carolreed14
+    id: 'wintermute:carolreed14'
     name: 'Carol Reed 14 - The Fall Of April'
     engine_id: wintermute
     company_id: mdna
@@ -1260,7 +1260,7 @@
     wikipedia_page: Carol_Reed_Mysteries
     series_id: carol
 -
-    id: carolreed15
+    id: 'wintermute:carolreed15'
     name: 'Carol Reed 15 - Geospots'
     engine_id: wintermute
     company_id: mdna
@@ -1272,7 +1272,7 @@
     wikipedia_page: Carol_Reed_Mysteries
     series_id: carol
 -
-    id: carolreed16
+    id: 'wintermute:carolreed16'
     name: 'Carol Reed 16 - Quarantine Diary'
     engine_id: wintermute
     company_id: mdna
@@ -1284,7 +1284,7 @@
     wikipedia_page: Carol_Reed_Mysteries
     series_id: carol
 -
-    id: carolreed4
+    id: 'wintermute:carolreed4'
     name: 'Carol Reed 4 - East Side Story'
     engine_id: wintermute
     company_id: mdna
@@ -1296,7 +1296,7 @@
     wikipedia_page: Carol_Reed_Mysteries
     series_id: carol
 -
-    id: carolreed5
+    id: 'wintermute:carolreed5'
     name: 'Carol Reed 5 - The Colour of Murder'
     engine_id: wintermute
     company_id: mdna
@@ -1308,7 +1308,7 @@
     wikipedia_page: Carol_Reed_Mysteries
     series_id: carol
 -
-    id: carolreed6
+    id: 'wintermute:carolreed6'
     name: 'Carol Reed 6 - Black Circle'
     engine_id: wintermute
     company_id: mdna
@@ -1320,7 +1320,7 @@
     wikipedia_page: Carol_Reed_Mysteries
     series_id: carol
 -
-    id: carolreed7
+    id: 'wintermute:carolreed7'
     name: 'Carol Reed 7 - Blue Madonna'
     engine_id: wintermute
     company_id: mdna
@@ -1332,7 +1332,7 @@
     wikipedia_page: Carol_Reed_Mysteries
     series_id: carol
 -
-    id: carolreed8
+    id: 'wintermute:carolreed8'
     name: 'Carol Reed 8 - Amber''s Blood'
     engine_id: wintermute
     company_id: mdna
@@ -1344,7 +1344,7 @@
     wikipedia_page: Carol_Reed_Mysteries
     series_id: carol
 -
-    id: carolreed9
+    id: 'wintermute:carolreed9'
     name: 'Carol Reed 9 - Cold Case Summer'
     engine_id: wintermute
     company_id: mdna
@@ -1356,7 +1356,7 @@
     wikipedia_page: Carol_Reed_Mysteries
     series_id: carol
 -
-    id: cartlife
+    id: 'ags:cartlife'
     name: 'Cart Life'
     engine_id: ags
     company_id: hofmeier
@@ -1368,7 +1368,7 @@
     wikipedia_page: Cart_Life
     series_id: ''
 -
-    id: darby
+    id: 'composer:darby'
     name: 'Darby the Dragon'
     engine_id: composer
     company_id: animationmagic
@@ -1380,7 +1380,7 @@
     wikipedia_page: Darby_the_Dragon
     series_id: ''
 -
-    id: castledornstein
+    id: 'ags:castledornstein'
     name: 'Castle Dornstein'
     engine_id: ags
     company_id: digitalmosaic
@@ -1392,7 +1392,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: gregory
+    id: 'composer:gregory'
     name: 'Gregory and the Hot Air Balloon'
     engine_id: composer
     company_id: animationmagic
@@ -1404,7 +1404,7 @@
     wikipedia_page: Gregory_and_the_Hot_Air_Balloon
     series_id: ''
 -
-    id: imoking
+    id: 'composer:imoking'
     name: 'Magic Tales: Imo & the King'
     engine_id: composer
     company_id: animationmagic
@@ -1416,7 +1416,7 @@
     wikipedia_page: Magic_Tales
     series_id: magictales
 -
-    id: liam
+    id: 'composer:liam'
     name: 'Magic Tales: Liam Finds a Story'
     engine_id: composer
     company_id: animationmagic
@@ -1428,7 +1428,7 @@
     wikipedia_page: Magic_Tales
     series_id: magictales
 -
-    id: charnelhousetrilogy
+    id: 'ags:charnelhousetrilogy'
     name: 'The Charnel House Trilogy'
     engine_id: ags
     company_id: owlcave
@@ -1440,7 +1440,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: chronicleofinnsmouth
+    id: 'ags:chronicleofinnsmouth'
     name: 'Chronicle of Innsmouth'
     engine_id: ags
     company_id: psychodev
@@ -1452,7 +1452,7 @@
     wikipedia_page: ''
     series_id: innsmouth
 -
-    id: littlesamurai
+    id: 'composer:littlesamurai'
     name: 'Magic Tales: The Little Samurai'
     engine_id: composer
     company_id: animationmagic
@@ -1464,7 +1464,7 @@
     wikipedia_page: Magic_Tales
     series_id: magictales
 -
-    id: magictales
+    id: 'composer:magictales'
     name: 'Magic Tales'
     engine_id: composer
     company_id: animationmagic
@@ -1476,7 +1476,7 @@
     wikipedia_page: Magic_Tales
     series_id: magictales
 -
-    id: princess
+    id: 'composer:princess'
     name: 'Magic Tales: The Princess and the Crab'
     engine_id: composer
     company_id: animationmagic
@@ -1488,7 +1488,7 @@
     wikipedia_page: Magic_Tales
     series_id: magictales
 -
-    id: chivalry
+    id: 'wintermute:chivalry'
     name: 'Chivalry is Not Dead'
     engine_id: wintermute
     company_id: squinky
@@ -1500,7 +1500,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: sleepingcub
+    id: 'composer:sleepingcub'
     name: 'Magic Tales: Sleeping Cub''s Test of Courage'
     engine_id: composer
     company_id: animationmagic
@@ -1512,7 +1512,7 @@
     wikipedia_page: Magic_Tales
     series_id: magictales
 -
-    id: cruise
+    id: 'cruise:cruise'
     name: 'Cruise for a Corpse'
     engine_id: cruise
     company_id: delphine
@@ -1524,7 +1524,7 @@
     wikipedia_page: Cruise_for_a_Corpse
     series_id: ''
 -
-    id: losteden
+    id: 'cryo:losteden'
     name: 'Lost Eden'
     engine_id: cryo
     company_id: cryo
@@ -1536,7 +1536,7 @@
     wikipedia_page: Lost_Eden
     series_id: ''
 -
-    id: versailles
+    id: 'cryomni3d:versailles'
     name: 'Versailles 1685'
     engine_id: cryomni3d
     company_id: cryo
@@ -1548,7 +1548,7 @@
     wikipedia_page: Versailles_1685
     series_id: ''
 -
-    id: amber
+    id: 'director:amber'
     name: 'AMBER: Journeys Beyond'
     engine_id: director
     company_id: hueforest
@@ -1560,7 +1560,7 @@
     wikipedia_page: 'Amber:_Journeys_Beyond'
     series_id: ''
 -
-    id: betterd
+    id: 'director:betterd'
     name: 'The Better Dead Ratification'
     engine_id: director
     company_id: artsectorone
@@ -1572,7 +1572,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: chopsuey
+    id: 'director:chopsuey'
     name: 'Chop Suey'
     engine_id: director
     company_id: magnetinteractive
@@ -1584,7 +1584,7 @@
     wikipedia_page: Chop_Suey_(video_game)
     series_id: ''
 -
-    id: director
+    id: 'director:director'
     name: 'Macromedia Director Game'
     engine_id: director
     company_id: unknown
@@ -1596,7 +1596,7 @@
     wikipedia_page: Adobe_Director
     series_id: ''
 -
-    id: directortest
+    id: 'director:directortest'
     name: 'Macromedia Director Test Target'
     engine_id: director
     company_id: unknown
@@ -1608,7 +1608,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: directortest-all
+    id: 'director:directortest-all'
     name: 'Macromedia Director All Movies Test Target'
     engine_id: director
     company_id: unknown
@@ -1620,7 +1620,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: easternmind
+    id: 'director:easternmind'
     name: 'Eastern Mind'
     engine_id: director
     company_id: sony
@@ -1632,7 +1632,7 @@
     wikipedia_page: 'Eastern_Mind:_The_Lost_Souls_of_Tong_Nou'
     series_id: ''
 -
-    id: colorsoncanvas
+    id: 'wintermute:colorsoncanvas'
     name: 'Colors on Canvas'
     engine_id: wintermute
     company_id: unknown
@@ -1644,7 +1644,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: ernie
+    id: 'director:ernie'
     name: Ernie
     engine_id: director
     company_id: unknown
@@ -1656,7 +1656,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: conspiracao
+    id: 'wintermute:conspiracao'
     name: 'Conspiração Dumont'
     engine_id: wintermute
     company_id: unknown
@@ -1668,7 +1668,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: corrosion
+    id: 'wintermute:corrosion'
     name: 'Corrosion: Cold Winter Waiting'
     engine_id: wintermute
     company_id: viperante
@@ -1680,7 +1680,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: fukuokagoround
+    id: 'director:fukuokagoround'
     name: 'Fukuoka Go-Round'
     engine_id: director
     company_id: unknown
@@ -1692,7 +1692,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: ganbareinuchan
+    id: 'director:ganbareinuchan'
     name: 'Ganbare! Inuchan: Rock''n Roll Edition'
     engine_id: director
     company_id: emotion
@@ -1704,7 +1704,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: ganbareinuchan2
+    id: 'director:ganbareinuchan2'
     name: 'Ganbare! Inuchan: Trip Around the World'
     engine_id: director
     company_id: bfactory
@@ -1716,7 +1716,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: gundam0079
+    id: 'director:gundam0079'
     name: 'Gundam 0079: The War for Earth'
     engine_id: director
     company_id: presto
@@ -1728,7 +1728,7 @@
     wikipedia_page: 'Gundam_0079:_The_War_for_Earth'
     series_id: ''
 -
-    id: henachoco01
+    id: 'director:henachoco01'
     name: 'Henachoco #1'
     engine_id: director
     company_id: itachoco
@@ -1740,7 +1740,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: crystalshardadventurebundle
+    id: 'ags:crystalshardadventurebundle'
     name: 'Crystal Shard Adventure Bundle'
     engine_id: ags
     company_id: crystalshard
@@ -1752,7 +1752,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: henachoco02
+    id: 'director:henachoco02'
     name: 'Henachoco #2'
     engine_id: director
     company_id: itachoco
@@ -1764,7 +1764,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: henachoco03
+    id: 'director:henachoco03'
     name: 'Henachoco #3'
     engine_id: director
     company_id: itachoco
@@ -1776,7 +1776,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: henachoco04
+    id: 'director:henachoco04'
     name: 'Henachoco #4'
     engine_id: director
     company_id: itachoco
@@ -1788,7 +1788,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: henachoco05
+    id: 'director:henachoco05'
     name: 'Yaken Rodem'
     engine_id: director
     company_id: itachoco
@@ -1800,7 +1800,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: danewguys2
+    id: 'ags:danewguys2'
     name: 'Da New Guys: Day of the Jackass'
     engine_id: ags
     company_id: wadjet
@@ -1812,7 +1812,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: id4p1
+    id: 'director:id4p1'
     name: 'iD4 Mission Disk 1 - Alien Supreme Commander'
     engine_id: director
     company_id: trendmasters
@@ -1824,7 +1824,7 @@
     wikipedia_page: ''
     series_id: id4
 -
-    id: id4p10
+    id: 'director:id4p10'
     name: 'iD4 Mission Disk 10 - Alien Bomber'
     engine_id: director
     company_id: trendmasters
@@ -1836,7 +1836,7 @@
     wikipedia_page: ''
     series_id: id4
 -
-    id: darkfallls
+    id: 'wintermute:darkfallls'
     name: 'Dark Fall: Lost Souls'
     engine_id: wintermute
     company_id: darkling
@@ -1848,7 +1848,7 @@
     wikipedia_page: 'Dark_Fall:_Lost_Souls'
     series_id: darkfall
 -
-    id: id4p11
+    id: 'director:id4p11'
     name: 'iD4 Mission Disk 11 - Area 51'
     engine_id: director
     company_id: trendmasters
@@ -1860,7 +1860,7 @@
     wikipedia_page: ''
     series_id: id4
 -
-    id: id4p2
+    id: 'director:id4p2'
     name: 'ID4 Mission Disk 2: Alien Science Officer'
     engine_id: director
     company_id: trendmasters
@@ -1872,7 +1872,7 @@
     wikipedia_page: ''
     series_id: id4
 -
-    id: deadcity
+    id: 'wintermute:deadcity'
     name: 'Dead City'
     engine_id: wintermute
     company_id: nihilis
@@ -1884,7 +1884,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: id4p3
+    id: 'director:id4p3'
     name: 'iD4 Mission Disk 3 - Warrior Alien'
     engine_id: director
     company_id: trendmasters
@@ -1896,7 +1896,7 @@
     wikipedia_page: ''
     series_id: id4
 -
-    id: id4p4
+    id: 'director:id4p4'
     name: 'iD4 Mission Disk 4 - Alien Navigator'
     engine_id: director
     company_id: trendmasters
@@ -1908,7 +1908,7 @@
     wikipedia_page: ''
     series_id: id4
 -
-    id: detectivegallo
+    id: 'ags:detectivegallo'
     name: 'Detective Gallo'
     engine_id: ags
     company_id: footprints
@@ -1920,7 +1920,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: devilincapital
+    id: 'wintermute:devilincapital'
     name: 'Devil In The Capital'
     engine_id: wintermute
     company_id: rskent
@@ -1932,7 +1932,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: dfafadventure
+    id: 'wintermute:dfafadventure'
     name: 'DFAF Adventure'
     engine_id: wintermute
     company_id: jennybee
@@ -1944,7 +1944,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: id4p5
+    id: 'director:id4p5'
     name: 'iD4 Mission Disk 5 - Captain Steve Hiller'
     engine_id: director
     company_id: trendmasters
@@ -1956,7 +1956,7 @@
     wikipedia_page: ''
     series_id: id4
 -
-    id: id4p6
+    id: 'director:id4p6'
     name: 'ID4 Mission Disk 6: Technical Expert David Levinson'
     engine_id: director
     company_id: trendmasters
@@ -1968,7 +1968,7 @@
     wikipedia_page: ''
     series_id: id4
 -
-    id: id4p7
+    id: 'director:id4p7'
     name: 'iD4 Mission Disk 7 - President Whitmore'
     engine_id: director
     company_id: trendmasters
@@ -1980,7 +1980,7 @@
     wikipedia_page: ''
     series_id: id4
 -
-    id: id4p8
+    id: 'director:id4p8'
     name: 'iD4 Mission Disk 8 - Alien Attack Fighter'
     engine_id: director
     company_id: trendmasters
@@ -1992,7 +1992,7 @@
     wikipedia_page: ''
     series_id: id4
 -
-    id: id4p9
+    id: 'director:id4p9'
     name: 'iD4 Mission Disk 9 - FA-18 Fighter Jet'
     engine_id: director
     company_id: trendmasters
@@ -2004,7 +2004,7 @@
     wikipedia_page: ''
     series_id: id4
 -
-    id: japanart07
+    id: 'director:japanart07'
     name: 'Japan Art Today 07: Takashi Murakami - A Romantic Evening'
     engine_id: director
     company_id: aloalo
@@ -2016,7 +2016,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: dirtysplit
+    id: 'wintermute:dirtysplit'
     name: 'Dirty Split'
     engine_id: wintermute
     company_id: dreamagination
@@ -2028,7 +2028,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: jewels
+    id: 'director:jewels'
     name: 'Jewels of the Oracle'
     engine_id: director
     company_id: eloi
@@ -2040,7 +2040,7 @@
     wikipedia_page: Jewels_of_the_Oracle
     series_id: ''
 -
-    id: docapocalypse
+    id: 'ags:docapocalypse'
     name: 'Doc Apocalypse'
     engine_id: ags
     company_id: midian
@@ -2052,7 +2052,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: jman
+    id: 'director:jman'
     name: 'The Journeyman Project'
     engine_id: director
     company_id: presto
@@ -2064,7 +2064,7 @@
     wikipedia_page: The_Journeyman_Project_(video_game)
     series_id: journeyman
 -
-    id: donalddowell
+    id: 'ags:donalddowell'
     name: 'Donald Dowell and the Ghost of Barker Manor'
     engine_id: ags
     company_id: apemarina
@@ -2076,7 +2076,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: downfall2009
+    id: 'ags:downfall2009'
     name: 'Downfall (2009)'
     engine_id: ags
     company_id: harvester
@@ -2088,7 +2088,7 @@
     wikipedia_page: ''
     series_id: deviltrilogy
 -
-    id: downfall2016
+    id: 'ags:downfall2016'
     name: 'Downfall (2016)'
     engine_id: ags
     company_id: harvester
@@ -2100,7 +2100,7 @@
     wikipedia_page: ''
     series_id: deviltrilogy
 -
-    id: lzone
+    id: 'director:lzone'
     name: L-ZONE
     engine_id: director
     company_id: synergy
@@ -2112,7 +2112,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: majestic
+    id: 'director:majestic'
     name: 'Majestic Part 1: Alien Encounter'
     engine_id: director
     company_id: piranha
@@ -2124,7 +2124,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: mediaband
+    id: 'director:mediaband'
     name: 'Meet Mediaband'
     engine_id: director
     company_id: unknown
@@ -2136,7 +2136,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: melements
+    id: 'director:melements'
     name: 'Masters of the Elements'
     engine_id: director
     company_id: unknown
@@ -2148,7 +2148,7 @@
     wikipedia_page: Masters_of_the_Elements
     series_id: ''
 -
-    id: nemurenu
+    id: 'director:nemurenu'
     name: 'Nemurenu Yoru no Chiisana O-Hanashi'
     engine_id: director
     company_id: emotion
@@ -2160,7 +2160,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: drbohus
+    id: 'wintermute:drbohus'
     name: 'Dr. Bohus'
     engine_id: wintermute
     company_id: local
@@ -2172,7 +2172,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: drdoylemotch
+    id: 'wintermute:drdoylemotch'
     name: 'Dr. Doyle - Mystery Of The Cloche Hat'
     engine_id: wintermute
     company_id: pnc
@@ -2184,7 +2184,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: dreamcat
+    id: 'wintermute:dreamcat'
     name: Dreamcat
     engine_id: wintermute
     company_id: jennybee
@@ -2196,7 +2196,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: dreaming
+    id: 'wintermute:dreaming'
     name: 'Des Reves Elastiques Avec Mille Insectes Nommes Georges'
     engine_id: wintermute
     company_id: squinky
@@ -2208,7 +2208,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: dreamscape
+    id: 'wintermute:dreamscape'
     name: Dreamscape
     engine_id: wintermute
     company_id: blekinge
@@ -2220,7 +2220,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: overringunder
+    id: 'director:overringunder'
     name: Over-Ring-Under
     engine_id: director
     company_id: toshiba
@@ -2232,7 +2232,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: pepperon
+    id: 'director:pepperon'
     name: 'Valmaison au fil des saisons / Pepperon'
     engine_id: director
     company_id: flammarion
@@ -2244,7 +2244,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: driller
+    id: 'wintermute:driller'
     name: 'The Driller Incident'
     engine_id: wintermute
     company_id: unknown
@@ -2256,7 +2256,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: spyclub
+    id: 'director:spyclub'
     name: 'Spy Club'
     engine_id: director
     company_id: unknown
@@ -2268,7 +2268,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: dustbowl
+    id: 'ags:dustbowl'
     name: Dustbowl
     engine_id: ags
     company_id: pompous
@@ -2280,7 +2280,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: the7colors
+    id: 'director:the7colors'
     name: 'The Seven Colors: Legend of PSY・S City'
     engine_id: director
     company_id: sony
@@ -2292,7 +2292,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: theapartment
+    id: 'director:theapartment'
     name: 'The Apartment, Interactive demo'
     engine_id: director
     company_id: unknown
@@ -2304,7 +2304,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: timegal
+    id: 'director:timegal'
     name: 'Time Gal'
     engine_id: director
     company_id: taito
@@ -2316,7 +2316,7 @@
     wikipedia_page: Time_Gal
     series_id: ''
 -
-    id: vvdinosaur
+    id: 'director:vvdinosaur'
     name: 'The Awesome Adventures of Victor Vector & Yondo: The Last Dinosaur Egg'
     engine_id: director
     company_id: sanctuary
@@ -2328,7 +2328,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: vvvampire
+    id: 'director:vvvampire'
     name: 'The Awesome Adventures of Victor Vector & Yondo: The Vampire''s Coffin'
     engine_id: director
     company_id: sanctuary
@@ -2340,7 +2340,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: warlock
+    id: 'director:warlock'
     name: 'Spaceship Warlock'
     engine_id: director
     company_id: reactorinc
@@ -2352,7 +2352,7 @@
     wikipedia_page: Spaceship_Warlock
     series_id: ''
 -
-    id: dm
+    id: 'dm:dm'
     name: 'Dungeon Master'
     engine_id: dm
     company_id: ftl
@@ -2364,7 +2364,7 @@
     wikipedia_page: Dungeon_Master_(video_game)
     series_id: ''
 -
-    id: draci
+    id: 'draci:draci'
     name: 'Dragon History'
     engine_id: draci
     company_id: nosense
@@ -2376,7 +2376,7 @@
     wikipedia_page: Dračí_Historie
     series_id: ''
 -
-    id: dragons
+    id: 'dragons:dragons'
     name: 'Blazing Dragons'
     engine_id: dragons
     company_id: crystaldynamics
@@ -2388,7 +2388,7 @@
     wikipedia_page: Blazing_Dragons_(video_game)
     series_id: ''
 -
-    id: drascula
+    id: 'drascula:drascula'
     name: 'Dráscula: The Vampire Strikes Back'
     engine_id: drascula
     company_id: alcachofa
@@ -2400,7 +2400,7 @@
     wikipedia_page: 'Dráscula:_The_Vampire_Strikes_Back'
     series_id: ''
 -
-    id: dreamweb
+    id: 'dreamweb:dreamweb'
     name: DreamWeb
     engine_id: dreamweb
     company_id: creativereality
@@ -2412,7 +2412,7 @@
     wikipedia_page: DreamWeb
     series_id: ''
 -
-    id: 3dkit-fanmade
+    id: 'freescape:3dkit-fanmade'
     name: '3D Construction Kit'
     engine_id: freescape
     company_id: incentive
@@ -2424,7 +2424,7 @@
     wikipedia_page: 3D_Construction_Kit
     series_id: ''
 -
-    id: driller
+    id: 'freescape:driller'
     name: Driller
     engine_id: freescape
     company_id: incentive
@@ -2436,7 +2436,7 @@
     wikipedia_page: Driller_(video_game)
     series_id: ''
 -
-    id: erinmyers
+    id: 'wintermute:erinmyers'
     name: 'The Death of Erin Myers'
     engine_id: wintermute
     company_id: viperante
@@ -2448,7 +2448,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: adrift
+    id: 'glk:adrift'
     name: 'ADRIFT Interactive Fiction games'
     engine_id: glk
     company_id: glk
@@ -2460,7 +2460,7 @@
     wikipedia_page: ADRIFT
     series_id: ''
 -
-    id: escapemansion
+    id: 'wintermute:escapemansion'
     name: 'Escape from the Mansion'
     engine_id: wintermute
     company_id: fan
@@ -2472,7 +2472,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: everydaygray
+    id: 'wintermute:everydaygray'
     name: 'Everyday Grey'
     engine_id: wintermute
     company_id: krumbukt
@@ -2484,7 +2484,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: excavationhb
+    id: 'ags:excavationhb'
     name: 'The Excavation at Hob''s Barrow'
     engine_id: ags
     company_id: cloakdagger
@@ -2496,7 +2496,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: facenoir
+    id: 'wintermute:facenoir'
     name: 'Face Noir'
     engine_id: wintermute
     company_id: madorange
@@ -2508,7 +2508,7 @@
     wikipedia_page: Face_Noir
     series_id: ''
 -
-    id: advsys
+    id: 'glk:advsys'
     name: 'AdvSys Interactive Fiction games'
     engine_id: glk
     company_id: glk
@@ -2520,7 +2520,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: falconcity
+    id: 'ags:falconcity'
     name: 'Falcon City'
     engine_id: ags
     company_id: likely
@@ -2532,7 +2532,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: agt
+    id: 'glk:agt'
     name: 'AGT Interactive Fiction games'
     engine_id: glk
     company_id: glk
@@ -2544,7 +2544,7 @@
     wikipedia_page: Adventure_Game_Toolkit
     series_id: ''
 -
-    id: alan
+    id: 'glk:alan'
     name: 'Alan 2 & 3 Interactive Fiction games'
     engine_id: glk
     company_id: glk
@@ -2556,7 +2556,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: archetype
+    id: 'glk:archetype'
     name: 'Archetype Interactive Fiction games'
     engine_id: glk
     company_id: glk
@@ -2568,7 +2568,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: corruption
+    id: 'glk:corruption'
     name: Corruption
     engine_id: glk
     company_id: magnetic
@@ -2580,7 +2580,7 @@
     wikipedia_page: Corruption_(1988_video_game)
     series_id: ''
 -
-    id: crimsoncrown
+    id: 'glk:crimsoncrown'
     name: 'The Crimson Crown: Further Adventures in Transylvania'
     engine_id: glk
     company_id: polarware
@@ -2592,7 +2592,7 @@
     wikipedia_page: 'Transylvania_(series)#The_Crimson_Crown_-_Further_Adventures_in_Transylvania'
     series_id: transylvania
 -
-    id: feriadarles
+    id: 'ags:feriadarles'
     name: 'Feria d''Arles'
     engine_id: ags
     company_id: tomsimpson
@@ -2604,7 +2604,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: findinghope
+    id: 'wintermute:findinghope'
     name: 'Finding Hope'
     engine_id: wintermute
     company_id: goldenbough
@@ -2616,7 +2616,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: enchanter
+    id: 'glk:enchanter'
     name: Enchanter
     engine_id: glk
     company_id: infocom
@@ -2628,7 +2628,7 @@
     wikipedia_page: Enchanter_(video_game)
     series_id: enchanter
 -
-    id: fish
+    id: 'glk:fish'
     name: Fish!
     engine_id: glk
     company_id: magnetic
@@ -2640,7 +2640,7 @@
     wikipedia_page: Fish!
     series_id: ''
 -
-    id: glulx
+    id: 'glk:glulx'
     name: 'Glulx Interactive Fiction games'
     engine_id: glk
     company_id: glk
@@ -2652,7 +2652,7 @@
     wikipedia_page: Glulx
     series_id: ''
 -
-    id: guild
+    id: 'glk:guild'
     name: 'The Guild of Thieves'
     engine_id: glk
     company_id: magnetic
@@ -2664,7 +2664,7 @@
     wikipedia_page: The_Guild_of_Thieves
     series_id: ''
 -
-    id: footballgame
+    id: 'ags:footballgame'
     name: 'Football Game'
     engine_id: ags
     company_id: cloakdagger
@@ -2676,7 +2676,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: forgottensound1
+    id: 'wintermute:forgottensound1'
     name: 'Forgotten Sound 1 - Revelation'
     engine_id: wintermute
     company_id: rskent
@@ -2688,7 +2688,7 @@
     wikipedia_page: ''
     series_id: forgottensound
 -
-    id: forgottensound2
+    id: 'wintermute:forgottensound2'
     name: 'Forgotten Sound 2 - Destiny'
     engine_id: wintermute
     company_id: rskent
@@ -2700,7 +2700,7 @@
     wikipedia_page: ''
     series_id: forgottensound
 -
-    id: four
+    id: 'wintermute:four'
     name: Four
     engine_id: wintermute
     company_id: unknown
@@ -2712,7 +2712,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: foxtail
+    id: 'wintermute:foxtail'
     name: FoxTail
     engine_id: wintermute
     company_id: gingertips
@@ -2724,7 +2724,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: framed
+    id: 'wintermute:framed'
     name: Framed
     engine_id: wintermute
     company_id: blekinge
@@ -2736,7 +2736,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: hugo
+    id: 'glk:hugo'
     name: 'Hugo Interactive Fiction games'
     engine_id: glk
     company_id: glk
@@ -2748,7 +2748,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: jacl
+    id: 'glk:jacl'
     name: 'JACL Interactive Fiction games'
     engine_id: glk
     company_id: glk
@@ -2760,7 +2760,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: jinxter
+    id: 'glk:jinxter'
     name: Jinxter
     engine_id: glk
     company_id: magnetic
@@ -2772,7 +2772,7 @@
     wikipedia_page: Jinxter
     series_id: ''
 -
-    id: level9
+    id: 'glk:level9'
     name: 'Level 9 Interactive Fiction games'
     engine_id: glk
     company_id: glk
@@ -2784,7 +2784,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: myth
+    id: 'glk:myth'
     name: Myth
     engine_id: glk
     company_id: magnetic
@@ -2796,7 +2796,7 @@
     wikipedia_page: Myth_(1989_video_game)
     series_id: ''
 -
-    id: ootopos
+    id: 'glk:ootopos'
     name: OO-Topos
     engine_id: glk
     company_id: polarware
@@ -2808,7 +2808,7 @@
     wikipedia_page: Oo-Topos
     series_id: ''
 -
-    id: pawn
+    id: 'glk:pawn'
     name: 'The Pawn'
     engine_id: glk
     company_id: magnetic
@@ -2820,7 +2820,7 @@
     wikipedia_page: The_Pawn
     series_id: ''
 -
-    id: planetfall
+    id: 'glk:planetfall'
     name: Planetfall
     engine_id: glk
     company_id: infocom
@@ -2832,7 +2832,7 @@
     wikipedia_page: Planetfall
     series_id: planetfall
 -
-    id: quest
+    id: 'glk:quest'
     name: 'Quest Interactive Fiction games'
     engine_id: glk
     company_id: glk
@@ -2844,7 +2844,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: scottadams
+    id: 'glk:scottadams'
     name: 'Scott Adams Interactive Fiction games'
     engine_id: glk
     company_id: glk
@@ -2856,7 +2856,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: sorcerer
+    id: 'glk:sorcerer'
     name: Sorcerer
     engine_id: glk
     company_id: infocom
@@ -2868,7 +2868,7 @@
     wikipedia_page: Sorcerer_(video_game)
     series_id: enchanter
 -
-    id: spellbreaker
+    id: 'glk:spellbreaker'
     name: Spellbreaker
     engine_id: glk
     company_id: infocom
@@ -2880,7 +2880,7 @@
     wikipedia_page: Spellbreaker
     series_id: enchanter
 -
-    id: stationfall
+    id: 'glk:stationfall'
     name: Stationfall
     engine_id: glk
     company_id: infocom
@@ -2892,7 +2892,7 @@
     wikipedia_page: Stationfall
     series_id: planetfall
 -
-    id: talisman
+    id: 'glk:talisman'
     name: 'Talisman: Challenging the Sands of Time'
     engine_id: glk
     company_id: polarware
@@ -2904,7 +2904,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: transylvania
+    id: 'glk:transylvania'
     name: Transylvania
     engine_id: glk
     company_id: polarware
@@ -2916,7 +2916,7 @@
     wikipedia_page: Transylvania_(video_game)
     series_id: transylvania
 -
-    id: wonderland
+    id: 'glk:wonderland'
     name: Wonderland
     engine_id: glk
     company_id: magnetic
@@ -2928,7 +2928,7 @@
     wikipedia_page: Wonderland_(video_game)
     series_id: ''
 -
-    id: zcode
+    id: 'glk:zcode'
     name: 'ZCode (Infocom and Inform) Interactive Fiction games'
     engine_id: glk
     company_id: glk
@@ -2940,7 +2940,7 @@
     wikipedia_page: Z-machine
     series_id: ''
 -
-    id: zork0
+    id: 'glk:zork0'
     name: 'Zork Zero: The Revenge of Megaboz'
     engine_id: glk
     company_id: infocom
@@ -2952,7 +2952,7 @@
     wikipedia_page: Zork_Zero
     series_id: zork
 -
-    id: geminirue
+    id: 'ags:geminirue'
     name: 'Gemini Rue'
     engine_id: ags
     company_id: wadjet
@@ -2964,7 +2964,7 @@
     wikipedia_page: Gemini_Rue
     series_id: ''
 -
-    id: ghostsheet
+    id: 'wintermute:ghostsheet'
     name: 'Ghost in the Sheet'
     engine_id: wintermute
     company_id: cbe
@@ -2976,7 +2976,7 @@
     wikipedia_page: Ghost_in_the_Sheet
     series_id: ''
 -
-    id: zork1
+    id: 'glk:zork1'
     name: 'Zork I: The Great Underground Empire'
     engine_id: glk
     company_id: infocom
@@ -2988,7 +2988,7 @@
     wikipedia_page: Zork_I
     series_id: zork
 -
-    id: zork2
+    id: 'glk:zork2'
     name: 'Zork II: The Wizard of Frobozz'
     engine_id: glk
     company_id: infocom
@@ -3000,7 +3000,7 @@
     wikipedia_page: Zork_II
     series_id: zork
 -
-    id: zork3
+    id: 'glk:zork3'
     name: 'Zork III: The Dungeon Master'
     engine_id: glk
     company_id: infocom
@@ -3012,7 +3012,7 @@
     wikipedia_page: Zork_III
     series_id: zork
 -
-    id: ztuu
+    id: 'glk:ztuu'
     name: 'Zork: The Undiscovered Underground'
     engine_id: glk
     company_id: infocom
@@ -3024,7 +3024,7 @@
     wikipedia_page: 'Zork:_The_Undiscovered_Underground'
     series_id: zork
 -
-    id: gnap
+    id: 'gnap:gnap'
     name: U.F.O.s
     engine_id: gnap
     company_id: artech
@@ -3036,7 +3036,7 @@
     wikipedia_page: U.F.O.s_(video_game)
     series_id: ''
 -
-    id: abracadabra
+    id: 'gob:abracadabra'
     name: 'Once Upon A Time: Abracadabra'
     engine_id: gob
     company_id: coktel
@@ -3048,7 +3048,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: adi2
+    id: 'gob:adi2'
     name: 'ADI 2'
     engine_id: gob
     company_id: coktel
@@ -3060,7 +3060,7 @@
     wikipedia_page: ''
     series_id: adi
 -
-    id: adi4
+    id: 'gob:adi4'
     name: 'ADI 4'
     engine_id: gob
     company_id: coktel
@@ -3072,7 +3072,7 @@
     wikipedia_page: ''
     series_id: adi
 -
-    id: goldencalf
+    id: 'wintermute:goldencalf'
     name: 'The Golden Calf'
     engine_id: wintermute
     company_id: rootfix
@@ -3084,7 +3084,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: goldenwake
+    id: 'ags:goldenwake'
     name: 'A Golden Wake'
     engine_id: ags
     company_id: grundislav
@@ -3096,7 +3096,7 @@
     wikipedia_page: A_Golden_Wake
     series_id: ''
 -
-    id: adibou1
+    id: 'gob:adibou1'
     name: 'Adibou 1'
     engine_id: gob
     company_id: coktel
@@ -3108,7 +3108,7 @@
     wikipedia_page: ''
     series_id: adibou
 -
-    id: adibou2
+    id: 'gob:adibou2'
     name: 'Adibou 2'
     engine_id: gob
     company_id: coktel
@@ -3120,7 +3120,7 @@
     wikipedia_page: ''
     series_id: adibou
 -
-    id: grandmabadass
+    id: 'ags:grandmabadass'
     name: 'GrandMa Badass'
     engine_id: ags
     company_id: adipson
@@ -3132,7 +3132,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: ajworld
+    id: 'gob:ajworld'
     name: 'A.J.''s World of Discovery'
     engine_id: gob
     company_id: coktel
@@ -3144,7 +3144,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: babayagaonce
+    id: 'gob:babayagaonce'
     name: 'Once Upon A Time: Baba Yaga'
     engine_id: gob
     company_id: coktel
@@ -3156,7 +3156,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: bambou
+    id: 'gob:bambou'
     name: 'Playtoons Limited Edition - Bambou le sauveur de la jungle'
     engine_id: gob
     company_id: coktel
@@ -3168,7 +3168,7 @@
     wikipedia_page: ''
     series_id: playtoons
 -
-    id: bargon
+    id: 'gob:bargon'
     name: 'Bargon Attack'
     engine_id: gob
     company_id: coktel
@@ -3180,7 +3180,7 @@
     wikipedia_page: Bargon_Attack
     series_id: ''
 -
-    id: guardduty
+    id: 'ags:guardduty'
     name: 'Guard Duty'
     engine_id: ags
     company_id: headware
@@ -3192,7 +3192,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: crousti
+    id: 'gob:crousti'
     name: Croustibat
     engine_id: gob
     company_id: coktel
@@ -3204,7 +3204,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: dynasty
+    id: 'gob:dynasty'
     name: 'The Last Dynasty'
     engine_id: gob
     company_id: coktel
@@ -3216,7 +3216,7 @@
     wikipedia_page: The_Last_Dynasty
     series_id: ''
 -
-    id: dynastywood
+    id: 'gob:dynastywood'
     name: 'The Last Dynasty & Woodruff'
     engine_id: gob
     company_id: coktel
@@ -3228,7 +3228,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: hamlet
+    id: 'wintermute:hamlet'
     name: 'Hamlet or the last game without MMORPG features, shaders and product placement'
     engine_id: wintermute
     company_id: mif2000
@@ -3240,7 +3240,7 @@
     wikipedia_page: Hamlet_(video_game)
     series_id: ''
 -
-    id: fascination
+    id: 'gob:fascination'
     name: Fascination
     engine_id: gob
     company_id: coktel
@@ -3252,7 +3252,7 @@
     wikipedia_page: Fascination_(video_game)
     series_id: ''
 -
-    id: geisha
+    id: 'gob:geisha'
     name: Geisha
     engine_id: gob
     company_id: coktel
@@ -3264,7 +3264,7 @@
     wikipedia_page: Geisha_(video_game)
     series_id: ''
 -
-    id: helga
+    id: 'wintermute:helga'
     name: 'Helga Deep In Trouble'
     engine_id: wintermute
     company_id: offstudio
@@ -3276,7 +3276,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: gob1
+    id: 'gob:gob1'
     name: Gobliiins
     engine_id: gob
     company_id: coktel
@@ -3288,7 +3288,7 @@
     wikipedia_page: Gobliiins
     series_id: gob
 -
-    id: gob2
+    id: 'gob:gob2'
     name: 'Gobliins 2: The Prince Buffoon'
     engine_id: gob
     company_id: coktel
@@ -3300,7 +3300,7 @@
     wikipedia_page: 'Gobliiins#Gobliins_2:_The_Prince_Buffoon'
     series_id: gob
 -
-    id: gob3
+    id: 'gob:gob3'
     name: 'Goblins Quest 3'
     engine_id: gob
     company_id: coktel
@@ -3312,7 +3312,7 @@
     wikipedia_page: 'Gobliiins#Goblins_Quest_3'
     series_id: gob
 -
-    id: inca
+    id: 'gob:inca'
     name: Inca
     engine_id: gob
     company_id: coktel
@@ -3324,7 +3324,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: inca2
+    id: 'gob:inca2'
     name: 'Inca II: Nations of Immortality'
     engine_id: gob
     company_id: coktel
@@ -3336,7 +3336,7 @@
     wikipedia_page: 'Inca_(video_game)#Sequel'
     series_id: ''
 -
-    id: heroinesquest
+    id: 'ags:heroinesquest'
     name: 'Heroine''s Quest: The Herald of Ragnarok'
     engine_id: ags
     company_id: crystalshard
@@ -3348,7 +3348,7 @@
     wikipedia_page: Heroine%27s_Quest
     series_id: ''
 -
-    id: lit
+    id: 'gob:lit'
     name: 'Lost in Time'
     engine_id: gob
     company_id: coktel
@@ -3360,7 +3360,7 @@
     wikipedia_page: Lost_in_Time_(video_game)
     series_id: ''
 -
-    id: lit1
+    id: 'gob:lit1'
     name: 'Lost in Time Part 1'
     engine_id: gob
     company_id: coktel
@@ -3372,7 +3372,7 @@
     wikipedia_page: Lost_in_Time_(video_game)
     series_id: ''
 -
-    id: lit2
+    id: 'gob:lit2'
     name: 'Lost in Time Part 2'
     engine_id: gob
     company_id: coktel
@@ -3384,7 +3384,7 @@
     wikipedia_page: Lost_in_Time_(video_game)
     series_id: ''
 -
-    id: littlered
+    id: 'gob:littlered'
     name: 'Once Upon A Time: Little Red Riding Hood'
     engine_id: gob
     company_id: coktel
@@ -3396,7 +3396,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: onceupon
+    id: 'gob:onceupon'
     name: 'Once Upon A Time'
     engine_id: gob
     company_id: coktel
@@ -3408,7 +3408,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: playtnck1
+    id: 'gob:playtnck1'
     name: 'Playtoons Construction Kit 1 - Monsters'
     engine_id: gob
     company_id: coktel
@@ -3420,7 +3420,7 @@
     wikipedia_page: ''
     series_id: playtoons
 -
-    id: playtnck2
+    id: 'gob:playtnck2'
     name: 'Playtoons Construction Kit 2 - Knights'
     engine_id: gob
     company_id: coktel
@@ -3432,7 +3432,7 @@
     wikipedia_page: ''
     series_id: playtoons
 -
-    id: playtnck3
+    id: 'gob:playtnck3'
     name: 'Playtoons Construction Kit 3 - Far West'
     engine_id: gob
     company_id: coktel
@@ -3444,7 +3444,7 @@
     wikipedia_page: ''
     series_id: playtoons
 -
-    id: hor
+    id: 'wintermute:hor'
     name: Hor
     engine_id: wintermute
     company_id: romank
@@ -3456,7 +3456,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: playtoons1
+    id: 'gob:playtoons1'
     name: 'Playtoons 1 - Uncle Archibald'
     engine_id: gob
     company_id: coktel
@@ -3468,7 +3468,7 @@
     wikipedia_page: 'https://en.wikipedia.org/wiki/Playtoons#Uncle_Archibald'
     series_id: playtoons
 -
-    id: playtoons2
+    id: 'gob:playtoons2'
     name: 'Playtoons 2 - The Case of the Counterfeit Collaborator'
     engine_id: gob
     company_id: coktel
@@ -3480,7 +3480,7 @@
     wikipedia_page: 'https://en.wikipedia.org/wiki/Playtoons#The_Case_of_the_Counterfeit_Collaborator'
     series_id: playtoons
 -
-    id: playtoons3
+    id: 'gob:playtoons3'
     name: 'Playtoons 3 - The Secret of the Castle'
     engine_id: gob
     company_id: coktel
@@ -3492,7 +3492,7 @@
     wikipedia_page: 'https://en.wikipedia.org/wiki/Playtoons#The_Secret_of_the_Castle'
     series_id: playtoons
 -
-    id: playtoons4
+    id: 'gob:playtoons4'
     name: 'Playtoons 4 - The Mandarine Prince'
     engine_id: gob
     company_id: coktel
@@ -3504,7 +3504,7 @@
     wikipedia_page: 'https://en.wikipedia.org/wiki/Playtoons#The_Mandarin_Prince'
     series_id: playtoons
 -
-    id: playtoons5
+    id: 'gob:playtoons5'
     name: 'Playtoons 5 - The Stone of Wakan'
     engine_id: gob
     company_id: coktel
@@ -3516,7 +3516,7 @@
     wikipedia_page: 'https://en.wikipedia.org/wiki/Playtoons#The_Stone_of_Wakan'
     series_id: playtoons
 -
-    id: playtoonsdemo
+    id: 'gob:playtoonsdemo'
     name: 'Playtoon 1 - Uncle Archibald, Playtoon 2 - Spirou, Playtoons 3 - Secret of the Castle Demo)'
     engine_id: gob
     company_id: coktel
@@ -3528,7 +3528,7 @@
     wikipedia_page: Playtoons
     series_id: playtoons
 -
-    id: urban
+    id: 'gob:urban'
     name: 'Urban Runner'
     engine_id: gob
     company_id: coktel
@@ -3540,7 +3540,7 @@
     wikipedia_page: Urban_Runner
     series_id: ''
 -
-    id: ween
+    id: 'gob:ween'
     name: 'Ween: The Prophecy'
     engine_id: gob
     company_id: coktel
@@ -3552,7 +3552,7 @@
     wikipedia_page: The_Prophecy_(video_game)
     series_id: ''
 -
-    id: woodruff
+    id: 'gob:woodruff'
     name: 'The Bizarre Adventures of Woodruff and the Schnibble'
     engine_id: gob
     company_id: coktel
@@ -3564,7 +3564,7 @@
     wikipedia_page: The_Bizarre_Adventures_of_Woodruff_and_the_Schnibble
     series_id: ''
 -
-    id: griffon
+    id: 'griffon:griffon'
     name: 'The Griffon Legend'
     engine_id: griffon
     company_id: fan
@@ -3576,7 +3576,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: grim
+    id: 'grim:grim'
     name: 'Grim Fandango'
     engine_id: grim
     company_id: lucasarts
@@ -3588,7 +3588,7 @@
     wikipedia_page: Grim_Fandango
     series_id: lucasartsnoseries
 -
-    id: monkey4
+    id: 'grim:monkey4'
     name: 'Escape From Monkey Island'
     engine_id: grim
     company_id: lucasarts
@@ -3600,7 +3600,7 @@
     wikipedia_page: Escape_from_Monkey_Island
     series_id: mi
 -
-    id: 11h
+    id: 'groovie:11h'
     name: 'The 11th Hour: The Sequel to The 7th Guest'
     engine_id: groovie
     company_id: trilobyte
@@ -3612,7 +3612,7 @@
     wikipedia_page: The_11th_Hour_(video_game)
     series_id: t7g
 -
-    id: clandestiny
+    id: 'groovie:clandestiny'
     name: Clandestiny
     engine_id: groovie
     company_id: trilobyte
@@ -3624,7 +3624,7 @@
     wikipedia_page: Clandestiny
     series_id: ''
 -
-    id: t7g
+    id: 'groovie:t7g'
     name: 'The 7th Guest'
     engine_id: groovie
     company_id: trilobyte
@@ -3636,7 +3636,7 @@
     wikipedia_page: The_7th_Guest
     series_id: t7g
 -
-    id: tlc
+    id: 'groovie:tlc'
     name: 'Tender Loving Care'
     engine_id: groovie
     company_id: aftermath
@@ -3648,7 +3648,7 @@
     wikipedia_page: Tender_Loving_Care_(video_game)
     series_id: ''
 -
-    id: unclehenry
+    id: 'groovie:unclehenry'
     name: 'Uncle Henry''s Playhouse'
     engine_id: groovie
     company_id: trilobyte
@@ -3660,7 +3660,7 @@
     wikipedia_page: Uncle_Henry%27s_Playhouse
     series_id: t7g
 -
-    id: hadesch
+    id: 'hadesch:hadesch'
     name: 'Hades Challenge'
     engine_id: hadesch
     company_id: disney
@@ -3672,7 +3672,7 @@
     wikipedia_page: 'Hercules_(franchise)#Hades_Challenge'
     series_id: ''
 -
-    id: hdb
+    id: 'hdb:hdb'
     name: 'Hyperspace Delivery Boy!'
     engine_id: hdb
     company_id: monkeystone
@@ -3684,7 +3684,7 @@
     wikipedia_page: Hyperspace_Delivery_Boy!
     series_id: ''
 -
-    id: hopkins
+    id: 'hopkins:hopkins'
     name: 'Hopkins FBI'
     engine_id: hopkins
     company_id: mpe
@@ -3696,7 +3696,7 @@
     wikipedia_page: Hopkins_FBI
     series_id: ''
 -
-    id: hugo1
+    id: 'hugo:hugo1'
     name: 'Hugo''s House of Horrors'
     engine_id: hugo
     company_id: graydesign
@@ -3708,7 +3708,7 @@
     wikipedia_page: Hugo%27s_House_of_Horrors
     series_id: hugo
 -
-    id: hugo2
+    id: 'hugo:hugo2'
     name: 'Hugo II: Whodunit?'
     engine_id: hugo
     company_id: graydesign
@@ -3720,7 +3720,7 @@
     wikipedia_page: 'Hugo_II,_Whodunit%3F'
     series_id: hugo
 -
-    id: hugo3
+    id: 'hugo:hugo3'
     name: 'Hugo III: Jungle of Doom'
     engine_id: hugo
     company_id: graydesign
@@ -3732,7 +3732,7 @@
     wikipedia_page: 'Hugo_III,_Jungle_of_Doom!'
     series_id: hugo
 -
-    id: sinistersix
+    id: 'hypno:sinistersix'
     name: 'Marvel Comics Spider-Man: The Sinister Six'
     engine_id: hypno
     company_id: brooklyn
@@ -3744,7 +3744,7 @@
     wikipedia_page: 'Spider-Man_in_video_games#Spider-Man:_The_Sinister_Six'
     series_id: ''
 -
-    id: soldierboyz
+    id: 'hypno:soldierboyz'
     name: 'Soldier Boyz'
     engine_id: hypno
     company_id: hypnotix
@@ -3756,7 +3756,7 @@
     wikipedia_page: Soldier_Boyz_(video_game)
     series_id: ''
 -
-    id: teacher
+    id: 'hypno:teacher'
     name: 'Bruce Coville''s My Teacher Is an Alien'
     engine_id: hypno
     company_id: hypnotix
@@ -3768,7 +3768,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: wetlands
+    id: 'hypno:wetlands'
     name: Wetlands
     engine_id: hypno
     company_id: hypnotix
@@ -3780,7 +3780,7 @@
     wikipedia_page: Wetlands_(video_game)
     series_id: ''
 -
-    id: icb
+    id: 'icb:icb'
     name: 'In Cold Blood'
     engine_id: icb
     company_id: revolution
@@ -3792,7 +3792,7 @@
     wikipedia_page: In_Cold_Blood_(video_game)
     series_id: ''
 -
-    id: igor
+    id: 'igor:igor'
     name: 'Igor: Objective Uikokahonia'
     engine_id: igor
     company_id: optik
@@ -3804,7 +3804,7 @@
     wikipedia_page: 'Igor:_Objective_Uikokahonia'
     series_id: ''
 -
-    id: bbdou
+    id: 'illusions:bbdou'
     name: 'MTV''s Beavis and Butt-Head Do U.'
     engine_id: illusions
     company_id: viacom
@@ -3816,7 +3816,7 @@
     wikipedia_page: Beavis_and_Butt-Head_Do_U.
     series_id: beavisbutthead
 -
-    id: duckman
+    id: 'illusions:duckman'
     name: 'Duckman: The Graphic Adventures of a Private Dick'
     engine_id: illusions
     company_id: playmates
@@ -3828,7 +3828,7 @@
     wikipedia_page: 'Duckman:_The_Graphic_Adventures_of_a_Private_Dick'
     series_id: ''
 -
-    id: kingdom
+    id: 'kingdom:kingdom'
     name: 'Kingdom: The Far Reaches'
     engine_id: kingdom
     company_id: virtual
@@ -3840,7 +3840,7 @@
     wikipedia_page: Thayer%27s_Quest
     series_id: ''
 -
-    id: eob
+    id: 'kyra:eob'
     name: 'Eye of the Beholder'
     engine_id: kyra
     company_id: westwood
@@ -3852,7 +3852,7 @@
     wikipedia_page: Eye_of_the_Beholder_(video_game)
     series_id: eob
 -
-    id: eob2
+    id: 'kyra:eob2'
     name: 'Eye of the Beholder II: The Legend of Darkmoon'
     engine_id: kyra
     company_id: westwood
@@ -3864,7 +3864,7 @@
     wikipedia_page: 'Eye_of_the_Beholder_II:_The_Legend_of_Darkmoon'
     series_id: eob
 -
-    id: kyra1
+    id: 'kyra:kyra1'
     name: 'The Legend of Kyrandia'
     engine_id: kyra
     company_id: westwood
@@ -3876,7 +3876,7 @@
     wikipedia_page: The_Legend_of_Kyrandia
     series_id: kyra
 -
-    id: ioawn4t
+    id: 'ags:ioawn4t'
     name: 'If On A Winter''s Night, Four Travelers'
     engine_id: ags
     company_id: deadidle
@@ -3888,7 +3888,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: kyra2
+    id: 'kyra:kyra2'
     name: 'The Legend of Kyrandia: Hand of Fate'
     engine_id: kyra
     company_id: westwood
@@ -3900,7 +3900,7 @@
     wikipedia_page: 'The_Legend_of_Kyrandia:_Hand_of_Fate'
     series_id: kyra
 -
-    id: kyra3
+    id: 'kyra:kyra3'
     name: 'The Legend of Kyrandia: Book 3 - Malcolm''s Revenge'
     engine_id: kyra
     company_id: westwood
@@ -3912,7 +3912,7 @@
     wikipedia_page: 'The_Legend_of_Kyrandia:_Malcolm%27s_Revenge'
     series_id: kyra
 -
-    id: lol
+    id: 'kyra:lol'
     name: 'Lands of Lore: The Throne of Chaos'
     engine_id: kyra
     company_id: westwood
@@ -3924,7 +3924,7 @@
     wikipedia_page: 'Lands_of_Lore:_The_Throne_of_Chaos'
     series_id: ''
 -
-    id: jamesperis
+    id: 'wintermute:jamesperis'
     name: 'James Peris: No License Nor Control'
     engine_id: wintermute
     company_id: pavo
@@ -3936,7 +3936,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: lab
+    id: 'lab:lab'
     name: 'The Labyrinth of Time'
     engine_id: lab
     company_id: terra
@@ -3948,7 +3948,7 @@
     wikipedia_page: The_Labyrinth_of_Time
     series_id: ''
 -
-    id: lastexpress
+    id: 'lastexpress:lastexpress'
     name: 'The Last Express'
     engine_id: lastexpress
     company_id: smokingcar
@@ -3960,7 +3960,7 @@
     wikipedia_page: The_Last_Express
     series_id: ''
 -
-    id: robin
+    id: 'lilliput:robin'
     name: 'The Adventures of Robin Hood'
     engine_id: lilliput
     company_id: millennium
@@ -3972,7 +3972,7 @@
     wikipedia_page: The_Adventures_of_Robin_Hood_(video_game)
     series_id: ''
 -
-    id: rome
+    id: 'lilliput:rome'
     name: 'Rome: Pathway to Power'
     engine_id: lilliput
     company_id: firstlight
@@ -3984,7 +3984,7 @@
     wikipedia_page: 'Rome:_Pathway_to_Power'
     series_id: ''
 -
-    id: lure
+    id: 'lure:lure'
     name: 'Lure of the Temptress'
     engine_id: lure
     company_id: revolution
@@ -3996,7 +3996,7 @@
     wikipedia_page: Lure_of_the_Temptress
     series_id: ''
 -
-    id: jorry
+    id: 'ags:jorry'
     name: JORRY
     engine_id: ags
     company_id: korozif
@@ -4008,7 +4008,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: julia
+    id: 'wintermute:julia'
     name: J.U.L.I.A.
     engine_id: wintermute
     company_id: cbe
@@ -4020,7 +4020,7 @@
     wikipedia_page: J.U.L.I.A.
     series_id: julia
 -
-    id: juliastars
+    id: 'wintermute:juliastars'
     name: 'J.U.L.I.A.: Among the Stars'
     engine_id: wintermute
     company_id: cbe
@@ -4032,7 +4032,7 @@
     wikipedia_page: J.U.L.I.A._Among_the_Stars
     series_id: julia
 -
-    id: juliauntold
+    id: 'wintermute:juliauntold'
     name: 'J.U.L.I.A. Untold'
     engine_id: wintermute
     company_id: cbe
@@ -4044,7 +4044,7 @@
     wikipedia_page: ''
     series_id: julia
 -
-    id: burger
+    id: 'm4:burger'
     name: 'Orion Burger'
     engine_id: m4
     company_id: sanctuary
@@ -4056,7 +4056,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: riddle
+    id: 'm4:riddle'
     name: 'Ripley''s Believe It or Not!: The Riddle of Master Lu'
     engine_id: m4
     company_id: sanctuary
@@ -4068,7 +4068,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: justignorethem
+    id: 'ags:justignorethem'
     name: 'Just Ignore Them'
     engine_id: ags
     company_id: stranga
@@ -4080,7 +4080,7 @@
     wikipedia_page: ''
     series_id: jit
 -
-    id: justignorethembrea1
+    id: 'ags:justignorethembrea1'
     name: 'Just Ignore Them: Brea''s Story Tape 1'
     engine_id: ags
     company_id: stranga
@@ -4092,7 +4092,7 @@
     wikipedia_page: ''
     series_id: jit
 -
-    id: kathyrain
+    id: 'ags:kathyrain'
     name: 'Kathy Rain'
     engine_id: ags
     company_id: clifftop
@@ -4104,7 +4104,7 @@
     wikipedia_page: Kathy_Rain
     series_id: ''
 -
-    id: killyourself
+    id: 'ags:killyourself'
     name: 'Kill Yourself'
     engine_id: ags
     company_id: gugames
@@ -4116,7 +4116,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: deja_vu
+    id: 'macventure:deja_vu'
     name: 'Deja Vu: A Nightmare Comes True!!'
     engine_id: macventure
     company_id: icom
@@ -4128,7 +4128,7 @@
     wikipedia_page: Déjà_Vu_(video_game)
     series_id: deja_vu
 -
-    id: knobblycrook
+    id: 'ags:knobblycrook'
     name: 'The Knobbly Crook'
     engine_id: ags
     company_id: gnarled
@@ -4140,7 +4140,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: knossos
+    id: 'wintermute:knossos'
     name: 'K''NOSSOS'
     engine_id: wintermute
     company_id: svarun
@@ -4152,7 +4152,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: deja_vu2
+    id: 'macventure:deja_vu2'
     name: 'Déjà Vu II: Lost in Las Vegas'
     engine_id: macventure
     company_id: icom
@@ -4164,7 +4164,7 @@
     wikipedia_page: 'Deja_Vu_II:_Lost_in_Las_Vegas'
     series_id: deja_vu
 -
-    id: shadowgate
+    id: 'macventure:shadowgate'
     name: Shadowgate
     engine_id: macventure
     company_id: icom
@@ -4176,7 +4176,7 @@
     wikipedia_page: Shadowgate
     series_id: ''
 -
-    id: uninvited
+    id: 'macventure:uninvited'
     name: Uninvited
     engine_id: macventure
     company_id: icom
@@ -4188,7 +4188,7 @@
     wikipedia_page: Uninvited_(video_game)
     series_id: ''
 -
-    id: kq1agdi
+    id: 'ags:kq1agdi'
     name: 'King''s Quest I: Quest for the Crown Remake'
     engine_id: ags
     company_id: agdi
@@ -4200,7 +4200,7 @@
     wikipedia_page: ''
     series_id: kqagdi
 -
-    id: lgop2
+    id: 'made:lgop2'
     name: 'Leather Goddesses of Phobos! 2: Gas Pump Girls Meet the Pulsating Inconvenience from Planet X'
     engine_id: made
     company_id: infocom
@@ -4212,7 +4212,7 @@
     wikipedia_page: 'Leather_Goddesses_of_Phobos_2:_Gas_Pump_Girls_Meet_the_Pulsating_Inconvenience_from_Planet_X!'
     series_id: ''
 -
-    id: kq2agdi
+    id: 'ags:kq2agdi'
     name: 'King''s Quest II: Romancing the Stones Remake'
     engine_id: ags
     company_id: agdi
@@ -4224,7 +4224,7 @@
     wikipedia_page: ''
     series_id: kqagdi
 -
-    id: manhole
+    id: 'made:manhole'
     name: 'The Manhole'
     engine_id: made
     company_id: cyan
@@ -4236,7 +4236,7 @@
     wikipedia_page: The_Manhole
     series_id: ''
 -
-    id: kq3agdi
+    id: 'ags:kq3agdi'
     name: 'King''s Quest III Redux: To Heir is Human'
     engine_id: ags
     company_id: agdi
@@ -4248,7 +4248,7 @@
     wikipedia_page: ''
     series_id: kqagdi
 -
-    id: kq3vga
+    id: 'ags:kq3vga'
     name: 'King''s Quest III: To Heir is Human VGA Remake'
     engine_id: ags
     company_id: infamousadv
@@ -4260,7 +4260,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: rodney
+    id: 'made:rodney'
     name: 'Rodney''s Funscreen'
     engine_id: made
     company_id: artbox
@@ -4272,7 +4272,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: rtz
+    id: 'made:rtz'
     name: 'Return to Zork'
     engine_id: made
     company_id: activision
@@ -4284,7 +4284,7 @@
     wikipedia_page: Return_to_Zork
     series_id: zork
 -
-    id: dragonsphere
+    id: 'mads:dragonsphere'
     name: Dragonsphere
     engine_id: mads
     company_id: microprose
@@ -4296,7 +4296,7 @@
     wikipedia_page: Dragonsphere
     series_id: ''
 -
-    id: nebular
+    id: 'mads:nebular'
     name: 'Rex Nebular and the Cosmic Gender Bender'
     engine_id: mads
     company_id: microprose
@@ -4308,7 +4308,7 @@
     wikipedia_page: Rex_Nebular_and_the_Cosmic_Gender_Bender
     series_id: ''
 -
-    id: phantom
+    id: 'mads:phantom'
     name: 'Return of the Phantom'
     engine_id: mads
     company_id: microprose
@@ -4320,7 +4320,7 @@
     wikipedia_page: Return_of_the_Phantom
     series_id: ''
 -
-    id: alientales
+    id: 'mohawk:alientales'
     name: 'Alien Tales'
     engine_id: mohawk
     company_id: broderbund
@@ -4332,7 +4332,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: kulivocko
+    id: 'wintermute:kulivocko'
     name: Kulivočko
     engine_id: wintermute
     company_id: fatfunky
@@ -4344,7 +4344,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: arthur
+    id: 'mohawk:arthur'
     name: 'Marc Brown''s Arthur''s Teacher Trouble'
     engine_id: mohawk
     company_id: livingbooks
@@ -4356,7 +4356,7 @@
     wikipedia_page: Living_Books
     series_id: livingbooks
 -
-    id: arthurbday
+    id: 'mohawk:arthurbday'
     name: 'Arthur''s Birthday'
     engine_id: mohawk
     company_id: livingbooks
@@ -4368,7 +4368,7 @@
     wikipedia_page: Living_Books
     series_id: livingbooks
 -
-    id: arthurcomp
+    id: 'mohawk:arthurcomp'
     name: 'Arthur''s Computer Adventure'
     engine_id: mohawk
     company_id: livingbooks
@@ -4380,7 +4380,7 @@
     wikipedia_page: Living_Books
     series_id: livingbooks
 -
-    id: arthurrace
+    id: 'mohawk:arthurrace'
     name: 'Arthur''s Reading Race'
     engine_id: mohawk
     company_id: livingbooks
@@ -4392,7 +4392,7 @@
     wikipedia_page: Living_Books
     series_id: livingbooks
 -
-    id: lamplightcity
+    id: 'ags:lamplightcity'
     name: 'Lamplight City'
     engine_id: ags
     company_id: grundislav
@@ -4404,7 +4404,7 @@
     wikipedia_page: Lamplight_City
     series_id: ''
 -
-    id: lancelothangover
+    id: 'ags:lancelothangover'
     name: 'Lancelot''s Hangover'
     engine_id: ags
     company_id: jbclerfayt
@@ -4416,7 +4416,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: larrylotter
+    id: 'ags:larrylotter'
     name: 'Larry Lotter and the Test of Time'
     engine_id: ags
     company_id: crystalshard
@@ -4428,7 +4428,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: beardark
+    id: 'mohawk:beardark'
     name: 'The Berenstain Bears In The Dark'
     engine_id: mohawk
     company_id: livingbooks
@@ -4440,7 +4440,7 @@
     wikipedia_page: Living_Books
     series_id: livingbooks
 -
-    id: bearfight
+    id: 'mohawk:bearfight'
     name: 'The Berenstain Bears Get in a Fight'
     engine_id: mohawk
     company_id: livingbooks
@@ -4452,7 +4452,7 @@
     wikipedia_page: Living_Books
     series_id: livingbooks
 -
-    id: carmentq
+    id: 'mohawk:carmentq'
     name: 'Carmen Sandiego''s ThinkQuick Challenge'
     engine_id: mohawk
     company_id: tlc
@@ -4464,7 +4464,7 @@
     wikipedia_page: Carmen_Sandiego%27s_ThinkQuick_Challenge
     series_id: carmen
 -
-    id: carmentqc
+    id: 'mohawk:carmentqc'
     name: 'Carmen Sandiego''s ThinkQuick Challenge Custom Question Creator'
     engine_id: mohawk
     company_id: tlc
@@ -4476,7 +4476,7 @@
     wikipedia_page: Carmen_Sandiego%27s_ThinkQuick_Challenge
     series_id: carmen
 -
-    id: catinthehat
+    id: 'mohawk:catinthehat'
     name: 'The Cat in the Hat'
     engine_id: mohawk
     company_id: livingbooks
@@ -4488,7 +4488,7 @@
     wikipedia_page: Living_Books
     series_id: livingbooks
 -
-    id: create
+    id: 'mohawk:create'
     name: 'The Story of Creation'
     engine_id: mohawk
     company_id: littleark
@@ -4500,7 +4500,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: legendofhand
+    id: 'ags:legendofhand'
     name: 'Legend of Hand'
     engine_id: ags
     company_id: cloakdagger
@@ -4512,7 +4512,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: cstime
+    id: 'mohawk:cstime'
     name: 'Where in Time is Carmen Sandiego?'
     engine_id: mohawk
     company_id: broderbund
@@ -4524,7 +4524,7 @@
     wikipedia_page: Carmen_Sandiego%27s_Great_Chase_Through_Time
     series_id: carmen
 -
-    id: csusa
+    id: 'mohawk:csusa'
     name: 'Where in the USA is Carmen Sandiego?'
     engine_id: mohawk
     company_id: broderbund
@@ -4536,7 +4536,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: csworld
+    id: 'mohawk:csworld'
     name: 'Where in the World is Carmen Sandiego?'
     engine_id: mohawk
     company_id: broderbund
@@ -4548,7 +4548,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: daniel
+    id: 'mohawk:daniel'
     name: 'Daniel in the Lions'' Den'
     engine_id: mohawk
     company_id: littleark
@@ -4560,7 +4560,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: lifein3minutes
+    id: 'wintermute:lifein3minutes'
     name: 'Life In 3 Minutes'
     engine_id: wintermute
     company_id: unknown
@@ -4572,7 +4572,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: grandma
+    id: 'mohawk:grandma'
     name: 'Just Grandma and Me'
     engine_id: mohawk
     company_id: livingbooks
@@ -4584,7 +4584,7 @@
     wikipedia_page: Living_Books
     series_id: livingbooks
 -
-    id: greeneggs
+    id: 'mohawk:greeneggs'
     name: 'Green Eggs and Ham'
     engine_id: mohawk
     company_id: livingbooks
@@ -4596,7 +4596,7 @@
     wikipedia_page: Living_Books
     series_id: livingbooks
 -
-    id: harryhh
+    id: 'mohawk:harryhh'
     name: 'Harry and the Haunted House'
     engine_id: mohawk
     company_id: livingbooks
@@ -4608,7 +4608,7 @@
     wikipedia_page: Living_Books
     series_id: livingbooks
 -
-    id: koala
+    id: 'mohawk:koala'
     name: 'Koala Lumpur: Journey to the Edge'
     engine_id: mohawk
     company_id: broderbund
@@ -4620,7 +4620,7 @@
     wikipedia_page: 'Koala_Lumpur:_Journey_to_the_Edge'
     series_id: ''
 -
-    id: lbsampler
+    id: 'mohawk:lbsampler'
     name: 'Living Books Sampler'
     engine_id: mohawk
     company_id: livingbooks
@@ -4632,7 +4632,7 @@
     wikipedia_page: Living_Books
     series_id: livingbooks
 -
-    id: lilmonster
+    id: 'mohawk:lilmonster'
     name: 'Little Monster at School'
     engine_id: mohawk
     company_id: livingbooks
@@ -4644,7 +4644,7 @@
     wikipedia_page: Living_Books
     series_id: livingbooks
 -
-    id: maggiesfa
+    id: 'mohawk:maggiesfa'
     name: 'Maggie''s Farmyard Adventure'
     engine_id: mohawk
     company_id: livingbooks
@@ -4656,7 +4656,7 @@
     wikipedia_page: Living_Books
     series_id: livingbooks
 -
-    id: makingofmyst
+    id: 'mohawk:makingofmyst'
     name: 'The Making of Myst'
     engine_id: mohawk
     company_id: cyan
@@ -4668,7 +4668,7 @@
     wikipedia_page: Myst
     series_id: myst
 -
-    id: lonelyrobot
+    id: 'wintermute:lonelyrobot'
     name: 'Project Lonely Robot'
     engine_id: wintermute
     company_id: blekinge
@@ -4680,7 +4680,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: myst
+    id: 'mohawk:myst'
     name: Myst
     engine_id: mohawk
     company_id: cyan
@@ -4692,7 +4692,7 @@
     wikipedia_page: Myst
     series_id: myst
 -
-    id: looky
+    id: 'wintermute:looky'
     name: Looky
     engine_id: wintermute
     company_id: mac
@@ -4704,7 +4704,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: mystme
+    id: 'mohawk:mystme'
     name: 'Myst: Masterpiece Edition'
     engine_id: mohawk
     company_id: cyan
@@ -4716,7 +4716,7 @@
     wikipedia_page: Myst
     series_id: myst
 -
-    id: newkid
+    id: 'mohawk:newkid'
     name: 'The New Kid on the Block'
     engine_id: mohawk
     company_id: livingbooks
@@ -4728,7 +4728,7 @@
     wikipedia_page: Living_Books
     series_id: livingbooks
 -
-    id: orly
+    id: 'mohawk:orly'
     name: 'Orly''s Draw-A-Story'
     engine_id: mohawk
     company_id: broderbund
@@ -4740,7 +4740,7 @@
     wikipedia_page: 'Orly''s_Draw-A-Story'
     series_id: ''
 -
-    id: lotl
+    id: 'wintermute:lotl'
     name: 'Limbo of the Lost'
     engine_id: wintermute
     company_id: majestic
@@ -4752,7 +4752,7 @@
     wikipedia_page: Limbo_of_the_Lost
     series_id: ''
 -
-    id: lovmamuta
+    id: 'wintermute:lovmamuta'
     name: 'Lov Mamuta'
     engine_id: wintermute
     company_id: unknown
@@ -4764,7 +4764,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: riven
+    id: 'mohawk:riven'
     name: 'Riven: The Sequel to Myst'
     engine_id: mohawk
     company_id: cyan
@@ -4776,7 +4776,7 @@
     wikipedia_page: Riven
     series_id: myst
 -
-    id: ruff
+    id: 'mohawk:ruff'
     name: 'Ruff''s Bone'
     engine_id: mohawk
     company_id: livingbooks
@@ -4788,7 +4788,7 @@
     wikipedia_page: Living_Books
     series_id: livingbooks
 -
-    id: rugrats
+    id: 'mohawk:rugrats'
     name: 'Rugrats Adventure Game'
     engine_id: mohawk
     company_id: broderbund
@@ -4800,7 +4800,7 @@
     wikipedia_page: Rugrats_Adventure_Game
     series_id: ''
 -
-    id: rugratsps
+    id: 'mohawk:rugratsps'
     name: 'Rugrats Print Shop'
     engine_id: mohawk
     company_id: livingbooks
@@ -4812,7 +4812,7 @@
     wikipedia_page: ''
     series_id: livingbooks
 -
-    id: seussabc
+    id: 'mohawk:seussabc'
     name: 'Dr. Seuss''s ABC'
     engine_id: mohawk
     company_id: livingbooks
@@ -4824,7 +4824,7 @@
     wikipedia_page: Living_Books
     series_id: livingbooks
 -
-    id: sheila
+    id: 'mohawk:sheila'
     name: 'Sheila Rae, the Brave'
     engine_id: mohawk
     company_id: livingbooks
@@ -4836,7 +4836,7 @@
     wikipedia_page: Living_Books
     series_id: livingbooks
 -
-    id: stellaluna
+    id: 'mohawk:stellaluna'
     name: Stellaluna
     engine_id: mohawk
     company_id: broderbund
@@ -4848,7 +4848,7 @@
     wikipedia_page: Living_Books
     series_id: livingbooks
 -
-    id: tortoise
+    id: 'mohawk:tortoise'
     name: 'Aesop''s Fables: The Tortoise and the Hare'
     engine_id: mohawk
     company_id: livingbooks
@@ -4860,7 +4860,7 @@
     wikipedia_page: Living_Books
     series_id: livingbooks
 -
-    id: zoombini
+    id: 'mohawk:zoombini'
     name: 'Logical Journey of the Zoombinis'
     engine_id: mohawk
     company_id: broderbund
@@ -4872,7 +4872,7 @@
     wikipedia_page: Logical_Journey_of_the_Zoombinis
     series_id: ''
 -
-    id: mortevielle
+    id: 'mortevielle:mortevielle'
     name: 'Mortville Manor'
     engine_id: mortevielle
     company_id: lankhor
@@ -4884,7 +4884,7 @@
     wikipedia_page: Mortville_Manor
     series_id: ''
 -
-    id: machumayu
+    id: 'wintermute:machumayu'
     name: 'Machu Mayu'
     engine_id: wintermute
     company_id: unknown
@@ -4896,7 +4896,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: mage
+    id: 'ags:mage'
     name: 'Mage''s Initiation: Reign of the Elements'
     engine_id: ags
     company_id: himalaya
@@ -4908,7 +4908,7 @@
     wikipedia_page: 'Mage%27s_Initiation:_Reign_of_the_Elements'
     series_id: ''
 -
-    id: obsidian
+    id: 'mtropolis:obsidian'
     name: Obsidian
     engine_id: mtropolis
     company_id: rocketscience
@@ -4920,7 +4920,7 @@
     wikipedia_page: Obsidian_(1997_video_game)
     series_id: ''
 -
-    id: mutationofjb
+    id: 'mutationofjb:mutationofjb'
     name: 'Mutation of J.B.'
     engine_id: mutationofjb
     company_id: invention
@@ -4932,7 +4932,7 @@
     wikipedia_page: Mutation_of_J.B.
     series_id: ''
 -
-    id: myst3
+    id: 'myst3:myst3'
     name: 'Myst III: Exile'
     engine_id: myst3
     company_id: presto
@@ -4944,7 +4944,7 @@
     wikipedia_page: 'Myst_III:_Exile'
     series_id: myst
 -
-    id: nancy1
+    id: 'nancy:nancy1'
     name: 'Nancy Drew: Secrets Can Kill'
     engine_id: nancy
     company_id: herinteractive
@@ -4956,7 +4956,7 @@
     wikipedia_page: 'Nancy_Drew:_Secrets_Can_Kill'
     series_id: nancy
 -
-    id: vampirediaries
+    id: 'nancy:vampirediaries'
     name: 'The Vampire Diaries'
     engine_id: nancy
     company_id: herinteractive
@@ -4968,7 +4968,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: neverhood
+    id: 'neverhood:neverhood'
     name: 'The Neverhood'
     engine_id: neverhood
     company_id: neverhood
@@ -4980,7 +4980,7 @@
     wikipedia_page: The_Neverhood
     series_id: ''
 -
-    id: fullpipe
+    id: 'ngi:fullpipe'
     name: 'Full Pipe'
     engine_id: ngi
     company_id: 1c
@@ -4992,7 +4992,7 @@
     wikipedia_page: Full_Pipe
     series_id: ''
 -
-    id: bra
+    id: 'parallaction:bra'
     name: 'The Big Red Adventure'
     engine_id: parallaction
     company_id: dynabyte
@@ -5004,7 +5004,7 @@
     wikipedia_page: The_Big_Red_Adventure
     series_id: ''
 -
-    id: nippon
+    id: 'parallaction:nippon'
     name: 'Nippon Safes, Inc.'
     engine_id: parallaction
     company_id: dynabyte
@@ -5016,7 +5016,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: maniacmansiondeluxe
+    id: 'ags:maniacmansiondeluxe'
     name: 'Maniac Mansion Deluxe'
     engine_id: ags
     company_id: fan
@@ -5028,7 +5028,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: pegasus
+    id: 'pegasus:pegasus'
     name: 'The Journeyman Project: Pegasus Prime'
     engine_id: pegasus
     company_id: presto
@@ -5040,7 +5040,7 @@
     wikipedia_page: 'The_Journeyman_Project:_Pegasus_Prime'
     series_id: journeyman
 -
-    id: petka1
+    id: 'petka:petka1'
     name: 'Red Comrades 1: Save the Galaxy'
     engine_id: petka
     company_id: skif
@@ -5052,7 +5052,7 @@
     wikipedia_page: Red_Comrades_Save_the_Galaxy
     series_id: petka
 -
-    id: petka2
+    id: 'petka:petka2'
     name: 'Red Comrades 2: For the Great Justice'
     engine_id: petka
     company_id: skif
@@ -5064,7 +5064,7 @@
     wikipedia_page: ''
     series_id: petka
 -
-    id: peril
+    id: 'pink:peril'
     name: 'The Pink Panther: Passport to Peril'
     engine_id: pink
     company_id: wanderlust
@@ -5076,7 +5076,7 @@
     wikipedia_page: 'The_Pink_Panther:_Passport_to_Peril'
     series_id: ''
 -
-    id: pokus
+    id: 'pink:pokus'
     name: 'The Pink Panther: Hokus Pokus Pink'
     engine_id: pink
     company_id: wanderlust
@@ -5088,7 +5088,7 @@
     wikipedia_page: 'The_Pink_Panther:_Hokus_Pokus_Pink'
     series_id: ''
 -
-    id: plumbers
+    id: 'plumbers:plumbers'
     name: 'Plumbers Don''t Wear Ties'
     engine_id: plumbers
     company_id: unitedpixtures
@@ -5100,7 +5100,7 @@
     wikipedia_page: Plumbers_Don%27t_Wear_Ties
     series_id: ''
 -
-    id: mentalrepairs
+    id: 'wintermute:mentalrepairs'
     name: 'Mental Repairs, Inc.'
     engine_id: wintermute
     company_id: unknown
@@ -5112,7 +5112,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: meta
+    id: 'ags:meta'
     name: META
     engine_id: ags
     company_id: crystalshard
@@ -5124,7 +5124,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: metaldead
+    id: 'ags:metaldead'
     name: 'Metal Dead'
     engine_id: ags
     company_id: wtw
@@ -5136,7 +5136,7 @@
     wikipedia_page: Metal_Dead
     series_id: ''
 -
-    id: metaphobia
+    id: 'ags:metaphobia'
     name: Metaphobia
     engine_id: ags
     company_id: digitalmosaic
@@ -5148,7 +5148,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: prince
+    id: 'prince:prince'
     name: 'The Prince and the Coward'
     engine_id: prince
     company_id: metropolis
@@ -5160,7 +5160,7 @@
     wikipedia_page: The_Prince_and_the_Coward
     series_id: ''
 -
-    id: private-eye
+    id: 'private:private-eye'
     name: 'Private Eye'
     engine_id: private
     company_id: brooklyn
@@ -5172,7 +5172,7 @@
     wikipedia_page: Private_Eye_(1996_video_game)
     series_id: ''
 -
-    id: queen
+    id: 'queen:queen'
     name: 'Flight of the Amazon Queen'
     engine_id: queen
     company_id: ibi
@@ -5184,7 +5184,7 @@
     wikipedia_page: Flight_of_the_Amazon_Queen
     series_id: ''
 -
-    id: mirage
+    id: 'wintermute:mirage'
     name: Mirage
     engine_id: wintermute
     company_id: blekinge
@@ -5196,7 +5196,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: dino
+    id: 'saga:dino'
     name: Dinotopia
     engine_id: saga
     company_id: dreamersguild
@@ -5208,7 +5208,7 @@
     wikipedia_page: Dinotopia_(video_game)
     series_id: ''
 -
-    id: fta2
+    id: 'saga:fta2'
     name: 'Halls of the Dead: Faery Tale Adventure II'
     engine_id: saga2
     company_id: dreamersguild
@@ -5220,7 +5220,7 @@
     wikipedia_page: 'Faery_Tale_Adventure_II:_Halls_of_the_Dead'
     series_id: ''
 -
-    id: ihnm
+    id: 'saga:ihnm'
     name: 'Harlan Ellison: I Have No Mouth, and I Must Scream'
     engine_id: saga
     company_id: dreamersguild
@@ -5232,7 +5232,7 @@
     wikipedia_page: 'I_Have_No_Mouth,_and_I_Must_Scream_(video_game)'
     series_id: ''
 -
-    id: ite
+    id: 'saga:ite'
     name: 'Inherit the Earth: Quest for the Orb'
     engine_id: saga
     company_id: dreamersguild
@@ -5244,7 +5244,7 @@
     wikipedia_page: Inherit_the_Earth
     series_id: ''
 -
-    id: astrochicken
+    id: 'sci:astrochicken'
     name: 'Astro Chicken'
     engine_id: sci
     company_id: sierra
@@ -5256,7 +5256,7 @@
     wikipedia_page: 'Space_Quest_III#Astro_Chicken'
     series_id: sq
 -
-    id: camelot
+    id: 'sci:camelot'
     name: 'Conquests of Camelot: The Search for the Grail'
     engine_id: sci
     company_id: sierra
@@ -5268,7 +5268,7 @@
     wikipedia_page: 'Conquests_of_Camelot:_The_Search_for_the_Grail'
     series_id: conquests
 -
-    id: castlebrain
+    id: 'sci:castlebrain'
     name: 'Castle of Dr. Brain'
     engine_id: sci
     company_id: sierra
@@ -5280,7 +5280,7 @@
     wikipedia_page: Castle_of_Dr._Brain
     series_id: brain
 -
-    id: catdate
+    id: 'sci:catdate'
     name: 'The Dating Pool'
     engine_id: sci
     company_id: fan
@@ -5292,7 +5292,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: chest
+    id: 'sci:chest'
     name: 'Inside the Chest'
     engine_id: sci
     company_id: sierra
@@ -5304,7 +5304,7 @@
     wikipedia_page: ''
     series_id: kq
 -
-    id: mountainsofmadness
+    id: 'ags:mountainsofmadness'
     name: 'Chronicle of Innsmouth: Mountains of Madness'
     engine_id: ags
     company_id: psychodev
@@ -5316,7 +5316,7 @@
     wikipedia_page: ''
     series_id: innsmouth
 -
-    id: christmas1988
+    id: 'sci:christmas1988'
     name: 'Christmas Card 1988'
     engine_id: sci
     company_id: sierra
@@ -5328,7 +5328,7 @@
     wikipedia_page: ''
     series_id: sierrachristmas
 -
-    id: christmas1990
+    id: 'sci:christmas1990'
     name: 'Christmas Card 1990: The Seasoned Professional'
     engine_id: sci
     company_id: sierra
@@ -5340,7 +5340,7 @@
     wikipedia_page: ''
     series_id: sierrachristmas
 -
-    id: christmas1992
+    id: 'sci:christmas1992'
     name: 'Christmas Card 1992'
     engine_id: sci
     company_id: sierra
@@ -5352,7 +5352,7 @@
     wikipedia_page: ''
     series_id: sierrachristmas
 -
-    id: msos
+    id: 'wintermute:msos'
     name: 'Monday Starts on Saturday'
     engine_id: wintermute
     company_id: rootfix
@@ -5364,7 +5364,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: mudlarks
+    id: 'ags:mudlarks'
     name: Mudlarks
     engine_id: ags
     company_id: cloakdagger
@@ -5376,7 +5376,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: cnick-kq
+    id: 'sci:cnick-kq'
     name: 'Crazy Nick''s Software Picks: King Graham''s Board Game Challenge'
     engine_id: sci
     company_id: sierra
@@ -5388,7 +5388,7 @@
     wikipedia_page: ''
     series_id: kq
 -
-    id: cnick-laurabow
+    id: 'sci:cnick-laurabow'
     name: 'Crazy Nick''s Software Picks: Parlor Games with Laura Bow'
     engine_id: sci
     company_id: sierra
@@ -5400,7 +5400,7 @@
     wikipedia_page: ''
     series_id: laurabow
 -
-    id: mybigsister
+    id: 'ags:mybigsister'
     name: 'My Big Sister'
     engine_id: ags
     company_id: stranga
@@ -5412,7 +5412,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: myburdentokeep
+    id: 'ags:myburdentokeep'
     name: 'My Burden to Keep'
     engine_id: ags
     company_id: perpetualdiversion
@@ -5424,7 +5424,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: cnick-longbow
+    id: 'sci:cnick-longbow'
     name: 'Crazy Nick''s Software Picks: Robin Hood''s Games of Skill and Chance'
     engine_id: sci
     company_id: sierra
@@ -5436,7 +5436,7 @@
     wikipedia_page: ''
     series_id: conquests
 -
-    id: cnick-lsl
+    id: 'sci:cnick-lsl'
     name: 'Crazy Nick''s Software Picks: Leisure Suit Larry''s Casino'
     engine_id: sci
     company_id: sierra
@@ -5448,7 +5448,7 @@
     wikipedia_page: ''
     series_id: lsl
 -
-    id: cnick-sq
+    id: 'sci:cnick-sq'
     name: 'Crazy Nick''s Software Picks: Roger Wilco''s Spaced Out Game Pack'
     engine_id: sci
     company_id: sierra
@@ -5460,7 +5460,7 @@
     wikipedia_page: ''
     series_id: sq
 -
-    id: ecoquest
+    id: 'sci:ecoquest'
     name: 'EcoQuest: The Search for Cetus'
     engine_id: sci
     company_id: sierra
@@ -5472,7 +5472,7 @@
     wikipedia_page: 'EcoQuest:_The_Search_for_Cetus'
     series_id: ecoquest
 -
-    id: mythguff
+    id: 'wintermute:mythguff'
     name: 'Myth: A Guff''s Tale'
     engine_id: wintermute
     company_id: solo
@@ -5484,7 +5484,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: ecoquest2
+    id: 'sci:ecoquest2'
     name: 'EcoQuest II: Lost Secret of the Rainforest'
     engine_id: sci
     company_id: sierra
@@ -5496,7 +5496,7 @@
     wikipedia_page: Lost_Secret_of_the_Rainforest
     series_id: ecoquest
 -
-    id: nellycootalot
+    id: 'ags:nellycootalot'
     name: 'Nelly Cootalot: Spoonbeaks Ahoy!'
     engine_id: ags
     company_id: abeckett
@@ -5508,7 +5508,7 @@
     wikipedia_page: 'Nelly_Cootalot:_Spoonbeaks_Ahoy!'
     series_id: nelly
 -
-    id: nellycootalot-hd
+    id: 'ags:nellycootalot-hd'
     name: 'Nelly Cootalot: Spoonbeaks Ahoy! HD'
     engine_id: ags
     company_id: abeckett
@@ -5520,7 +5520,7 @@
     wikipedia_page: 'Nelly_Cootalot:_Spoonbeaks_Ahoy!'
     series_id: nelly
 -
-    id: fairytales
+    id: 'sci:fairytales'
     name: 'Mixed Up Fairy Tales'
     engine_id: sci
     company_id: sierra
@@ -5532,7 +5532,7 @@
     wikipedia_page: Mixed-Up_Fairy_Tales
     series_id: mixedup
 -
-    id: neofeud
+    id: 'ags:neofeud'
     name: Neofeud
     engine_id: ags
     company_id: silverspook
@@ -5544,7 +5544,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: freddypharkas
+    id: 'sci:freddypharkas'
     name: 'Freddy Pharkas: Frontier Pharmacist'
     engine_id: sci
     company_id: sierra
@@ -5556,7 +5556,7 @@
     wikipedia_page: 'Freddy_Pharkas:_Frontier_Pharmacist'
     series_id: sierranoseries
 -
-    id: funseeker
+    id: 'sci:funseeker'
     name: 'Fun Seeker''s Guide'
     engine_id: sci
     company_id: sierra
@@ -5568,7 +5568,7 @@
     wikipedia_page: ''
     series_id: sierranoseries
 -
-    id: nightmareframes
+    id: 'ags:nightmareframes'
     name: 'Nightmare Frames'
     engine_id: ags
     company_id: postmodern
@@ -5580,7 +5580,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: nighttrain
+    id: 'wintermute:nighttrain'
     name: 'Night Train'
     engine_id: wintermute
     company_id: aka
@@ -5592,7 +5592,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: gk1
+    id: 'sci:gk1'
     name: 'Gabriel Knight: Sins of the Fathers'
     engine_id: sci
     company_id: sierra
@@ -5604,7 +5604,7 @@
     wikipedia_page: 'Gabriel_Knight:_Sins_of_the_Fathers'
     series_id: gk
 -
-    id: gk1demo
+    id: 'sci:gk1demo'
     name: 'Gabriel Knight: Sins of the Fathers (Demo)'
     engine_id: sci
     company_id: sierra
@@ -5616,7 +5616,7 @@
     wikipedia_page: 'Gabriel_Knight:_Sins_of_the_Fathers'
     series_id: gk
 -
-    id: gk2
+    id: 'sci:gk2'
     name: 'The Beast Within: A Gabriel Knight Mystery'
     engine_id: sci
     company_id: sierra
@@ -5628,7 +5628,7 @@
     wikipedia_page: 'The_Beast_Within:_A_Gabriel_Knight_Mystery'
     series_id: gk
 -
-    id: hoyle1
+    id: 'sci:hoyle1'
     name: 'Hoyle''s Official Book of Games: Volume 1'
     engine_id: sci
     company_id: sierra
@@ -5640,7 +5640,7 @@
     wikipedia_page: 'Hoyle%27s_Official_Book_of_Games#Volume_1'
     series_id: hoyle
 -
-    id: odissea
+    id: 'ags:odissea'
     name: 'Odissea - An Almost True Story'
     engine_id: ags
     company_id: midian
@@ -5652,7 +5652,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: oknytt
+    id: 'wintermute:oknytt'
     name: Oknytt
     engine_id: wintermute
     company_id: nemoria
@@ -5664,7 +5664,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: oldskies
+    id: 'ags:oldskies'
     name: 'Old Skies'
     engine_id: ags
     company_id: wadjet
@@ -5676,7 +5676,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: hoyle2
+    id: 'sci:hoyle2'
     name: 'Hoyle''s Official Book of Games: Volume 2'
     engine_id: sci
     company_id: sierra
@@ -5688,7 +5688,7 @@
     wikipedia_page: 'Hoyle%27s_Official_Book_of_Games#Volume_2'
     series_id: hoyle
 -
-    id: one
+    id: 'wintermute:one'
     name: One
     engine_id: wintermute
     company_id: unknown
@@ -5700,7 +5700,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: onehelluvaday
+    id: 'wintermute:onehelluvaday'
     name: 'One Helluva Day'
     engine_id: wintermute
     company_id: romank
@@ -5712,7 +5712,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: hoyle3
+    id: 'sci:hoyle3'
     name: 'Hoyle''s Official Book of Games: Volume 3'
     engine_id: sci
     company_id: sierra
@@ -5724,7 +5724,7 @@
     wikipedia_page: 'Hoyle%27s_Official_Book_of_Games#Volume_3'
     series_id: hoyle
 -
-    id: oott
+    id: 'ags:oott'
     name: 'Order of the Thorne: The King''s Challenge'
     engine_id: ags
     company_id: infamousq
@@ -5736,7 +5736,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: openquest
+    id: 'wintermute:openquest'
     name: 'Open Quest'
     engine_id: wintermute
     company_id: jennybee
@@ -5748,7 +5748,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: hoyle4
+    id: 'sci:hoyle4'
     name: 'Hoyle Classic Card Games'
     engine_id: sci
     company_id: sierra
@@ -5760,7 +5760,7 @@
     wikipedia_page: 'Hoyle%27s_Official_Book_of_Games#Hoyle_Classic_Card_Games_(Hoyle_4)'
     series_id: hoyle
 -
-    id: hoyle5
+    id: 'sci:hoyle5'
     name: 'Hoyle Classic Games'
     engine_id: sci
     company_id: sierra
@@ -5772,7 +5772,7 @@
     wikipedia_page: 'Hoyle%27s_Official_Book_of_Games#Hoyle_Classic_Games_(Hoyle_5)'
     series_id: hoyle
 -
-    id: hoyle5bridge
+    id: 'sci:hoyle5bridge'
     name: 'Hoyle Bridge'
     engine_id: sci
     company_id: sierra
@@ -5784,7 +5784,7 @@
     wikipedia_page: 'Hoyle%27s_Official_Book_of_Games#Hoyle_Classic_Games_(Hoyle_5)'
     series_id: hoyle
 -
-    id: hoyle5children
+    id: 'sci:hoyle5children'
     name: 'Hoyle Children''s Collection'
     engine_id: sci
     company_id: sierra
@@ -5796,7 +5796,7 @@
     wikipedia_page: 'Hoyle%27s_Official_Book_of_Games#Hoyle_Classic_Games_(Hoyle_5)'
     series_id: hoyle
 -
-    id: overtheedge
+    id: 'ags:overtheedge'
     name: 'The Journey Down: Over the Edge'
     engine_id: ags
     company_id: skygoblin
@@ -5808,7 +5808,7 @@
     wikipedia_page: The_Journey_Down
     series_id: ''
 -
-    id: ozorwell1
+    id: 'ags:ozorwell1'
     name: 'Oz Orwell and the Crawling Chaos'
     engine_id: ags
     company_id: midian
@@ -5820,7 +5820,7 @@
     wikipedia_page: ''
     series_id: ozorwell
 -
-    id: ozorwell2
+    id: 'ags:ozorwell2'
     name: 'Oz Orwell and the Exorcist'
     engine_id: ags
     company_id: midian
@@ -5832,7 +5832,7 @@
     wikipedia_page: ''
     series_id: ozorwell
 -
-    id: paintaria
+    id: 'wintermute:paintaria'
     name: Paintaria
     engine_id: wintermute
     company_id: traktor
@@ -5844,7 +5844,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: hoyle5solitaire
+    id: 'sci:hoyle5solitaire'
     name: 'Hoyle Solitaire'
     engine_id: sci
     company_id: sierra
@@ -5856,7 +5856,7 @@
     wikipedia_page: 'Hoyle%27s_Official_Book_of_Games#Hoyle_Classic_Games_(Hoyle_5)'
     series_id: hoyle
 -
-    id: iceman
+    id: 'sci:iceman'
     name: 'Code-Name: Iceman'
     engine_id: sci
     company_id: sierra
@@ -5868,7 +5868,7 @@
     wikipedia_page: 'Codename:_ICEMAN'
     series_id: sierranoseries
 -
-    id: inndemo
+    id: 'sci:inndemo'
     name: 'ImagiNation Network (INN) Demo'
     engine_id: sci
     company_id: sierra
@@ -5880,7 +5880,7 @@
     wikipedia_page: ''
     series_id: sierranoseries
 -
-    id: palladion
+    id: 'wintermute:palladion'
     name: Palladion
     engine_id: wintermute
     company_id: unknown
@@ -5892,7 +5892,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: papasdaughters1
+    id: 'wintermute:papasdaughters1'
     name: 'Papa''s Daughters'
     engine_id: wintermute
     company_id: herocraft
@@ -5904,7 +5904,7 @@
     wikipedia_page: ''
     series_id: papas
 -
-    id: papasdaughters2
+    id: 'wintermute:papasdaughters2'
     name: 'Papa''s Daughters Go to the Sea'
     engine_id: wintermute
     company_id: herocraft
@@ -5916,7 +5916,7 @@
     wikipedia_page: ''
     series_id: papas
 -
-    id: islandbrain
+    id: 'sci:islandbrain'
     name: 'The Island of Dr. Brain'
     engine_id: sci
     company_id: sierra
@@ -5928,7 +5928,7 @@
     wikipedia_page: The_Island_of_Dr._Brain
     series_id: brain
 -
-    id: jones
+    id: 'sci:jones'
     name: 'Jones in the Fast Lane'
     engine_id: sci
     company_id: sierra
@@ -5940,7 +5940,7 @@
     wikipedia_page: Jones_in_the_Fast_Lane
     series_id: sierranoseries
 -
-    id: kq1sci
+    id: 'sci:kq1sci'
     name: 'King''s Quest: Quest for the Crown'
     engine_id: sci
     company_id: sierra
@@ -5952,7 +5952,7 @@
     wikipedia_page: King%27s_Quest_I
     series_id: kq
 -
-    id: kq4sci
+    id: 'sci:kq4sci'
     name: 'King''s Quest IV: The Perils of Rosella'
     engine_id: sci
     company_id: sierra
@@ -5964,7 +5964,7 @@
     wikipedia_page: King%27s_Quest_IV
     series_id: kq
 -
-    id: kq5
+    id: 'sci:kq5'
     name: 'King''s Quest V: Absence Makes the Heart Go Yonder!'
     engine_id: sci
     company_id: sierra
@@ -5976,7 +5976,7 @@
     wikipedia_page: King%27s_Quest_V
     series_id: kq
 -
-    id: perfecttides
+    id: 'ags:perfecttides'
     name: 'Perfect Tides'
     engine_id: ags
     company_id: threebees
@@ -5988,7 +5988,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: perfidiouspetrolstation
+    id: 'ags:perfidiouspetrolstation'
     name: 'The Perfidious Petrol Station'
     engine_id: ags
     company_id: technocrat
@@ -6000,7 +6000,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: kq6
+    id: 'sci:kq6'
     name: 'King''s Quest VI: Heir Today, Gone Tomorrow'
     engine_id: sci
     company_id: sierra
@@ -6012,7 +6012,7 @@
     wikipedia_page: King%27s_Quest_VI
     series_id: kq
 -
-    id: kq7
+    id: 'sci:kq7'
     name: 'King''s Quest VII: The Princeless Bride'
     engine_id: sci
     company_id: sierra
@@ -6024,7 +6024,7 @@
     wikipedia_page: King%27s_Quest_VII
     series_id: kq
 -
-    id: kquestions
+    id: 'sci:kquestions'
     name: 'King''s Questions'
     engine_id: sci
     company_id: sierra
@@ -6036,7 +6036,7 @@
     wikipedia_page: ''
     series_id: kq
 -
-    id: laurabow
+    id: 'sci:laurabow'
     name: 'Laura Bow: The Colonel''s Bequest'
     engine_id: sci
     company_id: sierra
@@ -6048,7 +6048,7 @@
     wikipedia_page: The_Colonel%27s_Bequest
     series_id: laurabow
 -
-    id: laurabow2
+    id: 'sci:laurabow2'
     name: 'Laura Bow 2: The Dagger of Amon Ra'
     engine_id: sci
     company_id: sierra
@@ -6060,7 +6060,7 @@
     wikipedia_page: The_Dagger_of_Amon_Ra
     series_id: laurabow
 -
-    id: lighthouse
+    id: 'sci:lighthouse'
     name: 'Lighthouse: The Dark Being'
     engine_id: sci
     company_id: sierra
@@ -6072,7 +6072,7 @@
     wikipedia_page: 'Lighthouse:_The_Dark_Being'
     series_id: sierranoseries
 -
-    id: phantomfellows
+    id: 'ags:phantomfellows'
     name: 'The Phantom Fellows'
     engine_id: ags
     company_id: strummer
@@ -6084,7 +6084,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: pigeons
+    id: 'wintermute:pigeons'
     name: 'Pigeons in the Park'
     engine_id: wintermute
     company_id: squinky
@@ -6096,7 +6096,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: pizzamorgana
+    id: 'wintermute:pizzamorgana'
     name: 'Pizza Morgana: Episode 1 - Monsters and Manipulations in the Magical Forest'
     engine_id: wintermute
     company_id: corbomite
@@ -6108,7 +6108,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: longbow
+    id: 'sci:longbow'
     name: 'Conquests of the Longbow: The Legend of Robin Hood'
     engine_id: sci
     company_id: sierra
@@ -6120,7 +6120,7 @@
     wikipedia_page: 'Conquests_of_the_Longbow:_The_Legend_of_Robin_Hood'
     series_id: conquests
 -
-    id: lsl1sci
+    id: 'sci:lsl1sci'
     name: 'Leisure Suit Larry in the Land of the Lounge Lizards'
     engine_id: sci
     company_id: sierra
@@ -6132,7 +6132,7 @@
     wikipedia_page: Leisure_Suit_Larry_in_the_Land_of_the_Lounge_Lizards
     series_id: lsl
 -
-    id: lsl2
+    id: 'sci:lsl2'
     name: 'Leisure Suit Larry 2: Goes Looking for Love (in Several Wrong Places)'
     engine_id: sci
     company_id: sierra
@@ -6144,7 +6144,7 @@
     wikipedia_page: Leisure_Suit_Larry_Goes_Looking_for_Love_(in_Several_Wrong_Places)
     series_id: lsl
 -
-    id: lsl3
+    id: 'sci:lsl3'
     name: 'Leisure Suit Larry 3: Passionate Patti in Pursuit of the Pulsating Pectorals'
     engine_id: sci
     company_id: sierra
@@ -6156,7 +6156,7 @@
     wikipedia_page: 'Leisure_Suit_Larry_III:_Passionate_Patti_in_Pursuit_of_the_Pulsating_Pectorals'
     series_id: lsl
 -
-    id: lsl5
+    id: 'sci:lsl5'
     name: 'Leisure Suit Larry 5: Passionate Patti Does a Little Undercover Work'
     engine_id: sci
     company_id: sierra
@@ -6168,7 +6168,7 @@
     wikipedia_page: 'Leisure_Suit_Larry_5:_Passionate_Patti_Does_a_Little_Undercover_Work'
     series_id: lsl
 -
-    id: lsl6
+    id: 'sci:lsl6'
     name: 'Leisure Suit Larry 6: Shape Up or Slip Out!'
     engine_id: sci
     company_id: sierra
@@ -6180,7 +6180,7 @@
     wikipedia_page: 'Leisure_Suit_Larry_6:_Shape_Up_or_Slip_Out!'
     series_id: lsl
 -
-    id: lsl6hires
+    id: 'sci:lsl6hires'
     name: 'Leisure Suit Larry 6: Shape Up or Slip Out!'
     engine_id: sci
     company_id: sierra
@@ -6192,7 +6192,7 @@
     wikipedia_page: 'Leisure_Suit_Larry_6:_Shape_Up_or_Slip_Out!'
     series_id: lsl
 -
-    id: lsl7
+    id: 'sci:lsl7'
     name: 'Leisure Suit Larry 7: Love for Sail!'
     engine_id: sci
     company_id: sierra
@@ -6204,7 +6204,7 @@
     wikipedia_page: 'Leisure_Suit_Larry:_Love_for_Sail!'
     series_id: lsl
 -
-    id: mothergoose
+    id: 'sci:mothergoose'
     name: 'Mixed-Up Mother Goose'
     engine_id: sci
     company_id: sierra
@@ -6216,7 +6216,7 @@
     wikipedia_page: Mixed-Up_Mother_Goose
     series_id: mixedup
 -
-    id: mothergoose256
+    id: 'sci:mothergoose256'
     name: 'Mixed-Up Mother Goose'
     engine_id: sci
     company_id: sierra
@@ -6228,7 +6228,7 @@
     wikipedia_page: Mixed-Up_Mother_Goose
     series_id: mixedup
 -
-    id: mothergoosehires
+    id: 'sci:mothergoosehires'
     name: 'Mixed-Up Mother Goose Deluxe'
     engine_id: sci
     company_id: sierra
@@ -6240,7 +6240,7 @@
     wikipedia_page: Mixed-Up_Mother_Goose
     series_id: mixedup
 -
-    id: msastrochicken
+    id: 'sci:msastrochicken'
     name: 'Ms. Astro Chicken'
     engine_id: sci
     company_id: sierra
@@ -6252,7 +6252,7 @@
     wikipedia_page: 'Space_Quest_IV#Ms._Astro_Chicken'
     series_id: sq
 -
-    id: pepper
+    id: 'sci:pepper'
     name: 'Pepper''s Adventures in Time'
     engine_id: sci
     company_id: sierra
@@ -6264,7 +6264,7 @@
     wikipedia_page: Pepper%27s_Adventures_in_Time
     series_id: sierranoseries
 -
-    id: phantasmagoria
+    id: 'sci:phantasmagoria'
     name: Phantasmagoria
     engine_id: sci
     company_id: sierra
@@ -6276,7 +6276,7 @@
     wikipedia_page: Phantasmagoria_(video_game)
     series_id: phantasmagoria
 -
-    id: polechudes
+    id: 'wintermute:polechudes'
     name: 'Pole Chudes'
     engine_id: wintermute
     company_id: herocraft
@@ -6288,7 +6288,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: phantasmagoria2
+    id: 'sci:phantasmagoria2'
     name: 'Phantasmagoria 2: A Puzzle of Flesh'
     engine_id: sci
     company_id: sierra
@@ -6300,7 +6300,7 @@
     wikipedia_page: 'Phantasmagoria:_A_Puzzle_of_Flesh'
     series_id: phantasmagoria
 -
-    id: pq1sci
+    id: 'sci:pq1sci'
     name: 'Police Quest: In Pursuit of the Death Angel'
     engine_id: sci
     company_id: sierra
@@ -6312,7 +6312,7 @@
     wikipedia_page: 'Police_Quest:_In_Pursuit_of_the_Death_Angel'
     series_id: pq
 -
-    id: pq2
+    id: 'sci:pq2'
     name: 'Police Quest 2: The Vengeance'
     engine_id: sci
     company_id: sierra
@@ -6324,7 +6324,7 @@
     wikipedia_page: 'Police_Quest_II:_The_Vengeance'
     series_id: pq
 -
-    id: pq3
+    id: 'sci:pq3'
     name: 'Police Quest 3: The Kindred'
     engine_id: sci
     company_id: sierra
@@ -6336,7 +6336,7 @@
     wikipedia_page: 'Police_Quest_III:_The_Kindred'
     series_id: pq
 -
-    id: pq4
+    id: 'sci:pq4'
     name: 'Police Quest IV: Open Season'
     engine_id: sci
     company_id: sierra
@@ -6348,7 +6348,7 @@
     wikipedia_page: 'Police_Quest:_Open_Season'
     series_id: pq
 -
-    id: pq4demo
+    id: 'sci:pq4demo'
     name: 'Police Quest IV: Open Season (Demo)'
     engine_id: sci
     company_id: sierra
@@ -6360,7 +6360,7 @@
     wikipedia_page: 'Police_Quest:_Open_Season'
     series_id: pq
 -
-    id: pqswat
+    id: 'sci:pqswat'
     name: 'Police Quest: SWAT'
     engine_id: sci
     company_id: sierra
@@ -6372,7 +6372,7 @@
     wikipedia_page: 'Police_Quest:_SWAT'
     series_id: pq
 -
-    id: primordia
+    id: 'ags:primordia'
     name: Primordia
     engine_id: ags
     company_id: wormwood
@@ -6384,7 +6384,7 @@
     wikipedia_page: Primordia_(video_game)
     series_id: ''
 -
-    id: qfg1
+    id: 'sci:qfg1'
     name: 'Quest for Glory I: So You Want To Be A Hero'
     engine_id: sci
     company_id: sierra
@@ -6396,7 +6396,7 @@
     wikipedia_page: 'Quest_for_Glory:_So_You_Want_to_Be_a_Hero'
     series_id: qfg
 -
-    id: qfg1vga
+    id: 'sci:qfg1vga'
     name: 'Quest for Glory I: So You Want To Be A Hero'
     engine_id: sci
     company_id: sierra
@@ -6408,7 +6408,7 @@
     wikipedia_page: 'Quest_for_Glory:_So_You_Want_to_Be_a_Hero'
     series_id: qfg
 -
-    id: qfg2
+    id: 'sci:qfg2'
     name: 'Quest for Glory II: Trial by Fire'
     engine_id: sci
     company_id: sierra
@@ -6420,7 +6420,7 @@
     wikipedia_page: 'Quest_for_Glory_II:_Trial_by_Fire'
     series_id: qfg
 -
-    id: projectdoom
+    id: 'wintermute:projectdoom'
     name: 'Project: Doom'
     engine_id: wintermute
     company_id: blekinge
@@ -6432,7 +6432,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: projectjoe
+    id: 'wintermute:projectjoe'
     name: 'Project Joe'
     engine_id: wintermute
     company_id: sticky
@@ -6444,7 +6444,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: projectorface
+    id: 'ags:projectorface'
     name: 'Projector Face'
     engine_id: ags
     company_id: fluik
@@ -6456,7 +6456,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: qfg3
+    id: 'sci:qfg3'
     name: 'Quest for Glory III: Wages of War'
     engine_id: sci
     company_id: sierra
@@ -6468,7 +6468,7 @@
     wikipedia_page: 'Quest_for_Glory_III:_Wages_of_War'
     series_id: qfg
 -
-    id: qfg4
+    id: 'sci:qfg4'
     name: 'Quest for Glory IV: Shadows of Darkness'
     engine_id: sci
     company_id: sierra
@@ -6480,7 +6480,7 @@
     wikipedia_page: 'Quest_for_Glory:_Shadows_of_Darkness'
     series_id: qfg
 -
-    id: qfg4demo
+    id: 'sci:qfg4demo'
     name: 'Quest for Glory IV: Shadows of Darkness (Demo)'
     engine_id: sci
     company_id: sierra
@@ -6492,7 +6492,7 @@
     wikipedia_page: 'Quest_for_Glory:_Shadows_of_Darkness'
     series_id: qfg
 -
-    id: rama
+    id: 'sci:rama'
     name: RAMA
     engine_id: sci
     company_id: sierra
@@ -6504,7 +6504,7 @@
     wikipedia_page: Rama_(video_game)
     series_id: sierranoseries
 -
-    id: realm
+    id: 'sci:realm'
     name: 'The Realm'
     engine_id: sci
     company_id: sierra
@@ -6516,7 +6516,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: sci
+    id: 'sci:sci'
     name: 'Sierra SCI Game'
     engine_id: sci
     company_id: sierra
@@ -6528,7 +6528,7 @@
     wikipedia_page: ''
     series_id: sierranoseries
 -
-    id: sci-fanmade
+    id: 'sci:sci-fanmade'
     name: 'Fanmade SCI Game'
     engine_id: sci
     company_id: fan
@@ -6540,7 +6540,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: shivers
+    id: 'sci:shivers'
     name: Shivers
     engine_id: sci
     company_id: sierra
@@ -6552,7 +6552,7 @@
     wikipedia_page: Shivers_(video_game)
     series_id: sierranoseries
 -
-    id: shivers2
+    id: 'sci:shivers2'
     name: 'Shivers 2: Harvest of Souls'
     engine_id: sci
     company_id: sierra
@@ -6564,7 +6564,7 @@
     wikipedia_page: 'Shivers_II:_Harvest_of_Souls'
     series_id: sierranoseries
 -
-    id: qajarycat
+    id: 'wintermute:qajarycat'
     name: 'Qajary Cat'
     engine_id: wintermute
     company_id: rskent
@@ -6576,7 +6576,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: slater
+    id: 'sci:slater'
     name: 'Slater & Charlie Go Camping'
     engine_id: sci
     company_id: sierra
@@ -6588,7 +6588,7 @@
     wikipedia_page: Slater_%26_Charlie_Go_Camping
     series_id: sierranoseries
 -
-    id: sq1sci
+    id: 'sci:sq1sci'
     name: 'Space Quest I: Roger Wilco in the Sarien Encounter'
     engine_id: sci
     company_id: sierra
@@ -6600,7 +6600,7 @@
     wikipedia_page: Space_Quest_I
     series_id: sq
 -
-    id: sq3
+    id: 'sci:sq3'
     name: 'Space Quest III: The Pirates of Pestulon'
     engine_id: sci
     company_id: sierra
@@ -6612,7 +6612,7 @@
     wikipedia_page: Space_Quest_III
     series_id: sq
 -
-    id: sq4
+    id: 'sci:sq4'
     name: 'Space Quest IV: Roger Wilco and the Time Rippers'
     engine_id: sci
     company_id: sierra
@@ -6624,7 +6624,7 @@
     wikipedia_page: Space_Quest_IV
     series_id: sq
 -
-    id: qfg2agdi
+    id: 'ags:qfg2agdi'
     name: 'Quest for Glory II: Trial by Fire Remake'
     engine_id: ags
     company_id: agdi
@@ -6636,7 +6636,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: sq5
+    id: 'sci:sq5'
     name: 'Space Quest V: The Next Mutation'
     engine_id: sci
     company_id: sierra
@@ -6648,7 +6648,7 @@
     wikipedia_page: Space_Quest_V
     series_id: sq
 -
-    id: sq6
+    id: 'sci:sq6'
     name: 'Space Quest 6: Roger Wilco in the Spinal Frontier'
     engine_id: sci
     company_id: sierra
@@ -6660,7 +6660,7 @@
     wikipedia_page: Space_Quest_6
     series_id: sq
 -
-    id: torin
+    id: 'sci:torin'
     name: 'Torin''s Passage'
     engine_id: sci
     company_id: sierra
@@ -6672,7 +6672,7 @@
     wikipedia_page: Torin%27s_Passage
     series_id: sierranoseries
 -
-    id: qfi
+    id: 'ags:qfi'
     name: 'Quest for Infamy'
     engine_id: ags
     company_id: infamousq
@@ -6684,7 +6684,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: quantumnauts
+    id: 'ags:quantumnauts'
     name: Quantumnauts
     engine_id: ags
     company_id: midian
@@ -6696,7 +6696,7 @@
     wikipedia_page: ''
     series_id: quantum
 -
-    id: quantumnauts2
+    id: 'ags:quantumnauts2'
     name: 'Quantumnauts 2'
     engine_id: ags
     company_id: midian
@@ -6708,7 +6708,7 @@
     wikipedia_page: ''
     series_id: quantum
 -
-    id: activity
+    id: 'scumm:activity'
     name: 'Putt-Putt and Fatty Bear''s Activity Pack'
     engine_id: scumm
     company_id: he
@@ -6720,7 +6720,7 @@
     wikipedia_page: ''
     series_id: fbear
 -
-    id: airport
+    id: 'scumm:airport'
     name: 'Let''s Explore the Airport'
     engine_id: scumm
     company_id: he
@@ -6732,7 +6732,7 @@
     wikipedia_page: 'Junior_Field_Trips#Let''s_Explore_the_Airport'
     series_id: juniorfield
 -
-    id: questforyrolg
+    id: 'ags:questforyrolg'
     name: 'Quest for Yrolg'
     engine_id: ags
     company_id: crystalshard
@@ -6744,7 +6744,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: arttime
+    id: 'scumm:arttime'
     name: 'Blue''s Clues: Blue''s Art Time Activities'
     engine_id: scumm
     company_id: he
@@ -6756,7 +6756,7 @@
     wikipedia_page: ''
     series_id: blue
 -
-    id: atlantis
+    id: 'scumm:atlantis'
     name: 'Indiana Jones and the Fate of Atlantis'
     engine_id: scumm
     company_id: lucasarts
@@ -6768,7 +6768,7 @@
     wikipedia_page: Indiana_Jones_and_the_Fate_of_Atlantis
     series_id: indy
 -
-    id: balloon
+    id: 'scumm:balloon'
     name: 'Putt-Putt and Pep''s Balloon-O-Rama'
     engine_id: scumm
     company_id: he
@@ -6780,7 +6780,7 @@
     wikipedia_page: Putt-Putt_and_Pep%27s_Balloon-o-Rama
     series_id: puttputt
 -
-    id: baseball
+    id: 'scumm:baseball'
     name: 'Backyard Baseball'
     engine_id: scumm
     company_id: he
@@ -6792,7 +6792,7 @@
     wikipedia_page: Backyard_Baseball
     series_id: juniorsports
 -
-    id: rebeccacarlson1
+    id: 'wintermute:rebeccacarlson1'
     name: 'Rebecca Carlson Mystery 01 - Silent Footsteps'
     engine_id: wintermute
     company_id: frostlind
@@ -6804,7 +6804,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: redbow
+    id: 'ags:redbow'
     name: 'Red Bow'
     engine_id: ags
     company_id: stranga
@@ -6816,7 +6816,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: baseball2001
+    id: 'scumm:baseball2001'
     name: 'Backyard Baseball 2001'
     engine_id: scumm
     company_id: he
@@ -6828,7 +6828,7 @@
     wikipedia_page: Backyard_Baseball
     series_id: juniorsports
 -
-    id: baseball2003
+    id: 'scumm:baseball2003'
     name: 'Backyard Baseball 2003'
     engine_id: scumm
     company_id: he
@@ -6840,7 +6840,7 @@
     wikipedia_page: Backyard_Baseball
     series_id: juniorsports
 -
-    id: reptilesquest
+    id: 'wintermute:reptilesquest'
     name: 'On the Tracks of Dinosaurs'
     engine_id: wintermute
     company_id: unknown
@@ -6852,7 +6852,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: resonance
+    id: 'ags:resonance'
     name: Resonance
     engine_id: ags
     company_id: xii
@@ -6864,7 +6864,7 @@
     wikipedia_page: Resonance_(video_game)
     series_id: ''
 -
-    id: reversion1
+    id: 'wintermute:reversion1'
     name: 'Reversion: The Escape'
     engine_id: wintermute
     company_id: 3f
@@ -6876,7 +6876,7 @@
     wikipedia_page: ''
     series_id: reversion
 -
-    id: reversion2
+    id: 'wintermute:reversion2'
     name: 'Reversion: The Meeting'
     engine_id: wintermute
     company_id: 3f
@@ -6888,7 +6888,7 @@
     wikipedia_page: ''
     series_id: reversion
 -
-    id: reversion3
+    id: 'wintermute:reversion3'
     name: 'Reversion: The Return'
     engine_id: wintermute
     company_id: 3f
@@ -6900,7 +6900,7 @@
     wikipedia_page: ''
     series_id: reversion
 -
-    id: rhiannon
+    id: 'wintermute:rhiannon'
     name: 'Rhiannon: Curse of the Four Branches'
     engine_id: wintermute
     company_id: arberth
@@ -6912,7 +6912,7 @@
     wikipedia_page: 'Rhiannon:_Curse_of_the_Four_Branches'
     series_id: ''
 -
-    id: richardandalice
+    id: 'ags:richardandalice'
     name: 'Richard & Alice'
     engine_id: ags
     company_id: owlcave
@@ -6924,7 +6924,7 @@
     wikipedia_page: Richard_%26_Alice
     series_id: ''
 -
-    id: basketball
+    id: 'scumm:basketball'
     name: 'Backyard Basketball'
     engine_id: scumm
     company_id: he
@@ -6936,7 +6936,7 @@
     wikipedia_page: Backyard_Basketball
     series_id: juniorsports
 -
-    id: blues123time
+    id: 'scumm:blues123time'
     name: 'Blue''s 123 Time Activities'
     engine_id: scumm
     company_id: he
@@ -6948,7 +6948,7 @@
     wikipedia_page: Blue%27s_123_Time_Activities
     series_id: blue
 -
-    id: bluesabctime
+    id: 'scumm:bluesabctime'
     name: 'Blue''s ABC Time Activities'
     engine_id: scumm
     company_id: he
@@ -6960,7 +6960,7 @@
     wikipedia_page: ''
     series_id: blue
 -
-    id: ritter
+    id: 'wintermute:ritter'
     name: '1½ Ritter: Auf der Suche nach der hinreißenden Herzelinde'
     engine_id: wintermute
     company_id: daedalic
@@ -6972,7 +6972,7 @@
     wikipedia_page: 'https://de.wikipedia.org/wiki/1%C2%BD_Ritter_–_Auf_der_Suche_nach_der_hinreißenden_Herzelinde'
     series_id: ''
 -
-    id: bluesbirthday
+    id: 'scumm:bluesbirthday'
     name: 'Blue''s Clues: Blue''s Birthday Adventure'
     engine_id: scumm
     company_id: he
@@ -6984,7 +6984,7 @@
     wikipedia_page: Blue%27s_Birthday_Adventure
     series_id: blue
 -
-    id: rnrneverdies
+    id: 'ags:rnrneverdies'
     name: 'Rock ''n'' Roll Will Never Die!'
     engine_id: ags
     company_id: instantmillion
@@ -6996,7 +6996,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: bluestreasurehunt
+    id: 'scumm:bluestreasurehunt'
     name: 'Blue''s Treasure Hunt'
     engine_id: scumm
     company_id: he
@@ -7008,7 +7008,7 @@
     wikipedia_page: Blue%27s_Treasure_Hunt
     series_id: blue
 -
-    id: brstorm
+    id: 'scumm:brstorm'
     name: 'Bear Stormin'''
     engine_id: scumm
     company_id: he
@@ -7020,7 +7020,7 @@
     wikipedia_page: ''
     series_id: fbear
 -
-    id: catalog
+    id: 'scumm:catalog'
     name: 'Humongous Interactive Catalog'
     engine_id: scumm
     company_id: he
@@ -7032,7 +7032,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: roguestate
+    id: 'ags:roguestate'
     name: 'Rogue State'
     engine_id: ags
     company_id: lrdg
@@ -7044,7 +7044,7 @@
     wikipedia_page: ''
     series_id: roguestate
 -
-    id: chase
+    id: 'scumm:chase'
     name: 'SPY Fox in "Cheese Chase"'
     engine_id: scumm
     company_id: he
@@ -7056,7 +7056,7 @@
     wikipedia_page: ''
     series_id: spyfox
 -
-    id: rosemary
+    id: 'wintermute:rosemary'
     name: Rosemary
     engine_id: wintermute
     company_id: mitgamelab
@@ -7068,7 +7068,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: comi
+    id: 'scumm:comi'
     name: 'The Curse of Monkey Island'
     engine_id: scumm
     company_id: lucasarts
@@ -7080,7 +7080,7 @@
     wikipedia_page: The_Curse_of_Monkey_Island
     series_id: mi
 -
-    id: dig
+    id: 'scumm:dig'
     name: 'The Dig'
     engine_id: scumm
     company_id: lucasarts
@@ -7092,7 +7092,7 @@
     wikipedia_page: The_Dig_(video_game)
     series_id: lucasartsnoseries
 -
-    id: dog
+    id: 'scumm:dog'
     name: 'Putt-Putt and Pep''s Dog on a Stick'
     engine_id: scumm
     company_id: he
@@ -7104,7 +7104,7 @@
     wikipedia_page: ''
     series_id: puttputt
 -
-    id: farm
+    id: 'scumm:farm'
     name: 'Let''s Explore the Farm'
     engine_id: scumm
     company_id: he
@@ -7116,7 +7116,7 @@
     wikipedia_page: 'Junior_Field_Trips#Let''s_Explore_the_Farm'
     series_id: juniorfield
 -
-    id: fbear
+    id: 'scumm:fbear'
     name: 'Fatty Bear''s Birthday Surprise'
     engine_id: scumm
     company_id: he
@@ -7128,7 +7128,7 @@
     wikipedia_page: Fatty_Bear%27s_Birthday_Surprise
     series_id: fbear
 -
-    id: samaritan
+    id: 'ags:samaritan'
     name: 'The Samaritan Paradox'
     engine_id: ags
     company_id: faravid
@@ -7140,7 +7140,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: fbpack
+    id: 'scumm:fbpack'
     name: 'Fatty Bear''s FunPack'
     engine_id: scumm
     company_id: he
@@ -7152,7 +7152,7 @@
     wikipedia_page: ''
     series_id: fbear
 -
-    id: football
+    id: 'scumm:football'
     name: 'Backyard Football'
     engine_id: scumm
     company_id: he
@@ -7164,7 +7164,7 @@
     wikipedia_page: Backyard_Football
     series_id: juniorsports
 -
-    id: football2002
+    id: 'scumm:football2002'
     name: 'Backyard Football 2002'
     engine_id: scumm
     company_id: he
@@ -7176,7 +7176,7 @@
     wikipedia_page: Backyard_Football
     series_id: juniorsports
 -
-    id: satanandsons
+    id: 'wintermute:satanandsons'
     name: 'Satan and Sons'
     engine_id: wintermute
     company_id: unknown
@@ -7188,7 +7188,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: freddi
+    id: 'scumm:freddi'
     name: 'Freddi Fish and the Case of the Missing Kelp Seeds'
     engine_id: scumm
     company_id: he
@@ -7200,7 +7200,7 @@
     wikipedia_page: Freddi_Fish_and_the_Case_of_the_Missing_Kelp_Seeds
     series_id: freddi
 -
-    id: freddi2
+    id: 'scumm:freddi2'
     name: 'Freddi Fish 2: The Case of the Haunted Schoolhouse'
     engine_id: scumm
     company_id: he
@@ -7212,7 +7212,7 @@
     wikipedia_page: 'Freddi_Fish_2:_The_Case_of_the_Haunted_Schoolhouse'
     series_id: freddi
 -
-    id: freddi3
+    id: 'scumm:freddi3'
     name: 'Freddi Fish 3: The Case of the Stolen Conch Shell'
     engine_id: scumm
     company_id: he
@@ -7224,7 +7224,7 @@
     wikipedia_page: 'Freddi_Fish_3:_The_Case_of_the_Stolen_Conch_Shell'
     series_id: freddi
 -
-    id: freddi4
+    id: 'scumm:freddi4'
     name: 'Freddi Fish 4: The Case of the Hogfish Rustlers of Briny Gulch'
     engine_id: scumm
     company_id: he
@@ -7236,7 +7236,7 @@
     wikipedia_page: 'Freddi_Fish_4:_The_Case_of_the_Hogfish_Rustlers_of_Briny_Gulch'
     series_id: freddi
 -
-    id: freddicove
+    id: 'scumm:freddicove'
     name: 'Freddi Fish 5: The Case of the Creature of Coral Cove'
     engine_id: scumm
     company_id: he
@@ -7248,7 +7248,7 @@
     wikipedia_page: 'Freddi_Fish_5:_The_Case_of_the_Creature_of_Coral_Cove'
     series_id: freddi
 -
-    id: securanote
+    id: 'wintermute:securanote'
     name: Securanote
     engine_id: wintermute
     company_id: skaldic
@@ -7260,7 +7260,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: freddisfunshop
+    id: 'scumm:freddisfunshop'
     name: 'Freddi Fish''s One-Stop Fun Shop'
     engine_id: scumm
     company_id: he
@@ -7272,7 +7272,7 @@
     wikipedia_page: ''
     series_id: freddi
 -
-    id: ft
+    id: 'scumm:ft'
     name: 'Full Throttle'
     engine_id: scumm
     company_id: lucasarts
@@ -7284,7 +7284,7 @@
     wikipedia_page: Full_Throttle_(1995_video_game)
     series_id: lucasartsnoseries
 -
-    id: funpack
+    id: 'scumm:funpack'
     name: 'Putt-Putt''s Fun Pack'
     engine_id: scumm
     company_id: he
@@ -7296,7 +7296,7 @@
     wikipedia_page: ''
     series_id: puttputt
 -
-    id: indy3
+    id: 'scumm:indy3'
     name: 'Indiana Jones and the Last Crusade: The Graphic Adventure'
     engine_id: scumm
     company_id: lucasarts
@@ -7308,7 +7308,7 @@
     wikipedia_page: 'Indiana_Jones_and_the_Last_Crusade:_The_Graphic_Adventure'
     series_id: indy
 -
-    id: shaban
+    id: 'wintermute:shaban'
     name: Shaban
     engine_id: wintermute
     company_id: petagame
@@ -7320,7 +7320,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: indyloom
+    id: 'scumm:indyloom'
     name: 'Indiana Jones and the Last Crusade & Loom'
     engine_id: scumm
     company_id: lucasarts
@@ -7332,7 +7332,7 @@
     wikipedia_page: ''
     series_id: indy
 -
-    id: shardlight
+    id: 'ags:shardlight'
     name: Shardlight
     engine_id: ags
     company_id: wadjet
@@ -7344,7 +7344,7 @@
     wikipedia_page: Shardlight
     series_id: ''
 -
-    id: indyzak
+    id: 'scumm:indyzak'
     name: 'Games, Games, Games: Maniac Mansion + Zak McKracken + Indiana Jones and the last Crusade'
     engine_id: scumm
     company_id: lucasarts
@@ -7356,7 +7356,7 @@
     wikipedia_page: ''
     series_id: lucasartsnoseries
 -
-    id: jungle
+    id: 'scumm:jungle'
     name: 'Let''s Explore the Jungle'
     engine_id: scumm
     company_id: he
@@ -7368,7 +7368,7 @@
     wikipedia_page: 'Junior_Field_Trips#Let''s_Explore_the_Jungle'
     series_id: juniorfield
 -
-    id: shinestar
+    id: 'wintermute:shinestar'
     name: 'The Shine of a Star'
     engine_id: wintermute
     company_id: forgottenkey
@@ -7380,7 +7380,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: loom
+    id: 'scumm:loom'
     name: Loom
     engine_id: scumm
     company_id: lucasarts
@@ -7392,7 +7392,7 @@
     wikipedia_page: Loom_(video_game)
     series_id: lucasartsnoseries
 -
-    id: lost
+    id: 'scumm:lost'
     name: 'Pajama Sam''s Lost & Found'
     engine_id: scumm
     company_id: he
@@ -7404,7 +7404,7 @@
     wikipedia_page: ''
     series_id: pajama
 -
-    id: maniac
+    id: 'scumm:maniac'
     name: 'Maniac Mansion'
     engine_id: scumm
     company_id: lucasarts
@@ -7416,7 +7416,7 @@
     wikipedia_page: Maniac_Mansion
     series_id: maniac
 -
-    id: maze
+    id: 'scumm:maze'
     name: 'Freddi Fish and Luther''s Maze Madness'
     engine_id: scumm
     company_id: he
@@ -7428,7 +7428,7 @@
     wikipedia_page: ''
     series_id: freddi
 -
-    id: monkey
+    id: 'scumm:monkey'
     name: 'The Secret of Monkey Island'
     engine_id: scumm
     company_id: lucasarts
@@ -7440,7 +7440,7 @@
     wikipedia_page: The_Secret_of_Monkey_Island
     series_id: mi
 -
-    id: monkey2
+    id: 'scumm:monkey2'
     name: 'Monkey Island 2: LeChuck''s Revenge'
     engine_id: scumm
     company_id: lucasarts
@@ -7452,7 +7452,7 @@
     wikipedia_page: 'Monkey_Island_2:_LeChuck%27s_Revenge'
     series_id: mi
 -
-    id: moonbase
+    id: 'scumm:moonbase'
     name: 'Moonbase Commander'
     engine_id: scumm
     company_id: he
@@ -7464,7 +7464,7 @@
     wikipedia_page: MoonBase_Commander
     series_id: ''
 -
-    id: mustard
+    id: 'scumm:mustard'
     name: 'Spy Fox in "Hold the Mustard"'
     engine_id: scumm
     company_id: he
@@ -7476,7 +7476,7 @@
     wikipedia_page: ''
     series_id: spyfox
 -
-    id: pajama
+    id: 'scumm:pajama'
     name: 'Pajama Sam: No Need to Hide When It''s Dark Outside'
     engine_id: scumm
     company_id: he
@@ -7488,7 +7488,7 @@
     wikipedia_page: 'Pajama_Sam:_No_Need_to_Hide_When_It%27s_Dark_Outside'
     series_id: pajama
 -
-    id: pajama2
+    id: 'scumm:pajama2'
     name: 'Pajama Sam 2: Thunder and Lightning Aren''t so Frightening'
     engine_id: scumm
     company_id: he
@@ -7500,7 +7500,7 @@
     wikipedia_page: 'Pajama_Sam_2:_Thunder_and_Lightning_Aren%27t_so_Frightening'
     series_id: pajama
 -
-    id: pajama3
+    id: 'scumm:pajama3'
     name: 'Pajama Sam 3: You Are What You Eat From Your Head To Your Feet'
     engine_id: scumm
     company_id: he
@@ -7512,7 +7512,7 @@
     wikipedia_page: 'Pajama_Sam_3:_You_Are_What_You_Eat_from_Your_Head_to_Your_Feet'
     series_id: pajama
 -
-    id: pass
+    id: 'scumm:pass'
     name: 'Passport to Adventure (Indiana Jones and the Last Crusade, The Secret of Monkey Island, Loom)'
     engine_id: scumm
     company_id: lucasarts
@@ -7524,7 +7524,7 @@
     wikipedia_page: ''
     series_id: indy
 -
-    id: pjgames
+    id: 'scumm:pjgames'
     name: 'Pajama Sam: Games to Play on Any Day'
     engine_id: scumm
     company_id: he
@@ -7536,7 +7536,7 @@
     wikipedia_page: ''
     series_id: pajama
 -
-    id: sofiasdebt
+    id: 'wintermute:sofiasdebt'
     name: 'Sofia''s Debt'
     engine_id: wintermute
     company_id: artistic
@@ -7548,7 +7548,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: puttcircus
+    id: 'scumm:puttcircus'
     name: 'Putt-Putt Joins the Circus'
     engine_id: scumm
     company_id: he
@@ -7560,7 +7560,7 @@
     wikipedia_page: Putt-Putt_Joins_the_Circus
     series_id: puttputt
 -
-    id: puttmoon
+    id: 'scumm:puttmoon'
     name: 'Putt-Putt Goes to the Moon'
     engine_id: scumm
     company_id: he
@@ -7572,7 +7572,7 @@
     wikipedia_page: Putt-Putt_Goes_to_the_Moon
     series_id: puttputt
 -
-    id: puttputt
+    id: 'scumm:puttputt'
     name: 'Putt-Putt Joins the Parade'
     engine_id: scumm
     company_id: he
@@ -7584,7 +7584,7 @@
     wikipedia_page: Putt-Putt_Joins_the_Parade
     series_id: puttputt
 -
-    id: sotv1
+    id: 'wintermute:sotv1'
     name: 'Shadows on the Vatican - Act 1: Greed'
     engine_id: wintermute
     company_id: daringtouch
@@ -7596,7 +7596,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: sotv2
+    id: 'wintermute:sotv2'
     name: 'Shadows on the Vatican - Act II: Wrath'
     engine_id: wintermute
     company_id: daringtouch
@@ -7608,7 +7608,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: spaceinvaders
+    id: 'wintermute:spaceinvaders'
     name: 'Space Invaders'
     engine_id: wintermute
     company_id: unknown
@@ -7620,7 +7620,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: spacemadness
+    id: 'wintermute:spacemadness'
     name: 'Space Madness'
     engine_id: wintermute
     company_id: spreadcamp
@@ -7632,7 +7632,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: puttrace
+    id: 'scumm:puttrace'
     name: 'Putt-Putt Enters the Race'
     engine_id: scumm
     company_id: he
@@ -7644,7 +7644,7 @@
     wikipedia_page: Putt-Putt_Enters_the_Race
     series_id: puttputt
 -
-    id: puttsfunshop
+    id: 'scumm:puttsfunshop'
     name: 'Putt-Putt''s One-Stop Fun Shop'
     engine_id: scumm
     company_id: he
@@ -7656,7 +7656,7 @@
     wikipedia_page: ''
     series_id: puttputt
 -
-    id: putttime
+    id: 'scumm:putttime'
     name: 'Putt-Putt Travels Through Time'
     engine_id: scumm
     company_id: he
@@ -7668,7 +7668,7 @@
     wikipedia_page: Putt-Putt_Travels_Through_Time
     series_id: puttputt
 -
-    id: puttzoo
+    id: 'scumm:puttzoo'
     name: 'Putt-Putt Saves the Zoo'
     engine_id: scumm
     company_id: he
@@ -7680,7 +7680,7 @@
     wikipedia_page: Putt-Putt_Saves_the_Zoo
     series_id: puttputt
 -
-    id: readtime
+    id: 'scumm:readtime'
     name: 'Blue''s Reading Time Activities'
     engine_id: scumm
     company_id: he
@@ -7692,7 +7692,7 @@
     wikipedia_page: ''
     series_id: blue
 -
-    id: samnmax
+    id: 'scumm:samnmax'
     name: 'Sam & Max: Hit the Road'
     engine_id: scumm
     company_id: lucasarts
@@ -7704,7 +7704,7 @@
     wikipedia_page: Sam_%26_Max_Hit_the_Road
     series_id: lucasartsnoseries
 -
-    id: samsfunshop
+    id: 'scumm:samsfunshop'
     name: 'Pajama Sam''s One Stop Fun Shop'
     engine_id: scumm
     company_id: he
@@ -7716,7 +7716,7 @@
     wikipedia_page: ''
     series_id: pajama
 -
-    id: soccer
+    id: 'scumm:soccer'
     name: 'Backyard Soccer'
     engine_id: scumm
     company_id: he
@@ -7728,7 +7728,7 @@
     wikipedia_page: Backyard_Soccer
     series_id: juniorsports
 -
-    id: soccer2004
+    id: 'scumm:soccer2004'
     name: 'Backyard Soccer 2004'
     engine_id: scumm
     company_id: he
@@ -7740,7 +7740,7 @@
     wikipedia_page: Backyard_Soccer
     series_id: juniorsports
 -
-    id: sq2fg
+    id: 'ags:sq2fg'
     name: 'Space Quest for Glory'
     engine_id: ags
     company_id: infamousadv
@@ -7752,7 +7752,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: sq2vga
+    id: 'ags:sq2vga'
     name: 'Space Quest II - Vohaul''s Revenge VGA Remake'
     engine_id: ags
     company_id: infamousadv
@@ -7764,7 +7764,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: soccermls
+    id: 'scumm:soccermls'
     name: 'Backyard Soccer MLS Edition'
     engine_id: scumm
     company_id: he
@@ -7776,7 +7776,7 @@
     wikipedia_page: Backyard_Soccer_MLS_Edition
     series_id: juniorsports
 -
-    id: socks
+    id: 'scumm:socks'
     name: 'Pajama Sam''s Sock Works'
     engine_id: scumm
     company_id: he
@@ -7788,7 +7788,7 @@
     wikipedia_page: ''
     series_id: pajama
 -
-    id: sq45
+    id: 'ags:sq45'
     name: 'Space Quest IV.5 - Roger Wilco and the Voyage Home'
     engine_id: ags
     company_id: westend
@@ -7800,7 +7800,7 @@
     wikipedia_page: Resonance_(video_game)
     series_id: ''
 -
-    id: spyfox
+    id: 'scumm:spyfox'
     name: 'Spy Fox in "Dry Cereal"'
     engine_id: scumm
     company_id: he
@@ -7812,7 +7812,7 @@
     wikipedia_page: 'Spy_Fox_in_"Dry_Cereal"'
     series_id: spyfox
 -
-    id: spyfox2
+    id: 'scumm:spyfox2'
     name: 'Spy Fox 2: "Some Assembly Required"'
     engine_id: scumm
     company_id: he
@@ -7824,7 +7824,7 @@
     wikipedia_page: 'Spy_Fox_2:_"Some_Assembly_Required"'
     series_id: spyfox
 -
-    id: sqdote
+    id: 'ags:sqdote'
     name: 'Space Quest Minus 1: Decisions of the Elders'
     engine_id: ags
     company_id: fan
@@ -7836,7 +7836,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: sqinc
+    id: 'ags:sqinc'
     name: 'Space Quest: Incinerations'
     engine_id: ags
     company_id: fan
@@ -7848,7 +7848,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: sqvsb
+    id: 'ags:sqvsb'
     name: 'Space Quest: Vohaul Strikes Back'
     engine_id: ags
     company_id: teamvsb
@@ -7860,7 +7860,7 @@
     wikipedia_page: 'Space_Quest:_Vohaul_Strikes_Back'
     series_id: ''
 -
-    id: spyozon
+    id: 'scumm:spyozon'
     name: 'Spy Fox: "Operation Ozone"'
     engine_id: scumm
     company_id: he
@@ -7872,7 +7872,7 @@
     wikipedia_page: 'Spy_Fox_3:_"Operation_Ozone"'
     series_id: spyfox
 -
-    id: tentacle
+    id: 'scumm:tentacle'
     name: 'Maniac Mansion: Day of the Tentacle'
     engine_id: scumm
     company_id: lucasarts
@@ -7884,7 +7884,7 @@
     wikipedia_page: Day_of_the_Tentacle
     series_id: maniac
 -
-    id: thinker1
+    id: 'scumm:thinker1'
     name: 'Big Thinkers! 1st Grade'
     engine_id: scumm
     company_id: he
@@ -7896,7 +7896,7 @@
     wikipedia_page: Big_Thinkers_(video_game_series)
     series_id: bigthinkers
 -
-    id: starshipquasar
+    id: 'ags:starshipquasar'
     name: 'Starship Quasar'
     engine_id: ags
     company_id: crystalshard
@@ -7908,7 +7908,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: thinkerk
+    id: 'scumm:thinkerk'
     name: 'Big Thinkers! Kindergarten'
     engine_id: scumm
     company_id: he
@@ -7920,7 +7920,7 @@
     wikipedia_page: Big_Thinkers_(video_game_series)
     series_id: bigthinkers
 -
-    id: water
+    id: 'scumm:water'
     name: 'Freddi Fish and Luther''s Water Worries'
     engine_id: scumm
     company_id: he
@@ -7932,7 +7932,7 @@
     wikipedia_page: ''
     series_id: freddi
 -
-    id: strangeland
+    id: 'ags:strangeland'
     name: Strangeland
     engine_id: ags
     company_id: wormwood
@@ -7944,7 +7944,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: sulifallenharmony
+    id: 'ags:sulifallenharmony'
     name: 'Suli Fallen Harmony'
     engine_id: ags
     company_id: coutal
@@ -7956,7 +7956,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: sumatra
+    id: 'ags:sumatra'
     name: 'Sumatra: Fate of Yandi'
     engine_id: ags
     company_id: cloakdagger
@@ -7968,7 +7968,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: superjazzman
+    id: 'ags:superjazzman'
     name: 'Super Jazz Man'
     engine_id: ags
     company_id: herculean
@@ -7980,7 +7980,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: zak
+    id: 'scumm:zak'
     name: 'Zak McKracken and the Alien Mindbenders'
     engine_id: scumm
     company_id: lucasarts
@@ -7992,7 +7992,7 @@
     wikipedia_page: Zak_McKracken_and_the_Alien_Mindbenders
     series_id: lucasartsnoseries
 -
-    id: zakloom
+    id: 'scumm:zakloom'
     name: 'Zak McKracken & Loom'
     engine_id: scumm
     company_id: lucasarts
@@ -8004,7 +8004,7 @@
     wikipedia_page: ''
     series_id: lucasartsnoseries
 -
-    id: rosetattoo
+    id: 'sherlock:rosetattoo'
     name: 'The Lost Files of Sherlock Holmes: Case of the Rose Tattoo'
     engine_id: sherlock
     company_id: mythos
@@ -8016,7 +8016,7 @@
     wikipedia_page: 'The_Lost_Files_of_Sherlock_Holmes:_The_Case_of_the_Rose_Tattoo'
     series_id: sherlock
 -
-    id: scalpel
+    id: 'sherlock:scalpel'
     name: 'The Lost Files of Sherlock Holmes: The Case of the Serrated Scalpel'
     engine_id: sherlock
     company_id: mythos
@@ -8028,7 +8028,7 @@
     wikipedia_page: The_Lost_Files_of_Sherlock_Holmes
     series_id: sherlock
 -
-    id: sky
+    id: 'sky:sky'
     name: 'Beneath a Steel Sky'
     engine_id: sky
     company_id: revolution
@@ -8040,7 +8040,7 @@
     wikipedia_page: Beneath_a_Steel_Sky
     series_id: ''
 -
-    id: cubert
+    id: 'sludge:cubert'
     name: 'Cubert Badbone, P.I.'
     engine_id: sludge
     company_id: deirdrakiai
@@ -8052,7 +8052,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: frasse
+    id: 'sludge:frasse'
     name: 'Frasse and the Peas of Kejick'
     engine_id: sludge
     company_id: unknown
@@ -8064,7 +8064,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: interview
+    id: 'sludge:interview'
     name: 'The Interview'
     engine_id: sludge
     company_id: unknown
@@ -8076,7 +8076,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: life
+    id: 'sludge:life'
     name: 'Life Flashes By'
     engine_id: sludge
     company_id: unknown
@@ -8088,7 +8088,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: mandy
+    id: 'sludge:mandy'
     name: 'Mandy Christmas Adventure'
     engine_id: sludge
     company_id: unknown
@@ -8100,7 +8100,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: outoforder
+    id: 'sludge:outoforder'
     name: 'Out Of Order'
     engine_id: sludge
     company_id: hungry
@@ -8112,7 +8112,7 @@
     wikipedia_page: Out_of_Order_(video_game)
     series_id: ''
 -
-    id: robinsrescue
+    id: 'sludge:robinsrescue'
     name: 'Robin''s Rescue'
     engine_id: sludge
     company_id: unknown
@@ -8124,7 +8124,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: sludge
+    id: 'sludge:sludge'
     name: 'Sludge Game'
     engine_id: sludge
     company_id: unknown
@@ -8136,7 +8136,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: tgttpoacs
+    id: 'sludge:tgttpoacs'
     name: 'The Game That Takes Place on a Cruise Ship'
     engine_id: sludge
     company_id: deirdrakiai
@@ -8148,7 +8148,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: verbcoin
+    id: 'sludge:verbcoin'
     name: 'Verb Coin'
     engine_id: sludge
     company_id: unknown
@@ -8160,7 +8160,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: welcome
+    id: 'sludge:welcome'
     name: 'Welcome Example'
     engine_id: sludge
     company_id: unknown
@@ -8172,7 +8172,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: tlj
+    id: 'stark:tlj'
     name: 'The Longest Journey'
     engine_id: stark
     company_id: funcom
@@ -8184,7 +8184,7 @@
     wikipedia_page: The_Longest_Journey
     series_id: ''
 -
-    id: tales
+    id: 'ags:tales'
     name: Tales
     engine_id: ags
     company_id: apemarina
@@ -8196,7 +8196,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: st25
+    id: 'startrek:st25'
     name: 'Star Trek: 25th Anniversary'
     engine_id: startrek
     company_id: interplay
@@ -8208,7 +8208,7 @@
     wikipedia_page: 'Star_Trek:_25th_Anniversary_(computer_game)'
     series_id: startrek
 -
-    id: tanya1
+    id: 'wintermute:tanya1'
     name: 'Tanya Grotter and the Magical Double Bass'
     engine_id: wintermute
     company_id: creativedream
@@ -8220,7 +8220,7 @@
     wikipedia_page: ''
     series_id: tanya
 -
-    id: tanya2
+    id: 'wintermute:tanya2'
     name: 'Tanya Grotter and the Disappearing Floor'
     engine_id: wintermute
     company_id: creativedream
@@ -8232,7 +8232,7 @@
     wikipedia_page: ''
     series_id: tanya
 -
-    id: stjr
+    id: 'startrek:stjr'
     name: 'Star Trek: Judgment Rites'
     engine_id: startrek
     company_id: interplay
@@ -8244,7 +8244,7 @@
     wikipedia_page: 'Star_Trek:_Judgment_Rites'
     series_id: startrek
 -
-    id: technobabylon
+    id: 'ags:technobabylon'
     name: Technobabylon
     engine_id: ags
     company_id: technocrat
@@ -8256,7 +8256,7 @@
     wikipedia_page: Technobabylon
     series_id: ''
 -
-    id: msn1
+    id: 'supernova:msn1'
     name: 'Mission Supernova 1'
     engine_id: supernova
     company_id: tsdinge
@@ -8268,7 +8268,7 @@
     wikipedia_page: ''
     series_id: supernova
 -
-    id: tehran1933
+    id: 'wintermute:tehran1933'
     name: 'Murder In Tehran''s Alleys 1933'
     engine_id: wintermute
     company_id: rskent
@@ -8280,7 +8280,7 @@
     wikipedia_page: ''
     series_id: tehran
 -
-    id: tehran2016
+    id: 'wintermute:tehran2016'
     name: 'Murder In Tehran''s Alleys 2016'
     engine_id: wintermute
     company_id: rskent
@@ -8292,7 +8292,7 @@
     wikipedia_page: ''
     series_id: tehran
 -
-    id: msn2
+    id: 'supernova:msn2'
     name: 'Mission Supernova 2'
     engine_id: supernova
     company_id: tsdinge
@@ -8304,7 +8304,7 @@
     wikipedia_page: ''
     series_id: supernova
 -
-    id: sword1
+    id: 'sword1:sword1'
     name: 'Broken Sword: The Shadow of the Templars'
     engine_id: sword1
     company_id: revolution
@@ -8316,7 +8316,7 @@
     wikipedia_page: 'Broken_Sword:_The_Shadow_of_the_Templars'
     series_id: sword
 -
-    id: sword1demo
+    id: 'sword1:sword1demo'
     name: 'Broken Sword: The Shadow of the Templars (Demo)'
     engine_id: sword1
     company_id: revolution
@@ -8328,7 +8328,7 @@
     wikipedia_page: 'Broken_Sword:_The_Shadow_of_the_Templars'
     series_id: sword
 -
-    id: sword1mac
+    id: 'sword1:sword1mac'
     name: 'Broken Sword: The Shadow of the Templars (Mac)'
     engine_id: sword1
     company_id: revolution
@@ -8340,7 +8340,7 @@
     wikipedia_page: 'Broken_Sword:_The_Shadow_of_the_Templars'
     series_id: sword
 -
-    id: sword1macdemo
+    id: 'sword1:sword1macdemo'
     name: 'Broken Sword: The Shadow of the Templars (Mac demo)'
     engine_id: sword1
     company_id: revolution
@@ -8352,7 +8352,7 @@
     wikipedia_page: 'Broken_Sword:_The_Shadow_of_the_Templars'
     series_id: sword
 -
-    id: theadventuresoffatman
+    id: 'ags:theadventuresoffatman'
     name: 'The Adventures of Fatman'
     engine_id: ags
     company_id: socko
@@ -8364,7 +8364,7 @@
     wikipedia_page: The_Adventures_of_Fatman
     series_id: fatman
 -
-    id: theancientmark1
+    id: 'wintermute:theancientmark1'
     name: 'The Ancient Mark - Episode 1'
     engine_id: wintermute
     company_id: flippingtree
@@ -8376,7 +8376,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: sword1psx
+    id: 'sword1:sword1psx'
     name: 'Broken Sword: The Shadow of the Templars (PlayStation)'
     engine_id: sword1
     company_id: revolution
@@ -8388,7 +8388,7 @@
     wikipedia_page: 'Broken_Sword:_The_Shadow_of_the_Templars'
     series_id: sword
 -
-    id: thebox
+    id: 'wintermute:thebox'
     name: 'The Box'
     engine_id: wintermute
     company_id: blekinge
@@ -8400,7 +8400,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: thecastle
+    id: 'ags:thecastle'
     name: 'The Castle'
     engine_id: ags
     company_id: ishtar
@@ -8412,7 +8412,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: thecatlady
+    id: 'ags:thecatlady'
     name: 'The Cat Lady'
     engine_id: ags
     company_id: harvester
@@ -8424,7 +8424,7 @@
     wikipedia_page: The_Cat_Lady
     series_id: ''
 -
-    id: thekite
+    id: 'wintermute:thekite'
     name: 'The Kite'
     engine_id: wintermute
     company_id: anate
@@ -8436,7 +8436,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: thelastcrownmh
+    id: 'wintermute:thelastcrownmh'
     name: 'The Last Crown - Midnight Horror'
     engine_id: wintermute
     company_id: darkling
@@ -8448,7 +8448,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: thelostcrowngha
+    id: 'wintermute:thelostcrowngha'
     name: 'The Lost Crown - A Ghost-Hunting Adventure'
     engine_id: wintermute
     company_id: darkling
@@ -8460,7 +8460,7 @@
     wikipedia_page: 'The_Lost_Crown:_A_Ghost-Hunting_Adventure'
     series_id: ''
 -
-    id: themarionette
+    id: 'ags:themarionette'
     name: 'The Marionette'
     engine_id: ags
     company_id: effigy
@@ -8472,7 +8472,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: sword1psxdemo
+    id: 'sword1:sword1psxdemo'
     name: 'Broken Sword: The Shadow of the Templars (PlayStation demo)'
     engine_id: sword1
     company_id: revolution
@@ -8484,7 +8484,7 @@
     wikipedia_page: 'Broken_Sword:_The_Shadow_of_the_Templars'
     series_id: sword
 -
-    id: sword2
+    id: 'sword2:sword2'
     name: 'Broken Sword II: The Smoking Mirror'
     engine_id: sword2
     company_id: revolution
@@ -8496,7 +8496,7 @@
     wikipedia_page: 'Broken_Sword_II:_The_Smoking_Mirror'
     series_id: sword
 -
-    id: thesecretofhuttongrammarschoolvga
+    id: 'ags:thesecretofhuttongrammarschoolvga'
     name: 'The Secret of Hutton Grammar School VGA'
     engine_id: ags
     company_id: tomsimpson
@@ -8508,7 +8508,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: thesecretsofjesus
+    id: 'ags:thesecretsofjesus'
     name: 'The Secrets of Jesus'
     engine_id: ags
     company_id: amatouk
@@ -8520,7 +8520,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: theterribleoldman
+    id: 'ags:theterribleoldman'
     name: 'The Terrible Old Man'
     engine_id: ags
     company_id: cloakdagger
@@ -8532,7 +8532,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: sword2alt
+    id: 'sword2:sword2alt'
     name: 'Broken Sword II: The Smoking Mirror (alt)'
     engine_id: sword2
     company_id: revolution
@@ -8544,7 +8544,7 @@
     wikipedia_page: 'Broken_Sword_II:_The_Smoking_Mirror'
     series_id: sword
 -
-    id: sword2demo
+    id: 'sword2:sword2demo'
     name: 'Broken Sword II: The Smoking Mirror (Demo)'
     engine_id: sword2
     company_id: revolution
@@ -8556,7 +8556,7 @@
     wikipedia_page: 'Broken_Sword_II:_The_Smoking_Mirror'
     series_id: sword
 -
-    id: tib
+    id: 'wintermute:tib'
     name: 'Fairy Tales About Toshechka and Boshechka'
     engine_id: wintermute
     company_id: creativedream
@@ -8568,7 +8568,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: sword2psx
+    id: 'sword2:sword2psx'
     name: 'Broken Sword II: The Smoking Mirror (PlayStation)'
     engine_id: sword2
     company_id: revolution
@@ -8580,7 +8580,7 @@
     wikipedia_page: 'Broken_Sword_II:_The_Smoking_Mirror'
     series_id: sword
 -
-    id: timegentlemenplease
+    id: 'ags:timegentlemenplease'
     name: 'Time Gentlemen, Please!'
     engine_id: ags
     company_id: zombiecow
@@ -8592,7 +8592,7 @@
     wikipedia_page: 'https://en.wikipedia.org/wiki/Time_Gentlemen,_Please!_(video_game)'
     series_id: ''
 -
-    id: sword2psxdemo
+    id: 'sword2:sword2psxdemo'
     name: 'Broken Sword II: The Smoking Mirror (PlayStation/Demo)'
     engine_id: sword2
     company_id: revolution
@@ -8604,7 +8604,7 @@
     wikipedia_page: 'Broken_Sword_II:_The_Smoking_Mirror'
     series_id: sword
 -
-    id: sword25
+    id: 'sword25:sword25'
     name: 'Broken Sword 2.5: The Return of the Templars'
     engine_id: sword25
     company_id: mindfactory
@@ -8616,7 +8616,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: teenagent
+    id: 'teenagent:teenagent'
     name: 'Teen Agent'
     engine_id: teenagent
     company_id: metropolis
@@ -8628,7 +8628,7 @@
     wikipedia_page: Teenagent
     series_id: ''
 -
-    id: testbed
+    id: 'testbed:testbed'
     name: 'Testbed: The Backend Testing Framework'
     engine_id: testbed
     company_id: unknown
@@ -8640,7 +8640,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: syberia
+    id: 'tetraedge:syberia'
     name: Syberia
     engine_id: tetraedge
     company_id: microids
@@ -8652,7 +8652,7 @@
     wikipedia_page: Syberia
     series_id: syberia
 -
-    id: syberia2
+    id: 'tetraedge:syberia2'
     name: 'Syberia II'
     engine_id: tetraedge
     company_id: microids
@@ -8664,7 +8664,7 @@
     wikipedia_page: Syberia_II
     series_id: syberia
 -
-    id: dw
+    id: 'tinsel:dw'
     name: Discworld
     engine_id: tinsel
     company_id: perfect
@@ -8676,7 +8676,7 @@
     wikipedia_page: Discworld_(video_game)
     series_id: dw
 -
-    id: dw2
+    id: 'tinsel:dw2'
     name: 'Discworld II: Missing Presumed...!?'
     engine_id: tinsel
     company_id: perfect
@@ -8688,7 +8688,7 @@
     wikipedia_page: 'Discworld_II:_Missing_Presumed...!%3F'
     series_id: dw
 -
-    id: noir
+    id: 'tinsel:noir'
     name: 'Discworld Noir'
     engine_id: tinsel
     company_id: perfect
@@ -8700,7 +8700,7 @@
     wikipedia_page: Discworld_Noir
     series_id: dw
 -
-    id: tradestory
+    id: 'wintermute:tradestory'
     name: 'The Trader of Stories'
     engine_id: wintermute
     company_id: rudowski
@@ -8712,7 +8712,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: titanic
+    id: 'titanic:titanic'
     name: 'Starship Titanic'
     engine_id: titanic
     company_id: digitalvillage
@@ -8724,7 +8724,7 @@
     wikipedia_page: Starship_Titanic
     series_id: ''
 -
-    id: trilbysnotes
+    id: 'ags:trilbysnotes'
     name: 'Trilby''s Notes'
     engine_id: ags
     company_id: fullyramblomatic
@@ -8736,7 +8736,7 @@
     wikipedia_page: ''
     series_id: chzo
 -
-    id: trilbytheartoftheft
+    id: 'ags:trilbytheartoftheft'
     name: 'Trilby: The Art Of Theft'
     engine_id: ags
     company_id: fullyramblomatic
@@ -8748,7 +8748,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: toltecs
+    id: 'toltecs:toltecs'
     name: '3 Skulls of the Toltecs'
     engine_id: toltecs
     company_id: revistronic
@@ -8760,7 +8760,7 @@
     wikipedia_page: 3_Skulls_of_the_Toltecs
     series_id: ''
 -
-    id: tony
+    id: 'tony:tony'
     name: 'Tony Tough and the Night of Roasted Moths'
     engine_id: tony
     company_id: nayma
@@ -8772,7 +8772,7 @@
     wikipedia_page: Tony_Tough_and_the_Night_of_Roasted_Moths
     series_id: ''
 -
-    id: twelvethirteenep1
+    id: 'ags:twelvethirteenep1'
     name: 'Twelve Thirteen - Episode 1'
     engine_id: ags
     company_id: fullyramblomatic
@@ -8784,7 +8784,7 @@
     wikipedia_page: ''
     series_id: '1213'
 -
-    id: twelvethirteenep2
+    id: 'ags:twelvethirteenep2'
     name: 'Twelve Thirteen - Episode 2'
     engine_id: ags
     company_id: fullyramblomatic
@@ -8796,7 +8796,7 @@
     wikipedia_page: ''
     series_id: '1213'
 -
-    id: twelvethirteenep3
+    id: 'ags:twelvethirteenep3'
     name: 'Twelve Thirteen - Episode 3'
     engine_id: ags
     company_id: fullyramblomatic
@@ -8808,7 +8808,7 @@
     wikipedia_page: ''
     series_id: '1213'
 -
-    id: twelvethirteense
+    id: 'ags:twelvethirteense'
     name: 'Twelve Thirteen - Special Edition'
     engine_id: ags
     company_id: fullyramblomatic
@@ -8820,7 +8820,7 @@
     wikipedia_page: ''
     series_id: '1213'
 -
-    id: twc
+    id: 'wintermute:twc'
     name: 'The White Chamber'
     engine_id: wintermute
     company_id: studiotrophis
@@ -8832,7 +8832,7 @@
     wikipedia_page: The_White_Chamber
     series_id: ''
 -
-    id: toon
+    id: 'toon:toon'
     name: Toonstruck
     engine_id: toon
     company_id: burst
@@ -8844,7 +8844,7 @@
     wikipedia_page: Toonstruck
     series_id: ''
 -
-    id: touche
+    id: 'touche:touche'
     name: 'Touché: The Adventures of the Fifth Musketeer'
     engine_id: touche
     company_id: clipper
@@ -8856,7 +8856,7 @@
     wikipedia_page: 'Touché:_The_Adventures_of_the_Fifth_Musketeer'
     series_id: ''
 -
-    id: nl
+    id: 'trecision:nl'
     name: 'Nightlong: Union City Conspiracy'
     engine_id: trecision
     company_id: trecision
@@ -8868,7 +8868,7 @@
     wikipedia_page: 'Nightlong:_Union_City_Conspiracy'
     series_id: ''
 -
-    id: blueforce
+    id: 'tsage:blueforce'
     name: 'Blue Force'
     engine_id: tsage
     company_id: tsunami
@@ -8880,7 +8880,7 @@
     wikipedia_page: Blue_Force
     series_id: ''
 -
-    id: flashtraffic
+    id: 'tsage:flashtraffic'
     name: 'Flash Traffic: City of Angels'
     engine_id: tsage
     company_id: warner
@@ -8892,7 +8892,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: protostar
+    id: 'tsage:protostar'
     name: 'Protostar: War on the Frontier'
     engine_id: tsage
     company_id: tsunami
@@ -8904,7 +8904,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: ringworld
+    id: 'tsage:ringworld'
     name: 'Ringworld: Revenge of the Patriarch'
     engine_id: tsage
     company_id: tsunami
@@ -8916,7 +8916,7 @@
     wikipedia_page: 'Ringworld:_Revenge_of_the_Patriarch'
     series_id: ringworld
 -
-    id: unavowed
+    id: 'ags:unavowed'
     name: Unavowed
     engine_id: ags
     company_id: wadjet
@@ -8928,7 +8928,7 @@
     wikipedia_page: Unavowed
     series_id: ''
 -
-    id: ringworld2
+    id: 'tsage:ringworld2'
     name: 'Return to Ringworld'
     engine_id: tsage
     company_id: tsunami
@@ -8940,7 +8940,7 @@
     wikipedia_page: ''
     series_id: ringworld
 -
-    id: sherlock-logo
+    id: 'tsage:sherlock-logo'
     name: 'The Lost Files of Sherlock Holmes'
     engine_id: tsage
     company_id: mythos
@@ -8952,7 +8952,7 @@
     wikipedia_page: The_Lost_Files_of_Sherlock_Holmes
     series_id: sherlock
 -
-    id: tucker
+    id: 'tucker:tucker'
     name: 'Bud Tucker in Double Trouble'
     engine_id: tucker
     company_id: merit
@@ -8964,7 +8964,7 @@
     wikipedia_page: Bud_Tucker_in_Double_Trouble
     series_id: ''
 -
-    id: urbanwitchstory
+    id: 'ags:urbanwitchstory'
     name: 'Urban Witch Story'
     engine_id: ags
     company_id: postmodern
@@ -8976,7 +8976,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: lba
+    id: 'twine:lba'
     name: 'Little Big Adventure (Relentless: Twinsen''s Adventure)'
     engine_id: twine
     company_id: adeline
@@ -8988,7 +8988,7 @@
     wikipedia_page: Little_Big_Adventure
     series_id: lba
 -
-    id: lba2
+    id: 'twine:lba2'
     name: 'Little Big Adventure 2: Twinsen''s Odyssey'
     engine_id: twine
     company_id: adeline
@@ -9000,7 +9000,7 @@
     wikipedia_page: Little_Big_Adventure_2
     series_id: lba
 -
-    id: martiandreams
+    id: 'ultima:martiandreams'
     name: 'Ultima: Worlds of Adventure 2 - Martian Dreams'
     engine_id: ultima
     company_id: origin
@@ -9012,7 +9012,7 @@
     wikipedia_page: 'Ultima:_Worlds_of_Adventure_2:_Martian_Dreams'
     series_id: ultima
 -
-    id: martiandreams_enh
+    id: 'ultima:martiandreams_enh'
     name: 'Ultima: Worlds of Adventure 2 - Martian Dreams'
     engine_id: ultima
     company_id: origin
@@ -9024,7 +9024,7 @@
     wikipedia_page: 'Ultima:_Worlds_of_Adventure_2:_Martian_Dreams'
     series_id: ultima
 -
-    id: vsevolod
+    id: 'wintermute:vsevolod'
     name: Vsevolod
     engine_id: wintermute
     company_id: svarun
@@ -9036,7 +9036,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: regret
+    id: 'ultima:regret'
     name: 'Crusader: No Regret'
     engine_id: ultima
     company_id: origin
@@ -9048,7 +9048,7 @@
     wikipedia_page: 'Crusader:_No_Regret'
     series_id: crusader
 -
-    id: remorse
+    id: 'ultima:remorse'
     name: 'Crusader: No Remorse'
     engine_id: ultima
     company_id: origin
@@ -9060,7 +9060,7 @@
     wikipedia_page: 'Crusader:_No_Remorse'
     series_id: crusader
 -
-    id: thesavageempire
+    id: 'ultima:thesavageempire'
     name: 'Worlds of Ultima: The Savage Empire'
     engine_id: ultima
     company_id: origin
@@ -9072,7 +9072,7 @@
     wikipedia_page: 'Worlds_of_Ultima:_The_Savage_Empire'
     series_id: ultima
 -
-    id: war
+    id: 'wintermute:war'
     name: War
     engine_id: wintermute
     company_id: unknown
@@ -9084,7 +9084,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: thesavageempire_enh
+    id: 'ultima:thesavageempire_enh'
     name: 'Worlds of Ultima: The Savage Empire - Enhanced'
     engine_id: ultima
     company_id: origin
@@ -9096,7 +9096,7 @@
     wikipedia_page: 'Worlds_of_Ultima:_The_Savage_Empire'
     series_id: ultima
 -
-    id: ultima1
+    id: 'ultima:ultima1'
     name: 'Ultima I: The First Age of Darkness'
     engine_id: ultima
     company_id: origin
@@ -9108,7 +9108,7 @@
     wikipedia_page: 'Ultima_I:_The_First_Age_of_Darkness'
     series_id: ultima
 -
-    id: ultima4
+    id: 'ultima:ultima4'
     name: 'Ultima IV: Quest of the Avatar'
     engine_id: ultima
     company_id: origin
@@ -9120,7 +9120,7 @@
     wikipedia_page: 'Ultima_IV:_Quest_of_the_Avatar'
     series_id: ultima
 -
-    id: ultima4_enh
+    id: 'ultima:ultima4_enh'
     name: 'Ultima IV: Quest of the Avatar - Enhanced'
     engine_id: ultima
     company_id: origin
@@ -9132,7 +9132,7 @@
     wikipedia_page: 'Ultima_IV:_Quest_of_the_Avatar'
     series_id: ultima
 -
-    id: ultima6
+    id: 'ultima:ultima6'
     name: 'Ultima VI: The False Prophet'
     engine_id: ultima
     company_id: origin
@@ -9144,7 +9144,7 @@
     wikipedia_page: 'Ultima_VI:_The_False_Prophet'
     series_id: ultima
 -
-    id: ultima6_enh
+    id: 'ultima:ultima6_enh'
     name: 'Ultima VI: The False Prophet - Enhanced'
     engine_id: ultima
     company_id: origin
@@ -9156,7 +9156,7 @@
     wikipedia_page: 'Ultima_VI:_The_False_Prophet'
     series_id: ultima
 -
-    id: whispersofamachine
+    id: 'ags:whispersofamachine'
     name: 'Whispers of a Machine'
     engine_id: ags
     company_id: clifftop
@@ -9168,7 +9168,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: ultima8
+    id: 'ultima:ultima8'
     name: 'Ultima VIII - Pagan'
     engine_id: ultima
     company_id: origin
@@ -9180,7 +9180,7 @@
     wikipedia_page: 'Ultima_VIII:_Pagan'
     series_id: ultima
 -
-    id: wintermute
+    id: 'wintermute:wintermute'
     name: 'Wintermute engine game'
     engine_id: wintermute
     company_id: deadcode
@@ -9192,7 +9192,7 @@
     wikipedia_page: Wintermute_Engine
     series_id: ''
 -
-    id: wmedemo
+    id: 'wintermute:wmedemo'
     name: 'Wintermute Engine Technology Demo'
     engine_id: wintermute
     company_id: deadcode
@@ -9204,7 +9204,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: wmedemo3d
+    id: 'wintermute:wmedemo3d'
     name: 'Wintermute 3D Characters Technology Demo'
     engine_id: wintermute
     company_id: deadcode
@@ -9216,7 +9216,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: voyeur
+    id: 'voyeur:voyeur'
     name: Voyeur
     engine_id: voyeur
     company_id: philips
@@ -9228,7 +9228,7 @@
     wikipedia_page: Voyeur_(video_game)
     series_id: ''
 -
-    id: afm
+    id: 'wage:afm'
     name: 'Another Fine Mess'
     engine_id: wage
     company_id: unknown
@@ -9240,7 +9240,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: amot
+    id: 'wage:amot'
     name: 'A Mess O'' Trouble'
     engine_id: wage
     company_id: unknown
@@ -9252,7 +9252,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: wtetris
+    id: 'wintermute:wtetris'
     name: 'Wilma Tetris'
     engine_id: wintermute
     company_id: offstudio
@@ -9264,7 +9264,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: cantitoe
+    id: 'wage:cantitoe'
     name: 'Camp Cantitoe'
     engine_id: wage
     company_id: unknown
@@ -9276,7 +9276,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: drakmythcastle
+    id: 'wage:drakmythcastle'
     name: 'Drakmyth Castle'
     engine_id: wage
     company_id: unknown
@@ -9288,7 +9288,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: raysmaze
+    id: 'wage:raysmaze'
     name: 'Ray''s Maze'
     engine_id: wage
     company_id: unknown
@@ -9300,7 +9300,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: zbang
+    id: 'wintermute:zbang'
     name: 'Zbang! The Game'
     engine_id: wintermute
     company_id: corbomite
@@ -9312,7 +9312,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: scepters
+    id: 'wage:scepters'
     name: 'Enchanted Scepters'
     engine_id: wage
     company_id: unknown
@@ -9324,7 +9324,7 @@
     wikipedia_page: Enchanted_Scepters
     series_id: ''
 -
-    id: twisted
+    id: 'wage:twisted'
     name: Twisted!
     engine_id: wage
     company_id: unknown
@@ -9336,7 +9336,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: wage
+    id: 'wage:wage'
     name: WAGE
     engine_id: wage
     company_id: unknown
@@ -9348,7 +9348,7 @@
     wikipedia_page: World_Builder
     series_id: ''
 -
-    id: cloudsofxeen
+    id: 'xeen:cloudsofxeen'
     name: 'Might and Magic: Clouds of Xeen'
     engine_id: xeen
     company_id: nwc
@@ -9360,7 +9360,7 @@
     wikipedia_page: 'Might_and_Magic_IV:_Clouds_of_Xeen'
     series_id: mm
 -
-    id: darksideofxeen
+    id: 'xeen:darksideofxeen'
     name: 'Might and Magic: Darkside of Xeen'
     engine_id: xeen
     company_id: nwc
@@ -9372,7 +9372,7 @@
     wikipedia_page: 'Might_and_Magic_V:_Darkside_of_Xeen'
     series_id: mm
 -
-    id: swordsofxeen
+    id: 'xeen:swordsofxeen'
     name: 'Might and Magic: Swords of Xeen'
     engine_id: xeen
     company_id: nwc
@@ -9384,7 +9384,7 @@
     wikipedia_page: 'Might_and_Magic_V:_Darkside_of_Xeen#Swords_of_Xeen'
     series_id: mm
 -
-    id: worldofxeen
+    id: 'xeen:worldofxeen'
     name: 'Might and Magic: World of Xeen'
     engine_id: xeen
     company_id: nwc
@@ -9396,7 +9396,7 @@
     wikipedia_page: 'Might_and_Magic_V:_Darkside_of_Xeen#World_of_Xeen'
     series_id: mm
 -
-    id: zilm
+    id: 'wintermute:zilm'
     name: 'Zilm: A Game of Reflex'
     engine_id: wintermute
     company_id: skaldic
@@ -9408,7 +9408,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: zgi
+    id: 'zvision:zgi'
     name: 'Zork: Grand Inquisitor'
     engine_id: zvision
     company_id: activision
@@ -9420,7 +9420,7 @@
     wikipedia_page: 'Zork:_Grand_Inquisitor'
     series_id: zork
 -
-    id: zniwadventure
+    id: 'ags:zniwadventure'
     name: 'Zniw Adventure'
     engine_id: ags
     company_id: azure
@@ -9432,7 +9432,7 @@
     wikipedia_page: ''
     series_id: ''
 -
-    id: znemesis
+    id: 'zvision:znemesis'
     name: 'Zork Nemesis: The Forbidden Lands'
     engine_id: zvision
     company_id: activision

--- a/data/en/screenshots.yaml
+++ b/data/en/screenshots.yaml
@@ -1,2688 +1,2688 @@
 # This is a generated file, please do not edit manually
 -
-    id: 11h
+    id: 'groovie:11h'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: 5ld
+    id: 'wintermute:5ld'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: 5ma
+    id: 'wintermute:5ma'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: 5ma
+    id: 'wintermute:5ma'
     variant: ''
     platform_id: win
     language: de
     variant_id: '1'
 -
-    id: activity
+    id: 'scumm:activity'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: adibou2
+    id: 'gob:adibou2'
     variant: ''
     platform_id: dos
     language: fr
     variant_id: '1'
 -
-    id: airport
+    id: 'scumm:airport'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: arthur
+    id: 'mohawk:arthur'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: arthur
+    id: 'mohawk:arthur'
     variant: ''
     platform_id: win
     language: es
     variant_id: '1'
 -
-    id: arttime
+    id: 'scumm:arttime'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: astrochicken
+    id: 'sci:astrochicken'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: atlantis
+    id: 'scumm:atlantis'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: atlantis
+    id: 'scumm:atlantis'
     variant: ''
     platform_id: amiga
     language: en
     variant_id: '1'
 -
-    id: atlantis
+    id: 'scumm:atlantis'
     variant: ''
     platform_id: dos
     language: fr
     variant_id: '1'
 -
-    id: babayaga
+    id: 'composer:babayaga'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: balloon
+    id: 'scumm:balloon'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: bambou
+    id: 'gob:bambou'
     variant: ''
     platform_id: dos
     language: fr
     variant_id: '1'
 -
-    id: bargon
+    id: 'gob:bargon'
     variant: ''
     platform_id: dos
     language: fr
     variant_id: '1'
 -
-    id: bargon
+    id: 'gob:bargon'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: baseball2003
+    id: 'scumm:baseball2003'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: bbvs
+    id: 'bbvs:bbvs'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: bc
+    id: 'agi:bc'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: beardark
+    id: 'mohawk:beardark'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: bearfight
+    id: 'mohawk:bearfight'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: bearfight
+    id: 'mohawk:bearfight'
     variant: ''
     platform_id: win
     language: es
     variant_id: '1'
 -
-    id: bickadoodle
+    id: 'wintermute:bickadoodle'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: bladerunner
+    id: 'bladerunner:bladerunner'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: bladerunner
+    id: 'bladerunner:bladerunner'
     variant: ''
     platform_id: win
     language: es
     variant_id: '1'
 -
-    id: bladerunner
+    id: 'bladerunner:bladerunner'
     variant: ''
     platform_id: win
     language: fr
     variant_id: '1'
 -
-    id: bladerunner-final
+    id: 'bladerunner:bladerunner-final'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: blueforce
+    id: 'tsage:blueforce'
     variant: CD
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: blues123time
+    id: 'scumm:blues123time'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: bluesabctime
+    id: 'scumm:bluesabctime'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: camelot
+    id: 'sci:camelot'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: castlebrain
+    id: 'sci:castlebrain'
     variant: VGA
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: castlebrain
+    id: 'sci:castlebrain'
     variant: EGA
     platform_id: dos
     language: de
     variant_id: '2'
 -
-    id: chase
+    id: 'scumm:chase'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: chivalry
+    id: 'wintermute:chivalry'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: clandestiny
+    id: 'groovie:clandestiny'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: cloudsofxeen
+    id: 'xeen:cloudsofxeen'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: comi
+    id: 'scumm:comi'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: comi
+    id: 'scumm:comi'
     variant: ''
     platform_id: win
     language: de
     variant_id: '1'
 -
-    id: comi
+    id: 'scumm:comi'
     variant: ''
     platform_id: win
     language: zh-tw
     variant_id: '1'
 -
-    id: comi
+    id: 'scumm:comi'
     variant: ''
     platform_id: win
     language: fr
     variant_id: '1'
 -
-    id: crimsoncrown
+    id: 'glk:crimsoncrown'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: crousti
+    id: 'gob:crousti'
     variant: ''
     platform_id: dos
     language: pt-br
     variant_id: '1'
 -
-    id: cruise
+    id: 'cruise:cruise'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: cruise
+    id: 'cruise:cruise'
     variant: ''
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: cruise
+    id: 'cruise:cruise'
     variant: ''
     platform_id: dos
     language: es
     variant_id: '1'
 -
-    id: cruise
+    id: 'cruise:cruise'
     variant: ''
     platform_id: dos
     language: fr
     variant_id: '1'
 -
-    id: darby
+    id: 'composer:darby'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: ddp
+    id: 'agi:ddp'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: ddp
+    id: 'agi:ddp'
     variant: CGA
     platform_id: dos
     language: en
     variant_id: '2'
 -
-    id: deadcity
+    id: 'wintermute:deadcity'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: dig
+    id: 'scumm:dig'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: dimp
+    id: 'agos:dimp'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: dirtysplit
+    id: 'wintermute:dirtysplit'
     variant: ''
     platform_id: win
     language: de
     variant_id: '1'
 -
-    id: dog
+    id: 'scumm:dog'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: draci
+    id: 'draci:draci'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: draci
+    id: 'draci:draci'
     variant: ''
     platform_id: dos
     language: cs
     variant_id: '1'
 -
-    id: draci
+    id: 'draci:draci'
     variant: ''
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: draci
+    id: 'draci:draci'
     variant: ''
     platform_id: dos
     language: pl
     variant_id: '1'
 -
-    id: dragons
+    id: 'dragons:dragons'
     variant: ''
     platform_id: psx
     language: en-us
     variant_id: '1'
 -
-    id: drascula
+    id: 'drascula:drascula'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: drascula
+    id: 'drascula:drascula'
     variant: ''
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: drascula
+    id: 'drascula:drascula'
     variant: ''
     platform_id: dos
     language: es
     variant_id: '1'
 -
-    id: drascula
+    id: 'drascula:drascula'
     variant: ''
     platform_id: dos
     language: fr
     variant_id: '1'
 -
-    id: drascula
+    id: 'drascula:drascula'
     variant: ''
     platform_id: dos
     language: it
     variant_id: '1'
 -
-    id: dreamweb
+    id: 'dreamweb:dreamweb'
     variant: ''
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: dreamweb
+    id: 'dreamweb:dreamweb'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: dreamweb
+    id: 'dreamweb:dreamweb'
     variant: ''
     platform_id: dos
     language: es
     variant_id: '1'
 -
-    id: dreamweb
+    id: 'dreamweb:dreamweb'
     variant: ''
     platform_id: dos
     language: fr
     variant_id: '1'
 -
-    id: dreamweb
+    id: 'dreamweb:dreamweb'
     variant: ''
     platform_id: dos
     language: it
     variant_id: '1'
 -
-    id: driller
+    id: 'freescape:driller'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: driller
+    id: 'freescape:driller'
     variant: TinyGL
     platform_id: dos
     language: en
     variant_id: '2'
 -
-    id: driller
+    id: 'freescape:driller'
     variant: ''
     platform_id: amiga
     language: en
     variant_id: '1'
 -
-    id: duckman
+    id: 'illusions:duckman'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: dw
+    id: 'tinsel:dw'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: dw
+    id: 'tinsel:dw'
     variant: ''
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: dw
+    id: 'tinsel:dw'
     variant: PAL
     platform_id: psx
     language: en
     variant_id: '1'
 -
-    id: dw2
+    id: 'tinsel:dw2'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: ecoquest
+    id: 'sci:ecoquest'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: ecoquest
+    id: 'sci:ecoquest'
     variant: ''
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: ecoquest
+    id: 'sci:ecoquest'
     variant: ''
     platform_id: dos
     language: fr
     variant_id: '1'
 -
-    id: ecoquest2
+    id: 'sci:ecoquest2'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: elvira1
+    id: 'agos:elvira1'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: elvira2
+    id: 'agos:elvira2'
     variant: ''
     platform_id: amiga
     language: en
     variant_id: '1'
 -
-    id: eob
+    id: 'kyra:eob'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: eob2
+    id: 'kyra:eob2'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: escapemansion
+    id: 'wintermute:escapemansion'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: fairytales
+    id: 'sci:fairytales'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: farm
+    id: 'scumm:farm'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: fascination
+    id: 'gob:fascination'
     variant: CD
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: fascination
+    id: 'gob:fascination'
     variant: ''
     platform_id: amiga
     language: de
     variant_id: '1'
 -
-    id: fascination
+    id: 'gob:fascination'
     variant: ''
     platform_id: amiga
     language: fr
     variant_id: '1'
 -
-    id: fascination
+    id: 'gob:fascination'
     variant: CD
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: fascination
+    id: 'gob:fascination'
     variant: CD
     platform_id: dos
     language: es
     variant_id: '1'
 -
-    id: fascination
+    id: 'gob:fascination'
     variant: CD
     platform_id: dos
     language: fr
     variant_id: '1'
 -
-    id: fascination
+    id: 'gob:fascination'
     variant: CD
     platform_id: dos
     language: it
     variant_id: '1'
 -
-    id: fbear
+    id: 'scumm:fbear'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: fbear
+    id: 'scumm:fbear'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: fbpack
+    id: 'scumm:fbpack'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: feeble
+    id: 'agos:feeble'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: football
+    id: 'scumm:football'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: freddi
+    id: 'scumm:freddi'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: freddi2
+    id: 'scumm:freddi2'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: freddi3
+    id: 'scumm:freddi3'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: freddi4
+    id: 'scumm:freddi4'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: freddypharkas
+    id: 'sci:freddypharkas'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: freddypharkas
+    id: 'sci:freddypharkas'
     variant: ''
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: freddypharkas
+    id: 'sci:freddypharkas'
     variant: ''
     platform_id: win
     language: fr
     variant_id: '1'
 -
-    id: ft
+    id: 'scumm:ft'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: ft
+    id: 'scumm:ft'
     variant: ''
     platform_id: dos
     language: pt-br
     variant_id: '1'
 -
-    id: fullpipe
+    id: 'ngi:fullpipe'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: fullpipe
+    id: 'ngi:fullpipe'
     variant: ''
     platform_id: win
     language: de
     variant_id: '1'
 -
-    id: funpack
+    id: 'scumm:funpack'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: fw
+    id: 'cine:fw'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: geisha
+    id: 'gob:geisha'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: geisha
+    id: 'gob:geisha'
     variant: ''
     platform_id: amiga
     language: en
     variant_id: '1'
 -
-    id: gk1
+    id: 'sci:gk1'
     variant: CD
     platform_id: win
     language: fr
     variant_id: '1'
 -
-    id: gk2
+    id: 'sci:gk2'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: gnap
+    id: 'gnap:gnap'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: gob1
+    id: 'gob:gob1'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: gob1
+    id: 'gob:gob1'
     variant: ''
     platform_id: dos
     language: pl
     variant_id: '1'
 -
-    id: gob2
+    id: 'gob:gob2'
     variant: CD
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: gob2
+    id: 'gob:gob2'
     variant: ''
     platform_id: amiga
     language: de
     variant_id: '1'
 -
-    id: gob2
+    id: 'gob:gob2'
     variant: CD
     platform_id: dos
     language: pl
     variant_id: '1'
 -
-    id: gob3
+    id: 'gob:gob3'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: gob3
+    id: 'gob:gob3'
     variant: ''
     platform_id: amiga
     language: fr
     variant_id: '1'
 -
-    id: gob3
+    id: 'gob:gob3'
     variant: CD
     platform_id: dos
     language: pl
     variant_id: '1'
 -
-    id: goldrush
+    id: 'agi:goldrush'
     variant: ''
     platform_id: amiga
     language: en
     variant_id: '1'
 -
-    id: goldrush
+    id: 'agi:goldrush'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: grandma
+    id: 'mohawk:grandma'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: grandma
+    id: 'mohawk:grandma'
     variant: ''
     platform_id: win
     language: es
     variant_id: '1'
 -
-    id: grandma
+    id: 'mohawk:grandma'
     variant: ''
     platform_id: win
     language: ja
     variant_id: '1'
 -
-    id: greeneggs
+    id: 'mohawk:greeneggs'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: gregory
+    id: 'composer:gregory'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: grim
+    id: 'grim:grim'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: harryhh
+    id: 'mohawk:harryhh'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: harryhh
+    id: 'mohawk:harryhh'
     variant: ''
     platform_id: win
     language: es
     variant_id: '1'
 -
-    id: hdb
+    id: 'hdb:hdb'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: helga
+    id: 'wintermute:helga'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: hires1
+    id: 'adl:hires1'
     variant: ''
     platform_id: apple2
     language: en
     variant_id: '1'
 -
-    id: hires1
+    id: 'adl:hires1'
     variant: 'TV Emulation'
     platform_id: apple2
     language: en
     variant_id: '2'
 -
-    id: hopkins
+    id: 'hopkins:hopkins'
     variant: ''
     platform_id: linux
     language: en
     variant_id: '1'
 -
-    id: hoyle1
+    id: 'sci:hoyle1'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: hoyle2
+    id: 'sci:hoyle2'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: hoyle2
+    id: 'sci:hoyle2'
     variant: ''
     platform_id: amiga
     language: en
     variant_id: '1'
 -
-    id: hoyle3
+    id: 'sci:hoyle3'
     variant: ''
     platform_id: amiga
     language: en
     variant_id: '1'
 -
-    id: hoyle3
+    id: 'sci:hoyle3'
     variant: EGA
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: hoyle3
+    id: 'sci:hoyle3'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '2'
 -
-    id: hoyle5
+    id: 'sci:hoyle5'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: hoyle5solitaire
+    id: 'sci:hoyle5solitaire'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: iceman
+    id: 'sci:iceman'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: ihnm
+    id: 'saga:ihnm'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: ihnm
+    id: 'saga:ihnm'
     variant: 'Fan Translation'
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: imoking
+    id: 'composer:imoking'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: indy3
+    id: 'scumm:indy3'
     variant: EGA
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: indy3
+    id: 'scumm:indy3'
     variant: ''
     platform_id: amiga
     language: en
     variant_id: '1'
 -
-    id: indy3
+    id: 'scumm:indy3'
     variant: VGA
     platform_id: dos
     language: en
     variant_id: '2'
 -
-    id: islandbrain
+    id: 'sci:islandbrain'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: ite
+    id: 'saga:ite'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: ite
+    id: 'saga:ite'
     variant: ''
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: jones
+    id: 'sci:jones'
     variant: EGA
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: jones
+    id: 'sci:jones'
     variant: VGA
     platform_id: dos
     language: en
     variant_id: '2'
 -
-    id: jumble
+    id: 'agos:jumble'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: jungle
+    id: 'scumm:jungle'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: kq1
+    id: 'agi:kq1'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: kq1sci
+    id: 'sci:kq1sci'
     variant: 'VGA Remake'
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: kq2
+    id: 'agi:kq2'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: kq3
+    id: 'agi:kq3'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: kq4
+    id: 'agi:kq4'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: kq4sci
+    id: 'sci:kq4sci'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: kq5
+    id: 'sci:kq5'
     variant: EGA
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: kq5
+    id: 'sci:kq5'
     variant: VGA
     platform_id: dos
     language: en
     variant_id: '2'
 -
-    id: kq5
+    id: 'sci:kq5'
     variant: VGA
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: kq5
+    id: 'sci:kq5'
     variant: VGA
     platform_id: dos
     language: pl
     variant_id: '1'
 -
-    id: kq6
+    id: 'sci:kq6'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: kq6
+    id: 'sci:kq6'
     variant: ''
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: kq7
+    id: 'sci:kq7'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: kq7
+    id: 'sci:kq7'
     variant: ''
     platform_id: win
     language: fr
     variant_id: '1'
 -
-    id: kyra1
+    id: 'kyra:kyra1'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: kyra1
+    id: 'kyra:kyra1'
     variant: ''
     platform_id: amiga
     language: en
     variant_id: '1'
 -
-    id: kyra1
+    id: 'kyra:kyra1'
     variant: ''
     platform_id: pc98
     language: ja
     variant_id: '1'
 -
-    id: kyra1
+    id: 'kyra:kyra1'
     variant: ''
     platform_id: fmtowns
     language: ja
     variant_id: '1'
 -
-    id: kyra2
+    id: 'kyra:kyra2'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: kyra2
+    id: 'kyra:kyra2'
     variant: ''
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: kyra2
+    id: 'kyra:kyra2'
     variant: ''
     platform_id: dos
     language: fr
     variant_id: '1'
 -
-    id: kyra2
+    id: 'kyra:kyra2'
     variant: ''
     platform_id: fmtowns
     language: ja
     variant_id: '1'
 -
-    id: kyra3
+    id: 'kyra:kyra3'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: kyra3
+    id: 'kyra:kyra3'
     variant: ''
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: lab
+    id: 'lab:lab'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: laurabow
+    id: 'sci:laurabow'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: laurabow2
+    id: 'sci:laurabow2'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: laurabow2
+    id: 'sci:laurabow2'
     variant: ''
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: lba
+    id: 'twine:lba'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: lgop2
+    id: 'made:lgop2'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: lgop2
+    id: 'made:lgop2'
     variant: ''
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: liam
+    id: 'composer:liam'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: lighthouse
+    id: 'sci:lighthouse'
     variant: ''
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: lilmonster
+    id: 'mohawk:lilmonster'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: lilmonster
+    id: 'mohawk:lilmonster'
     variant: ''
     platform_id: win
     language: es
     variant_id: '1'
 -
-    id: lit
+    id: 'gob:lit'
     variant: CD
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: lit
+    id: 'gob:lit'
     variant: CD
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: lit
+    id: 'gob:lit'
     variant: CD
     platform_id: dos
     language: fr
     variant_id: '1'
 -
-    id: lit
+    id: 'gob:lit'
     variant: CD
     platform_id: dos
     language: it
     variant_id: '1'
 -
-    id: littlered
+    id: 'gob:littlered'
     variant: ''
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: littlered
+    id: 'gob:littlered'
     variant: ''
     platform_id: dos
     language: es
     variant_id: '1'
 -
-    id: littlered
+    id: 'gob:littlered'
     variant: ''
     platform_id: dos
     language: fr
     variant_id: '1'
 -
-    id: littlered
+    id: 'gob:littlered'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: littlered
+    id: 'gob:littlered'
     variant: ''
     platform_id: dos
     language: it
     variant_id: '1'
 -
-    id: littlesamurai
+    id: 'composer:littlesamurai'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: lol
+    id: 'kyra:lol'
     variant: CD
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: lol
+    id: 'kyra:lol'
     variant: ''
     platform_id: fmtowns
     language: ja
     variant_id: '1'
 -
-    id: longbow
+    id: 'sci:longbow'
     variant: EGA
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: longbow
+    id: 'sci:longbow'
     variant: VGA
     platform_id: dos
     language: en
     variant_id: '2'
 -
-    id: longbow
+    id: 'sci:longbow'
     variant: VGA
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: loom
+    id: 'scumm:loom'
     variant: EGA
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: loom
+    id: 'scumm:loom'
     variant: EGA
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: loom
+    id: 'scumm:loom'
     variant: ''
     platform_id: amiga
     language: en
     variant_id: '1'
 -
-    id: loom
+    id: 'scumm:loom'
     variant: VGA
     platform_id: dos
     language: en
     variant_id: '2'
 -
-    id: loom
+    id: 'scumm:loom'
     variant: ''
     platform_id: pce
     language: en
     variant_id: '1'
 -
-    id: loom
+    id: 'scumm:loom'
     variant: ''
     platform_id: pce
     language: ja
     variant_id: '1'
 -
-    id: lsl1
+    id: 'agi:lsl1'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: lsl1
+    id: 'agi:lsl1'
     variant: ''
     platform_id: amiga
     language: en
     variant_id: '1'
 -
-    id: lsl1
+    id: 'agi:lsl1'
     variant: ''
     platform_id: dos
     language: pl
     variant_id: '1'
 -
-    id: lsl1sci
+    id: 'sci:lsl1sci'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: lsl1sci
+    id: 'sci:lsl1sci'
     variant: ''
     platform_id: amiga
     language: en
     variant_id: '1'
 -
-    id: lsl1sci
+    id: 'sci:lsl1sci'
     variant: EGA
     platform_id: dos
     language: en
     variant_id: '2'
 -
-    id: lsl1sci
+    id: 'sci:lsl1sci'
     variant: ''
     platform_id: dos
     language: pl
     variant_id: '1'
 -
-    id: lsl2
+    id: 'sci:lsl2'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: lsl2
+    id: 'sci:lsl2'
     variant: ''
     platform_id: dos
     language: pl
     variant_id: '1'
 -
-    id: lsl3
+    id: 'sci:lsl3'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: lsl3
+    id: 'sci:lsl3'
     variant: ''
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: lsl3
+    id: 'sci:lsl3'
     variant: ''
     platform_id: dos
     language: pl
     variant_id: '1'
 -
-    id: lsl5
+    id: 'sci:lsl5'
     variant: ''
     platform_id: amiga
     language: en
     variant_id: '1'
 -
-    id: lsl5
+    id: 'sci:lsl5'
     variant: ''
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: lsl5
+    id: 'sci:lsl5'
     variant: ''
     platform_id: dos
     language: pl
     variant_id: '1'
 -
-    id: lsl6
+    id: 'sci:lsl6'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: lsl6
+    id: 'sci:lsl6'
     variant: ''
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: lsl6
+    id: 'sci:lsl6'
     variant: ''
     platform_id: dos
     language: pl
     variant_id: '1'
 -
-    id: lsl6hires
+    id: 'sci:lsl6hires'
     variant: ''
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: lsl6hires
+    id: 'sci:lsl6hires'
     variant: ''
     platform_id: dos
     language: fr
     variant_id: '1'
 -
-    id: lsl7
+    id: 'sci:lsl7'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: lure
+    id: 'lure:lure'
     variant: VGA
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: lure
+    id: 'lure:lure'
     variant: EGA
     platform_id: dos
     language: it
     variant_id: '1'
 -
-    id: manhole
+    id: 'made:manhole'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: manhole
+    id: 'made:manhole'
     variant: ''
     platform_id: dos
     language: ja
     variant_id: '1'
 -
-    id: maniac
+    id: 'scumm:maniac'
     variant: ''
     platform_id: amiga
     language: en
     variant_id: '1'
 -
-    id: maniac
+    id: 'scumm:maniac'
     variant: ''
     platform_id: nes
     language: en
     variant_id: '1'
 -
-    id: maniac
+    id: 'scumm:maniac'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: maniac
+    id: 'scumm:maniac'
     variant: Enhanced
     platform_id: dos
     language: en
     variant_id: '2'
 -
-    id: maniac
+    id: 'scumm:maniac'
     variant: ''
     platform_id: amiga
     language: de
     variant_id: '1'
 -
-    id: maze
+    id: 'scumm:maze'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: mh1
+    id: 'agi:mh1'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: mh1
+    id: 'agi:mh1'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '2'
 -
-    id: mh2
+    id: 'agi:mh2'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: mickey
+    id: 'agi:mickey'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: mickey
+    id: 'agi:mickey'
     variant: CGA
     platform_id: dos
     language: en
     variant_id: '2'
 -
-    id: mixedup
+    id: 'agi:mixedup'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: monkey
+    id: 'scumm:monkey'
     variant: CD
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: monkey
+    id: 'scumm:monkey'
     variant: Hercules
     platform_id: dos
     language: en
     variant_id: '2'
 -
-    id: monkey
+    id: 'scumm:monkey'
     variant: CGA
     platform_id: dos
     language: en
     variant_id: '3'
 -
-    id: monkey
+    id: 'scumm:monkey'
     variant: EGA
     platform_id: dos
     language: en
     variant_id: '4'
 -
-    id: monkey
+    id: 'scumm:monkey'
     variant: VGA
     platform_id: dos
     language: en
     variant_id: '5'
 -
-    id: monkey
+    id: 'scumm:monkey'
     variant: VGA
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: monkey
+    id: 'scumm:monkey'
     variant: ''
     platform_id: amiga
     language: en
     variant_id: '1'
 -
-    id: monkey
+    id: 'scumm:monkey'
     variant: CD
     platform_id: dos
     language: de
     variant_id: '2'
 -
-    id: monkey
+    id: 'scumm:monkey'
     variant: ''
     platform_id: segacd
     language: en
     variant_id: '1'
 -
-    id: monkey2
+    id: 'scumm:monkey2'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: monkey2
+    id: 'scumm:monkey2'
     variant: ''
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: monkey2
+    id: 'scumm:monkey2'
     variant: ''
     platform_id: amiga
     language: en
     variant_id: '1'
 -
-    id: mortevielle
+    id: 'mortevielle:mortevielle'
     variant: ''
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: mothergoose256
+    id: 'sci:mothergoose256'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: mothergoosehires
+    id: 'sci:mothergoosehires'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: mothergoosehires
+    id: 'sci:mothergoosehires'
     variant: ''
     platform_id: win
     language: es
     variant_id: '1'
 -
-    id: mothergoosehires
+    id: 'sci:mothergoosehires'
     variant: ''
     platform_id: win
     language: de
     variant_id: '1'
 -
-    id: mothergoosehires
+    id: 'sci:mothergoosehires'
     variant: ''
     platform_id: win
     language: fr
     variant_id: '1'
 -
-    id: mustard
+    id: 'scumm:mustard'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: myst
+    id: 'mohawk:myst'
     variant: ''
     platform_id: win
     language: it
     variant_id: '1'
 -
-    id: myst3
+    id: 'myst3:myst3'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: mystme
+    id: 'mohawk:mystme'
     variant: ''
     platform_id: win
     language: de
     variant_id: '1'
 -
-    id: mystme
+    id: 'mohawk:mystme'
     variant: ''
     platform_id: win
     language: fr
     variant_id: '1'
 -
-    id: nebular
+    id: 'mads:nebular'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: neverhood
+    id: 'neverhood:neverhood'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: newkid
+    id: 'mohawk:newkid'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: nippon
+    id: 'parallaction:nippon'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: nippon
+    id: 'parallaction:nippon'
     variant: ''
     platform_id: amiga
     language: de
     variant_id: '1'
 -
-    id: nippon
+    id: 'parallaction:nippon'
     variant: ''
     platform_id: amiga
     language: fr
     variant_id: '1'
 -
-    id: nippon
+    id: 'parallaction:nippon'
     variant: ''
     platform_id: dos
     language: it
     variant_id: '1'
 -
-    id: nl
+    id: 'trecision:nl'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: pajama
+    id: 'scumm:pajama'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: pajama2
+    id: 'scumm:pajama2'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: pajama3
+    id: 'scumm:pajama3'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: pegasus
+    id: 'pegasus:pegasus'
     variant: ''
     platform_id: mac
     language: en
     variant_id: '1'
 -
-    id: pepper
+    id: 'sci:pepper'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: phantasmagoria
+    id: 'sci:phantasmagoria'
     variant: ''
     platform_id: dos
     language: fr
     variant_id: '1'
 -
-    id: phantasmagoria2
+    id: 'sci:phantasmagoria2'
     variant: ''
     platform_id: win
     language: fr
     variant_id: '1'
 -
-    id: plumbers
+    id: 'plumbers:plumbers'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: pq1
+    id: 'agi:pq1'
     variant: ''
     platform_id: amiga
     language: en
     variant_id: '1'
 -
-    id: pq1
+    id: 'agi:pq1'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: pq1sci
+    id: 'sci:pq1sci'
     variant: 'VGA Remake'
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: pq2
+    id: 'sci:pq2'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: pq3
+    id: 'sci:pq3'
     variant: ''
     platform_id: amiga
     language: en
     variant_id: '1'
 -
-    id: pq3
+    id: 'sci:pq3'
     variant: VGA
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: pq3
+    id: 'sci:pq3'
     variant: EGA
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: pq3
+    id: 'sci:pq3'
     variant: VGA
     platform_id: dos
     language: en
     variant_id: '2'
 -
-    id: pq4
+    id: 'sci:pq4'
     variant: CD
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: pq4
+    id: 'sci:pq4'
     variant: CD
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: pq4
+    id: 'sci:pq4'
     variant: CD
     platform_id: dos
     language: fr
     variant_id: '1'
 -
-    id: princess
+    id: 'composer:princess'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: puttcircus
+    id: 'scumm:puttcircus'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: puttmoon
+    id: 'scumm:puttmoon'
     variant: ''
     platform_id: 3do
     language: en
     variant_id: '1'
 -
-    id: puttmoon
+    id: 'scumm:puttmoon'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: puttputt
+    id: 'scumm:puttputt'
     variant: ''
     platform_id: 3do
     language: en
     variant_id: '1'
 -
-    id: puttputt
+    id: 'scumm:puttputt'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: puttrace
+    id: 'scumm:puttrace'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: putttime
+    id: 'scumm:putttime'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: puttzoo
+    id: 'scumm:puttzoo'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: puzzle
+    id: 'agos:puzzle'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: qfg1
+    id: 'agi:qfg1'
     variant: EGA
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: qfg1vga
+    id: 'sci:qfg1vga'
     variant: VGA
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: qfg2
+    id: 'sci:qfg2'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: qfg3
+    id: 'sci:qfg3'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: qfg4
+    id: 'sci:qfg4'
     variant: CD
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: queen
+    id: 'queen:queen'
     variant: ''
     platform_id: amiga
     language: en
     variant_id: '1'
 -
-    id: queen
+    id: 'queen:queen'
     variant: ''
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: queen
+    id: 'queen:queen'
     variant: ''
     platform_id: dos
     language: fr
     variant_id: '1'
 -
-    id: queen
+    id: 'queen:queen'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: queen
+    id: 'queen:queen'
     variant: ''
     platform_id: dos
     language: iw
     variant_id: '1'
 -
-    id: rama
+    id: 'sci:rama'
     variant: CD
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: rama
+    id: 'sci:rama'
     variant: ''
     platform_id: dos
     language: fr
     variant_id: '1'
 -
-    id: ringworld
+    id: 'tsage:ringworld'
     variant: ''
     platform_id: dos
     language: es
     variant_id: '1'
 -
-    id: ringworld
+    id: 'tsage:ringworld'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: ringworld2
+    id: 'tsage:ringworld2'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: ritter
+    id: 'wintermute:ritter'
     variant: ''
     platform_id: win
     language: de
     variant_id: '1'
 -
-    id: riven
+    id: 'mohawk:riven'
     variant: DVD
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: riven
+    id: 'mohawk:riven'
     variant: ''
     platform_id: win
     language: pt-br
     variant_id: '1'
 -
-    id: rodney
+    id: 'made:rodney'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: rosemary
+    id: 'wintermute:rosemary'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: rosetattoo
+    id: 'sherlock:rosetattoo'
     variant: CD
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: rosetattoo
+    id: 'sherlock:rosetattoo'
     variant: ''
     platform_id: dos
     language: fr
     variant_id: '1'
 -
-    id: rtz
+    id: 'made:rtz'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: rtz
+    id: 'made:rtz'
     variant: ''
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: ruff
+    id: 'mohawk:ruff'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: ruff
+    id: 'mohawk:ruff'
     variant: ''
     platform_id: win
     language: es
     variant_id: '1'
 -
-    id: samnmax
+    id: 'scumm:samnmax'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: samnmax
+    id: 'scumm:samnmax'
     variant: ''
     platform_id: dos
     language: fr
     variant_id: '1'
 -
-    id: scalpel
+    id: 'sherlock:scalpel'
     variant: ''
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: seussabc
+    id: 'mohawk:seussabc'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: sfinx
+    id: 'cge2:sfinx'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: sheila
+    id: 'mohawk:sheila'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: sheila
+    id: 'mohawk:sheila'
     variant: ''
     platform_id: win
     language: es
     variant_id: '1'
 -
-    id: vampirediaries
+    id: 'nancy:vampirediaries'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: nancy1
+    id: 'nancy:nancy1'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: nancy1
+    id: 'nancy:nancy1'
     variant: ''
     platform_id: win
     language: ru
     variant_id: '1'
 -
-    id: shivers
+    id: 'sci:shivers'
     variant: ''
     platform_id: win
     language: fr
     variant_id: '1'
 -
-    id: simon1
+    id: 'agos:simon1'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: simon2
+    id: 'agos:simon2'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: simon2
+    id: 'agos:simon2'
     variant: ''
     platform_id: dos
     language: iw
     variant_id: '1'
 -
-    id: sinistersix
+    id: 'hypno:sinistersix'
     variant: ''
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: sky
+    id: 'sky:sky'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: slater
+    id: 'sci:slater'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: sleepingcub
+    id: 'composer:sleepingcub'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: socks
+    id: 'scumm:socks'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: soltys
+    id: 'cge:soltys'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: soltys
+    id: 'cge:soltys'
     variant: ''
     platform_id: dos
     language: es
     variant_id: '1'
 -
-    id: soltys
+    id: 'cge:soltys'
     variant: ''
     platform_id: dos
     language: pl
     variant_id: '1'
 -
-    id: spyfox
+    id: 'scumm:spyfox'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: spyfox2
+    id: 'scumm:spyfox2'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: sq1
+    id: 'agi:sq1'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: sq1sci
+    id: 'sci:sq1sci'
     variant: EGA
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: sq1sci
+    id: 'sci:sq1sci'
     variant: VGA
     platform_id: dos
     language: en
     variant_id: '2'
 -
-    id: sq2
+    id: 'agi:sq2'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: sq3
+    id: 'sci:sq3'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: sq3
+    id: 'sci:sq3'
     variant: ''
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: sq4
+    id: 'sci:sq4'
     variant: ''
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: sq4
+    id: 'sci:sq4'
     variant: EGA
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: sq4
+    id: 'sci:sq4'
     variant: VGA
     platform_id: dos
     language: en
     variant_id: '2'
 -
-    id: sq5
+    id: 'sci:sq5'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: sq5
+    id: 'sci:sq5'
     variant: ''
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: sq6
+    id: 'sci:sq6'
     variant: ''
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: sq6
+    id: 'sci:sq6'
     variant: ''
     platform_id: dos
     language: fr
     variant_id: '1'
 -
-    id: stellaluna
+    id: 'mohawk:stellaluna'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: swampy
+    id: 'agos:swampy'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: sword1
+    id: 'sword1:sword1'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: sword1
+    id: 'sword1:sword1'
     variant: ''
     platform_id: win
     language: de
     variant_id: '1'
 -
-    id: sword1
+    id: 'sword1:sword1'
     variant: ''
     platform_id: psx
     language: en
     variant_id: '1'
 -
-    id: sword1
+    id: 'sword1:sword1'
     variant: ''
     platform_id: psx
     language: de
     variant_id: '1'
 -
-    id: sword1
+    id: 'sword1:sword1'
     variant: ''
     platform_id: psx
     language: es
     variant_id: '1'
 -
-    id: sword1
+    id: 'sword1:sword1'
     variant: ''
     platform_id: psx
     language: fr
     variant_id: '1'
 -
-    id: sword1
+    id: 'sword1:sword1'
     variant: ''
     platform_id: psx
     language: it
     variant_id: '1'
 -
-    id: sword2
+    id: 'sword2:sword2'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: sword2
+    id: 'sword2:sword2'
     variant: ''
     platform_id: win
     language: de
     variant_id: '1'
 -
-    id: sword2
+    id: 'sword2:sword2'
     variant: ''
     platform_id: win
     language: pl
     variant_id: '1'
 -
-    id: sword2
+    id: 'sword2:sword2'
     variant: ''
     platform_id: psx
     language: en
     variant_id: '1'
 -
-    id: sword25
+    id: 'sword25:sword25'
     variant: ''
     platform_id: win
     language: de
     variant_id: '1'
 -
-    id: t7g
+    id: 'groovie:t7g'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: teenagent
+    id: 'teenagent:teenagent'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: tentacle
+    id: 'scumm:tentacle'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: tentacle
+    id: 'scumm:tentacle'
     variant: ''
     platform_id: dos
     language: fr
     variant_id: '1'
 -
-    id: tentacle
+    id: 'scumm:tentacle'
     variant: ''
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: thinker1
+    id: 'scumm:thinker1'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: thinkerk
+    id: 'scumm:thinkerk'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: titanic
+    id: 'titanic:titanic'
     variant: CD
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: tlc
+    id: 'groovie:tlc'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: tlj
+    id: 'stark:tlj'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: toltecs
+    id: 'toltecs:toltecs'
     variant: ''
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: toltecs
+    id: 'toltecs:toltecs'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: tony
+    id: 'tony:tony'
     variant: ''
     platform_id: win
     language: de
     variant_id: '1'
 -
-    id: toon
+    id: 'toon:toon'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: toon
+    id: 'toon:toon'
     variant: ''
     platform_id: win
     language: fr
     variant_id: '1'
 -
-    id: torin
+    id: 'sci:torin'
     variant: ''
     platform_id: win
     language: de
     variant_id: '1'
 -
-    id: torin
+    id: 'sci:torin'
     variant: ''
     platform_id: win
     language: fr
     variant_id: '1'
 -
-    id: tortoise
+    id: 'mohawk:tortoise'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: tortoise
+    id: 'mohawk:tortoise'
     variant: ''
     platform_id: win
     language: es
     variant_id: '1'
 -
-    id: touche
+    id: 'touche:touche'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: touche
+    id: 'touche:touche'
     variant: ''
     platform_id: dos
     language: fr
     variant_id: '1'
 -
-    id: transylvania
+    id: 'glk:transylvania'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: troll
+    id: 'agi:troll'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: tucker
+    id: 'tucker:tucker'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: tucker
+    id: 'tucker:tucker'
     variant: ''
     platform_id: dos
     language: de
     variant_id: '1'
 -
-    id: twc
+    id: 'wintermute:twc'
     variant: 'Definitive Edition'
     platform_id: win
     language: de
     variant_id: '1'
 -
-    id: unclehenry
+    id: 'groovie:unclehenry'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: urban
+    id: 'gob:urban'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: versailles
+    id: 'cryomni3d:versailles'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: versailles
+    id: 'cryomni3d:versailles'
     variant: ''
     platform_id: dos
     language: it
     variant_id: '1'
 -
-    id: versailles
+    id: 'cryomni3d:versailles'
     variant: ''
     platform_id: win
     language: fr
     variant_id: '1'
 -
-    id: water
+    id: 'scumm:water'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: waxworks
+    id: 'agos:waxworks'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: waxworks
+    id: 'agos:waxworks'
     variant: ''
     platform_id: amiga
     language: en
     variant_id: '1'
 -
-    id: ween
+    id: 'gob:ween'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: ween
+    id: 'gob:ween'
     variant: ''
     platform_id: amiga
     language: fr
     variant_id: '1'
 -
-    id: ween
+    id: 'gob:ween'
     variant: ''
     platform_id: amiga
     language: it
     variant_id: '1'
 -
-    id: wetlands
+    id: 'hypno:wetlands'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: winnie
+    id: 'agi:winnie'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: woodruff
+    id: 'gob:woodruff'
     variant: ''
     platform_id: win
     language: en
     variant_id: '1'
 -
-    id: woodruff
+    id: 'gob:woodruff'
     variant: ''
     platform_id: win
     language: de
     variant_id: '1'
 -
-    id: woodruff
+    id: 'gob:woodruff'
     variant: ''
     platform_id: win
     language: es
     variant_id: '1'
 -
-    id: woodruff
+    id: 'gob:woodruff'
     variant: ''
     platform_id: win
     language: fr
     variant_id: '1'
 -
-    id: woodruff
+    id: 'gob:woodruff'
     variant: ''
     platform_id: win
     language: en-gb
     variant_id: '1'
 -
-    id: woodruff
+    id: 'gob:woodruff'
     variant: ''
     platform_id: win
     language: it
     variant_id: '1'
 -
-    id: zak
+    id: 'scumm:zak'
     variant: ''
     platform_id: c64
     language: de
     variant_id: '1'
 -
-    id: zak
+    id: 'scumm:zak'
     variant: ''
     platform_id: dos
     language: en
     variant_id: '1'
 -
-    id: zak
+    id: 'scumm:zak'
     variant: ''
     platform_id: amiga
     language: en
     variant_id: '1'
 -
-    id: zak
+    id: 'scumm:zak'
     variant: ''
     platform_id: fmtowns
     language: en
     variant_id: '1'
 -
-    id: zgi
+    id: 'zvision:zgi'
     variant: CD
     platform_id: win
     language: de
     variant_id: '1'
 -
-    id: znemesis
+    id: 'zvision:znemesis'
     variant: ''
     platform_id: dos
     language: de

--- a/include/DataUtils.php
+++ b/include/DataUtils.php
@@ -83,12 +83,6 @@ class DataUtils
             // Convert TRUE/FALSE strings to Booleans
             foreach ($data as $objKey => $obj) {
                 foreach ($obj as $key => $val) {
-                    // TODO Temporarily convert new game ids to the old format.
-                    //   When we are fully migrated, remove this
-                    if (($key === 'id' || $key === 'game_id') && strpos($val, ':') !== FALSE) {
-                        $data[$objKey][$key] = substr($val, strpos($val, ':') + 1);
-                    }
-
                     if ($val === 'TRUE') {
                         $data[$objKey][$key] = true;
                     } elseif ($val === 'FALSE') {

--- a/include/Models/ScreenshotsModel.php
+++ b/include/Models/ScreenshotsModel.php
@@ -145,7 +145,7 @@ class ScreenshotsModel extends BasicModel
         $count = 0;
         // Iterate over each game and count the number of screenshot files
         foreach ($games as $game) {
-            $count += count(glob("./" . DIR_SCREENSHOTS . "/" . $game->getEngine()->getId() . "/" . $game->getId() . "/*_full.png"));
+            $count += count(glob("./" . DIR_SCREENSHOTS . "/" .  str_replace(":", "/", $game->getId()) . "/*_full.png"));
         }
         return $count;
     }

--- a/include/OrmObjects/Compatibility.php
+++ b/include/OrmObjects/Compatibility.php
@@ -29,12 +29,13 @@ class Compatibility extends BaseCompatibility
 
     public function getScummVmId($version)
     {
+        $gameId = $this->getGame()->getId();
         if ($version == "DEV" || version_compare($version, "2.2.0") > 0) {
-            // If version is > 2.2.0, return engine_id:game_id
-            return $this->getGame()->getEngineId() . ":" . $this->getGame()->getId();
+            // If version is > 2.2.0, return in the form of `scumm:monkey`
+            return $gameId;
         } else {
-            // If version is <= 2.2.0, return the game_id
-            return $this->getGame()->getId();
+            // If version is <= 2.2.0, return in the form of `monkey`
+            return substr($gameId, strpos($gameId, ':') + 1);
         }
     }
 

--- a/include/OrmObjects/Screenshot.php
+++ b/include/OrmObjects/Screenshot.php
@@ -20,7 +20,8 @@ class Screenshot extends BaseScreenshot
     public function getFiles()
     {
         if (!$this->files) {
-            foreach (glob("./" . DIR_SCREENSHOTS . "/" . $this->getGame()->getEngine()->getId() . "/" . $this->getGame()->getId() . "/" . $this->getFileMask()) as $file) {
+            $gameId = str_replace(":", "/", $this->getGame()->getId());
+            foreach (glob("./" . DIR_SCREENSHOTS . "/" . $gameId . "/" . $this->getFileMask()) as $file) {
                 // Remove the base folder
                 $name = str_replace("./" . DIR_SCREENSHOTS . "/", "", $file);
                 // Remove the suffix, eg. "_full.png"
@@ -50,7 +51,8 @@ class Screenshot extends BaseScreenshot
         if ($series) {
             return $series->getId();
         } else {
-            return $this->getId();
+            // Remove engine prefix
+            return substr($this->getId(), strpos($this->getId(), ':') + 1);
         }
     }
 
@@ -89,7 +91,9 @@ class Screenshot extends BaseScreenshot
 
     public function getFileMask()
     {
-        $mask = $this->getGame()->getId() . "_";
+        // Remove engine prefix
+        $game_short_id = substr($this->getGame()->getId(), strpos($this->getGame()->getId(), ':') + 1);
+        $mask = $game_short_id . "_";
         if ($this->getPlatform()) {
             $mask .= $this->getPlatform()->getId() . "_";
         }

--- a/templates/components/list_items.tpl
+++ b/templates/components/list_items.tpl
@@ -24,7 +24,8 @@
                 </li>
             {elseif $type === 'screenshot_categories'}
                 <li class="file">
-                    <span class="sprite-games-{$key} sprite"></span>
+                    {* Strip engine prefix for sprite, if it exists *}
+                    <span class="sprite-games-{(str_contains($key, ':') == True) ? substr($key, strpos($key, ':') + 1) : $key} sprite"></span>
                     <a href="{'/screenshots/'|lang}{$screenshot.category}/{$key}/">{$item.name}</a>
                     <span class="download-extras">({$item.count} shots)</span>
                 </li>


### PR DESCRIPTION
Previously, game ids were displayed in the form of `monkey`. Now they are displayed in the form of `scumm:monkey`.

Note that this changes some of the URLs for the screenshots and compatibility pages.

## Before
* https://www.scummvm.org/compatibility/DEV/monkey/

## After
* https://www.scummvm.org/compatibility/DEV/scumm:monkey/