### PR TITLE
WEB: Removing GOG affiliate link

### DIFF
--- a/include/Constants.php
+++ b/include/Constants.php
@@ -34,8 +34,6 @@ class Constants
 
         /* External URLs */
         define('GOG_URL_PREFIX', "https://www.gog.com/game/");
-        // ScummVM affiliate id
-        define('GOG_URL_SUFFIX', '?pp=22d200f8670dbdb3e253a90eee5098477c95c23d');
         define('STEAM_URL_PREFIX', 'https://store.steampowered.com/app/');
 
         /* Paths */

--- a/include/OrmObjects/Compatibility.php
+++ b/include/OrmObjects/Compatibility.php
@@ -90,7 +90,7 @@ class Compatibility extends BaseCompatibility
         $availableSites = [];
         $gogId = $this->getGame()->getGogId();
         if ($gogId) {
-            $availableSites[] = "- [GOG.com](" . GOG_URL_PREFIX . $gogId . GOG_URL_SUFFIX . ") (affiliate link)";
+            $availableSites[] = "- [GOG.com](" . GOG_URL_PREFIX . $gogId . ")";
         }
         $steamId = $this->getGame()->getSteamId();
         if ($steamId) {


### PR DESCRIPTION
Per Discord discussion, the legacy affiliate program is ending.

## Before

<img width="447" alt="Before" src="https://github.com/scummvm/scummvm-web/assets/6200170/6b5aba6b-bc36-4ef5-91ea-3e3797be6876">

## After

<img width="454" alt="After" src="https://github.com/scummvm/scummvm-web/assets/6200170/337ae9f0-755e-40f9-b70f-a736d66b7741">
