### PR TITLE
WEB: Moving game mods to top of links page

### DIFF
--- a/data/en/links.yaml
+++ b/data/en/links.yaml
@@ -1,3 +1,29 @@
+- name: Game mods made possible by ScummVM
+  notes: >-
+    The following are links to projects that modify games in ways that were not possible in the original game engines,
+    but are possible now thanks to ScummVM.
+  links:
+    - name: Remastered Soundtracks by The Fat Man and Team Fat
+      notes: >-
+        ScummVM-compatible music sets by the original composer of several supported games, including instructions on 
+        how to hear the remastered music while playing.
+      url: 'https://thefatmanandteamfat.bandcamp.com'
+    - name: Monkey Island Ultimate Talkie Edition Builders
+      notes: >-
+        Builders to create talkie versions for DOS and ScummVM out of the Special Edition releases.
+      url: 'http://gratissaugen.de/ultimatetalkies/'
+    - name: ScummVM Music Enhancement Project by James Woodcock
+      notes: >-
+        A fanmade selection of recreated soundtracks based on the original MIDI files
+        for several games supported by ScummVM.
+      url: 'https://www.pixelrefresh.com/content/scummvm-music-enhancement-project/'
+    - name: Loom Replacement Music
+      notes: >-
+        Instructions for how to replace the music in floppy versions of Loom
+        with the corresponding music from the Swan Lake ballet. There are
+        currently no known freely downloadable tracks, so you have to provide
+        them yourself.
+      url: 'https://wiki.scummvm.org/index.php/Loom#Audio_tracks'
 - name: Libraries & Technologies
   notes: >-
     The following lists some libraries and technologies ScummVM makes use of
@@ -26,32 +52,6 @@
         FLAC without any loss in quality. ScummVM optionally supports playback
         of CD tracks and other audio data encoded using FLAC.
       url: 'https://xiph.org/flac/'
-- name: Game mods made possible by ScummVM
-  notes: >-
-    The following are links to projects that modify games in ways that were not possible in the original game engines,
-    but are possible now thanks to ScummVM.
-  links:
-    - name: Remastered Soundtracks by The Fat Man and Team Fat
-      notes: >-
-        ScummVM-compatible music sets by the original composer of several supported games, including instructions on 
-        how to hear the remastered music while playing.
-      url: 'https://thefatmanandteamfat.bandcamp.com'
-    - name: Monkey Island Ultimate Talkie Edition Builders
-      notes: >-
-        Builders to create talkie versions for DOS and ScummVM out of the Special Edition releases.
-      url: 'http://gratissaugen.de/ultimatetalkies/'
-    - name: ScummVM Music Enhancement Project by James Woodcock
-      notes: >-
-        A fanmade selection of recreated soundtracks based on the original MIDI files
-        for several games supported by ScummVM.
-      url: 'https://www.pixelrefresh.com/content/scummvm-music-enhancement-project/'
-    - name: Loom Replacement Music
-      notes: >-
-        Instructions for how to replace the music in floppy versions of Loom
-        with the corresponding music from the Swan Lake ballet. There are
-        currently no known freely downloadable tracks, so you have to provide
-        them yourself.
-      url: 'https://wiki.scummvm.org/index.php/Loom#Audio_tracks'
 - name: Other sites of interest
   notes: >-
     The following are links to sites that provide news and help on retro-gaming


### PR DESCRIPTION
I figure we should advertise ScummVM-related stuff over third-party stuff.

## Before
<img width="581" alt="Before" src="https://github.com/scummvm/scummvm-web/assets/6200170/7a7a4bee-4bb1-4e00-8b3c-2899f3c5cb22">

## After
<img width="631" alt="After" src="https://github.com/scummvm/scummvm-web/assets/6200170/f5284079-d990-4778-b644-067056622076">
