### PR TITLE
WEB: Using simple replace for support description

### DIFF
--- a/include/OrmObjects/Compatibility.php
+++ b/include/OrmObjects/Compatibility.php
@@ -42,7 +42,7 @@ class Compatibility extends BaseCompatibility
     public function getNotes()
     {
         $notes = "### Support Level\n\n";
-        $notes .= "%{$this->getSupport()}%\n\n";
+        $notes .= "[[support_description]]\n\n";
 
         if ($stable = $this->getStablePlatforms()) {
             $notes .= "### Supported Platforms \n";

--- a/templates/components/compatibility_details.tpl
+++ b/templates/components/compatibility_details.tpl
@@ -21,7 +21,7 @@
         </tr>
         <tr class="color2">
             <td colspan="3" class="details">
-                {$game->getNotes()|regex_replace:"/%.+%/":$support_description}
+                {$game->getNotes()|replace:"[[support_description]]":$support_description}
             </td>
         </tr>
     </tbody>


### PR DESCRIPTION
Fixes [issue #13720](https://bugs.scummvm.org/ticket/13720).

The old system used a placeholder and was overbroad in its regex replace for that placeholder, which garbled links. Since we don't need a special regex for a placeholder, this does the job in a simpler and more reliable way.