### PR TITLE
deps: upgrade zip.js

### DIFF
--- a/dumper-companion/package-lock.json
+++ b/dumper-companion/package-lock.json
@@ -8,7 +8,7 @@
       "name": "dumper-companion",
       "version": "0.0.1",
       "dependencies": {
-        "@zip.js/zip.js": "^2.7.60",
+        "@zip.js/zip.js": "^2.7.61",
         "preact": "^10.26.5",
         "punycode": "^2.3.1",
         "ts-loader": "^9.5.2",
@@ -783,9 +783,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@zip.js/zip.js": {
-      "version": "2.7.60",
-      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.60.tgz",
-      "integrity": "sha512-vA3rLyqdxBrVo1FWSsbyoecaqWTV+vgPRf0QKeM7kVDG0r+lHUqd7zQDv1TO9k4BcAoNzNDSNrrel24Mk6addA==",
+      "version": "2.7.61",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.61.tgz",
+      "integrity": "sha512-+tZvY10nkW0pJoU88XFWLBd2O9PJPvEnDhSY/jQHfIroN5W5qGfPgFHKC4lkx0+9Vw/0IAkNHf1XBVInBkM9Vw==",
       "license": "BSD-3-Clause",
       "engines": {
         "bun": ">=0.7.0",

--- a/dumper-companion/package.json
+++ b/dumper-companion/package.json
@@ -15,7 +15,7 @@
     "globals": "^16.0.0"
   },
   "dependencies": {
-    "@zip.js/zip.js": "^2.7.60",
+    "@zip.js/zip.js": "^2.7.61",
     "preact": "^10.26.5",
     "punycode": "^2.3.1",
     "ts-loader": "^9.5.2",


### PR DESCRIPTION
This fixes the directory permission bug that broke ZIP files on Mac/Linux. Dumper Companion needs to use either 2.7.61+ or 2.7.56 and lower.

Replacement for #479 now that a fixed release is out.