### PR TITLE
WEB: Add announcement for GSoC participants

### DIFF
--- a/data/en/news/20240505.markdown
+++ b/data/en/news/20240505.markdown
@@ -1,0 +1,69 @@
+---
+
+title: Google Summer of Code 2024 - drum roll please!
+
+author: djwillis
+
+date: 1714906800
+
+---
+
+Please welcome this year's participants!
+
+On Wednesday 1st May Google [announced](https://opensource.googleblog.com/2024/05/google-summer-of-code-2024-accepted-contributors-announced.html) the list of participants accepted for this year's Google Summer of Code and we are very happy to report that [4 contributors](https://summerofcode.withgoogle.com/programs/2024/organizations/scummvm) have been accepted to work on various parts of the ScummVM project this summer.
+
+Now we have had a chance to dot the i's and cross the t's we are really pleased to welcome them all to the project and ask everyone to show them a very warm welcome as they get settled.
+
+In no particular order, a heartfelt welcome to...
+
+----
+
+**Project: Implementation of a Game Files Integrity Checking System for ScummVM**
+
+_Chike Lee_ - Chico / [InariInDream](https://github.com/InariInDream)
+
+ScummVM requires game data files to operate. Frequently, especially when copying from the old media, the files can be damaged. Thus, a system that could let the end-users compute checksums and compare them with known good references is desirable. 
+
+Chike will be looking to extend existing work in this area and complete the end to end implementation during the summer.
+
+----
+
+**Project: Enhance Macromedia Director Support**
+
+_Krish Ganatra_ - Krish / [Krish28](https://github.com/Krish2882005/)
+
+Macromedia Director is a popular multimedia authoring tool from the 90s, and many iconic adventure titles have been released using it. Improving its support in ScummVM will preserve gaming history and provide players with access to beloved classics. 
+
+Krish will be undertaking a range of targeted enhancements to Macromedia Director support in ScummVM to extend compatibility and support.
+
+----
+
+**Project: Porting qdEngine to ScummVM**
+
+_Kunal Tiwari_ - [kunxl.gg](https://github.com/kunxl-gg)
+
+K-D Labs created qdEngine and it has been used in several point-and-click adventure games, primarily in Russian, and also translated into Lithuanian, Czech and English. The most known games are Pilot Brothers 3 and Pilot Brothers 3D. 
+
+Kunal will be working to bring this engine's code into ScummVM with a goal to add full support for the engine during the summer.
+
+----
+
+**Project: Add Keymapper to multiple Engines**
+
+_Nabeel Shabbir_ - kashmiri_markhor / [NabeelShabbir](https://github.com/NabeelShabbir)
+
+ScummVM includes a global fully configurable keymapper, but this requires engines to be adapted to use it. The goal of this project is to fully integrate ScummVM keymapper into a large number of our supported engines.
+
+Nabeel will be working on this throughout the summer, starting with the larger engines and more advanced keymapper requirements.
+
+----
+
+We are now in the community bonding period that runs up until the 27th of May when coding on the projects formally begins.
+
+Please give them all a very warm welcome, and visit our [Discord server](https://discord.gg/4cDsMNtcpG) if you want to discuss these projects, each project has a dedicated channel.
+
+You can also expect regular updates from the participants on their respective blogs that will be linked from the [planet](https://planet.scummvm.org/). 
+
+The team is very excited about these projects - and we hope you are as well.
+
+We also wanted to take the time to thank everyone who applied to ScummVM for this year's Google Summer of Code programme. Unfortunately, not every application was successful, but we are so grateful for the interest shown and would love you all to still consider helping with ScummVM in some capacity in the future.


### PR DESCRIPTION
Add EN news article for the GSoC 2024 following
Google publishing accepted participant projects.