### PR TITLE
WEB: Added SEO functionality

### DIFF
--- a/templates/pages/index.tpl
+++ b/templates/pages/index.tpl
@@ -8,7 +8,8 @@
     <base href="{$baseurl|lang}">
     <link rel="alternate" type="application/atom+xml" title="{#indexAtomFeed#}" href="{$baseurl|lang}/feeds/atom/">
     <link rel="alternate" type="application/rss+xml" title="{#indexRSSFeed#}" href="{$baseurl|lang}/feeds/rss/">
-    <title>ScummVM :: {$title}</title>
+    <title>ScummVM :: {$title} :: {$content_title}</title>
+    <meta name="description" content="{(str_contains($content, PHP_EOL) == True) ? substr($content, 0, strpos($content, PHP_EOL)-1) : $content;}"> 
     <!-- Favicon -->
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=oLBEjaJ9ag">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=oLBEjaJ9ag">
@@ -23,10 +24,11 @@
     <!-- OpenGraph -->
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
-    <meta property="og:title" content="ScummVM">
-    <meta property="og:description" content="ScummVM is a collection of game engines for playing classic graphical RPGs and point-and-click adventure games on modern hardware.">
-    <meta property="og:url" content="{'https://www.scummvm.org'|lang}">
+    <meta property="og:title" content="{$title} :: {$content_title}">
+    <meta property="og:description" content="{(str_contains($content, PHP_EOL) == True) ? substr($content, 0, strpos($content, PHP_EOL)-1) : $content;}">
+    <meta property="og:url" content="{$baseurl}{$pageurl}">
     <meta property="og:image" content="https://www.scummvm.org/images/og-image.jpg">
+    <link rel="canonical" href="{$baseurl}{$pageurl}" />
     <!-- Translations -->
     {foreach from=$available_languages key=key item=item}
     {if $lang != $key}


### PR DESCRIPTION
Currently ScummVM doesn't use any SEO, meaning if you share pages they all externally preview as if you shared just the homepage, so therefore:
1. Switched to SEO title
1. Added SEO meta description
1. Switched to SEO og:title
1. Switched to SEO og:description
1. Switched to SEO og:url
1. Added SEO canonical URL

This should solve [this ticket](https://bugs.scummvm.org/ticket/14380), but only the site owners can preview this, so please check first it works well for the homepage, articles, compatibility, etc.

I'm auto generating the description based on the same `substr` principle as in https://github.com/scummvm/scummvm-web/blob/master/templates/components/list_items.tpl