### PR TITLE
deps: downgrade zip.js to 2.7.56

### DIFF
--- a/dumper-companion/package-lock.json
+++ b/dumper-companion/package-lock.json
@@ -8,7 +8,7 @@
       "name": "dumper-companion",
       "version": "0.0.1",
       "dependencies": {
-        "@zip.js/zip.js": "^2.7.60",
+        "@zip.js/zip.js": "2.7.56",
         "preact": "^10.26.5",
         "punycode": "^2.3.1",
         "ts-loader": "^9.5.2",
@@ -783,9 +783,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@zip.js/zip.js": {
-      "version": "2.7.60",
-      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.60.tgz",
-      "integrity": "sha512-vA3rLyqdxBrVo1FWSsbyoecaqWTV+vgPRf0QKeM7kVDG0r+lHUqd7zQDv1TO9k4BcAoNzNDSNrrel24Mk6addA==",
+      "version": "2.7.56",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.56.tgz",
+      "integrity": "sha512-Qf3WwfpBu5ezb8qOadfI6OccjRm+ECproDaDUQKg+UJRcy8kbctDbjoDonfbOrECae/iNboa83ARH2Zvz+HRHw==",
       "license": "BSD-3-Clause",
       "engines": {
         "bun": ">=0.7.0",

--- a/dumper-companion/package.json
+++ b/dumper-companion/package.json
@@ -15,7 +15,7 @@
     "globals": "^16.0.0"
   },
   "dependencies": {
-    "@zip.js/zip.js": "^2.7.60",
+    "@zip.js/zip.js": "2.7.56",
     "preact": "^10.26.5",
     "punycode": "^2.3.1",
     "ts-loader": "^9.5.2",


### PR DESCRIPTION
2.7.57 and newer have a bug which creates incorrect subdirectory permissions when ZIP files are opened on Unix systems (macOS, Linux, etc.). The version pin can be removed once there's a new version with fixed permissions.

If you use a Unix OS, you can test this on the currently-live version of dumper companion by trying to extract an ISO containing subdirectories. The subdirectories will be created as `-rw-r--r--@`, with no executable permissions, and so both the terminal and GUI file browsers like Finder will refuse to let the user access those directories.

See: https://github.com/gildas-lormeau/zip.js/issues/567